### PR TITLE
Fix and enable back Couchbase tests

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -70,8 +70,8 @@ jobs:
           - ngx-mariadb-oauth2-infinispan
           - ngx-mongodb-kafka-cucumber
           - ngx-h2mem-ws-nol2
-          #- ngx-couchbase
-          #- ngx-gradle-couchbase-search
+          - ngx-couchbase
+          - ngx-gradle-couchbase-search
           - ngx-gradle-fr
           - ngx-gradle-mysql-es-noi18n-mapsid
           - ngx-gradle-mariadb-oauth2-infinispan
@@ -117,18 +117,18 @@ jobs:
             war: 0
             e2e: 1
             testcontainers: 0
-          #- app-sample: ngx-couchbase
-          #  entity: couchbase
-          #  environment: prod
-          #  war: 0
-          #  e2e: 1
-          #  testcontainers: 1
-          #- app-sample: ngx-gradle-couchbase-search
-          #  entity: couchbase
-          #  environment: prod
-          #  war: 0
-          #  e2e: 1
-          #  testcontainers: 1
+          - app-sample: ngx-couchbase
+            entity: couchbase
+            environment: prod
+            war: 0
+            e2e: 1
+            testcontainers: 1
+          - app-sample: ngx-gradle-couchbase-search
+            entity: couchbase
+            environment: prod
+            war: 0
+            e2e: 1
+            testcontainers: 1
           - app-sample: ngx-gradle-fr
             entity: sql
             environment: prod

--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration_couchbase.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration_couchbase.java.ejs
@@ -24,6 +24,7 @@ import tech.jhipster.config.JHipsterProperties;
 
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.couchmove.Couchmove;
 <%_ if (searchEngineCouchbase) { _%>
 import <%= packageName %>.repository.Custom<% if (reactive) { %>Reactive<% } %>CouchbaseRepository;
@@ -39,13 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.couchbase.CouchbaseProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-<%_ if (searchEngineElasticsearch) { _%>
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
-<%_ } _%>
-import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.*;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.GenericConverter;
@@ -65,6 +60,7 @@ import org.springframework.data.couchbase.core.mapping.event.ValidatingCouchbase
 import org.springframework.data.couchbase.repository.auditing.EnableCouchbaseAuditing;
 <%_ } _%>
 import org.springframework.data.couchbase.repository.config.Enable<%_ if (reactive) { _%>Reactive<% } %>CouchbaseRepositories;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
@@ -175,12 +171,22 @@ public class DatabaseConfiguration extends AbstractCouchbaseConfiguration {
         return mappingCouchbaseConverter;
     }
 
+    /**
+     * Workaround for Couchbase overriding SB default jackson mapper: https://github.com/spring-projects/spring-data-couchbase/issues/1209
+     */
+    @Bean
+    @Primary
+    ObjectMapper jacksonObjectMapper(Jackson2ObjectMapperBuilder builder) {
+        return builder.createXmlMapper(false).build();
+    }
+
     @Bean
     public Couchmove couchmove(Cluster cluster) {
         log.debug("Configuring Couchmove");
         Bucket bucket = cluster.bucket(getBucketName());
         Couchmove couchmove = new Couchmove(bucket, cluster, "config/couchmove/changelog");
         couchmove.migrate();
+        couchmove.buildN1qlDeferredIndexes();
         return couchmove;
     }
 

--- a/generators/server/templates/src/main/java/package/repository/AuthorityRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/AuthorityRepository.java.ejs
@@ -34,7 +34,6 @@ import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.data.mongodb.repository.<% if (reactive) { %>Reactive<% } %>MongoRepository;
 <%_ } _%>
 <%_ if (databaseTypeCouchbase) { _%>
-import org.springframework.data.couchbase.repository.<% if (reactive) { %>Reactive<% } %>CouchbaseRepository;
 import org.springframework.data.couchbase.repository.Query;
 import com.couchbase.client.java.query.QueryScanConsistency;
 import org.springframework.data.couchbase.repository.ScanConsistency;
@@ -68,7 +67,7 @@ import org.springframework.data.neo4j.repository.<% if (reactive) { %>Reactive<%
 <%_ if (databaseTypeCouchbase) { _%>
 @Repository
 <%_ } _%>
-public interface AuthorityRepository extends <% if (databaseTypeSql) { %><% if (reactive) { %>R2dbc<% } else { %>Jpa<% } %>Repository<% } else { %><% if (reactive) { %>Reactive<% } %><% if (databaseTypeMongodb) { %>MongoRepository<% } %><% if (databaseTypeNeo4j) { %>Neo4jRepository<% } %><% if (databaseTypeCouchbase) { %>CouchbaseRepository<% } %><% } %><Authority, String> {
+public interface AuthorityRepository extends <% if (databaseTypeSql) { %><% if (reactive) { %>R2dbc<% } else { %>Jpa<% } %>Repository<% } else { %><% if (reactive) { %>Reactive<% } %><% if (databaseTypeMongodb) { %>MongoRepository<% } %><% if (databaseTypeNeo4j) { %>Neo4jRepository<% } %><% if (databaseTypeCouchbase) { %>N1qlCouchbaseRepository<% } %><% } %><Authority, String> {
 <%_ if (databaseTypeNeo4j) { _%>
     <% if (!reactive) { %>// See https://github.com/neo4j/sdn-rx/issues/51<%_ } _%>
     <% if (reactive) { %>Flux<% } else { %>List<% } %><<%= asEntity('Authority') %>> findAll();

--- a/generators/server/templates/src/main/java/package/repository/N1qlCouchbaseRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/N1qlCouchbaseRepository.java.ejs
@@ -41,6 +41,10 @@ import static java.lang.String.format;
 @NoRepositoryBean
 public interface N1qlCouchbaseRepository<T, ID> extends CouchbaseRepository<T, ID><% if (searchEngineCouchbase) { %>, SearchCouchbaseRepository<T, ID><% } %> {
 
+    static String pageableStatement(Pageable pageable) {
+        return pageableStatement(pageable, "");
+    }
+
     static String pageableStatement(Pageable pageable, String prefix) {
         Sort sort = Sort.by(
             pageable.getSort().stream()
@@ -67,4 +71,7 @@ public interface N1qlCouchbaseRepository<T, ID> extends CouchbaseRepository<T, I
 
     @ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
     Page<T> findAll(Pageable pageable);
+
+    @ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
+    void deleteAll();
 }

--- a/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
@@ -96,11 +96,9 @@ import org.springframework.data.mongodb.repository.<% if (reactive) { %>Reactive
 import org.springframework.data.neo4j.repository.<% if (reactive) { %>Reactive<% } %>Neo4jRepository;
 <%_ } _%>
 <%_ if (databaseTypeCouchbase) { _%>
-import org.springframework.data.domain.Sort;
 import com.couchbase.client.java.query.QueryScanConsistency;
 import org.springframework.data.couchbase.repository.Query;
 import org.springframework.data.couchbase.repository.ScanConsistency;
-import org.springframework.data.couchbase.repository.<% if (reactive) { %>Reactive<% } %>CouchbaseRepository;
 import org.springframework.data.domain.PageImpl;
 <%_ } _%>
 <%_ if (reactive && databaseTypeCassandra) { _%>
@@ -172,7 +170,7 @@ import static <%= packageName %>.config.Constants.ID_DELIMITER;
 _%>
 <%_ if ((databaseTypeSql && !reactive) || databaseTypeMongodb || databaseTypeNeo4j || databaseTypeCouchbase) { _%>
 @Repository
-public interface UserRepository extends <% if (databaseTypeSql) { %>JpaRepository<<%= asEntity('User') %>, <%= user.primaryKey.type %>><% } %><% if (reactive) { %>Reactive<% } %><% if (databaseTypeMongodb) { %>MongoRepository<<%= asEntity('User') %>, String><% } %><% if (databaseTypeNeo4j) { %>Neo4jRepository<<%= asEntity('User') %>, String><% } %><% if (databaseTypeCouchbase) { %>CouchbaseRepository<<%= asEntity('User') %>, String><%if (searchEngineCouchbase) { %>, SearchCouchbaseRepository<<%= asEntity('User') %>, String><% } } %> {
+public interface UserRepository extends <% if (databaseTypeSql) { %>JpaRepository<<%= asEntity('User') %>, <%= user.primaryKey.type %>><% } %><% if (reactive) { %>Reactive<% } %><% if (databaseTypeMongodb) { %>MongoRepository<<%= asEntity('User') %>, String><% } %><% if (databaseTypeNeo4j) { %>Neo4jRepository<<%= asEntity('User') %>, String><% } %><% if (databaseTypeCouchbase) { %>N1qlCouchbaseRepository<<%= asEntity('User') %>, String><%if (searchEngineCouchbase) { %>, SearchCouchbaseRepository<<%= asEntity('User') %>, String><% } } %> {
   <%_ if (cacheManagerIsAvailable) { _%>
 
     String USERS_BY_LOGIN_CACHE = "usersByLogin";
@@ -242,18 +240,6 @@ public interface UserRepository extends <% if (databaseTypeSql) { %>JpaRepositor
     <%= listOrFlux %><<%= asEntity('User') %>> findAll();
 
   <%_ } _%>
-  <%_ if (databaseTypeCouchbase) { _%>
-    @Override
-    @ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
-    <%= listOrFlux %><<%= asEntity('User') %>> findAll();
-
-  <%_ } _%>
-  <%_ if (databaseTypeCouchbase) { _%>
-    @Override
-    @ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
-    <%= listOrFlux %><<%= asEntity('User') %>> findAll(Sort sort);
-
-  <%_ } _%>
   <%_ if (databaseTypeSql) { _%>
     @EntityGraph(attributePaths = "authorities")
     <%_ if (cacheManagerIsAvailable) { _%>
@@ -287,7 +273,7 @@ public interface UserRepository extends <% if (databaseTypeSql) { %>JpaRepositor
   <% } else { %>
     <%_ if (databaseTypeCouchbase) { _%>
     default Page<<%= asEntity('User') %>> findAllActivatedIsTrue(Pageable pageable) {
-        return new PageImpl<>(findAllActivatedIsTrue(new org.springframework.data.couchbase.core.query.Query().with(pageable).export()), pageable, countAllActivatedIsTrue());
+        return new PageImpl<>(findAllActivatedIsTrue(N1qlCouchbaseRepository.pageableStatement(pageable)), pageable, countAllActivatedIsTrue());
     }
     <%_ } else { _%>
     Page<<%= asEntity('User') %>> findAllByIdNotNullAndActivatedIsTrue(Pageable pageable);

--- a/generators/server/templates/src/main/resources/config/couchmove/changelog/V0__create_indexes.n1ql.ejs
+++ b/generators/server/templates/src/main/resources/config/couchmove/changelog/V0__create_indexes.n1ql.ejs
@@ -1,4 +1,3 @@
--- create indexes
 CREATE INDEX type ON `${bucket}`(`_class`)
     WITH { "defer_build" : true };
 <%_ if (!skipUserManagement) { _%>
@@ -18,6 +17,3 @@ CREATE INDEX token_date ON `${bucket}`(tokenDate)
     WITH { "defer_build" : true };
   <%_ } _%>
 <%_ } _%>
-
--- build indexes asynchronously
-BUILD INDEX ON `${bucket}`(type<% if (!skipUserManagement) { %>, user_mail<% if (authenticationTypeSession) { %>, token_login, token_date<% } %><% } %>);

--- a/generators/server/templates/src/test/java/package/web/rest/PublicUserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/PublicUserResourceIT.java.ejs
@@ -208,7 +208,7 @@ class PublicUserResourceIT <% if (databaseTypeCassandra) { %>extends AbstractCas
 <% } _%>
     }
 
-<%_ if ((databaseTypeSql || databaseTypeMongodb || databaseTypeNeo4j)
+<%_ if ((databaseTypeSql || databaseTypeMongodb || databaseTypeNeo4j || databaseTypeCouchbase)
   && (!(authenticationTypeOauth2 && applicationTypeMicroservice))) { _%>
     @Test
   <%_ if (databaseTypeSql && !reactive) { _%>

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -482,9 +482,6 @@ class UserResourceIT <% if (databaseTypeCassandra) { %>extends AbstractCassandra
     }
 <%_ } _%>
 
-<%_ if (databaseTypeCouchbase) { _%>
-    @org.junit.Ignore
-<%_ } _%>
     @Test
 <%_ if (databaseTypeSql && !reactive) { _%>
     @Transactional


### PR DESCRIPTION
When trying to fix Couchbase tests, I discovered that since Spring Boot 2.5.4, the application doesn't use `JacksonAutoConfiguration#jacksonObjectMapper()` bean, which causes the application to fail since the modules are not loaded anymore. Adding manually the bean fixed the problem.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
