### PR TITLE
[Vue] Fix 'npm start' (webpack-dev-server 4.0.0)

### DIFF
--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -193,7 +193,7 @@
     "webapp:build": "<%= clientPackageManager %> run clean-www && <%= clientPackageManager %> run webapp:build:dev",
     "webapp:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --progress=profile --env stats=minimal",
     "webapp:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --progress=profile --env stats=minimal",
-    "webapp:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --progress=profile --inline --env stats=normal",
+    "webapp:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --progress=profile --env stats=normal",
     "webapp:prod": "<%= clientPackageManager %> run clean-www && <%= clientPackageManager %> run webapp:build:prod",
     "webapp:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "webpack serve",

--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -49,7 +49,9 @@ module.exports = async env => webpackMerge(await commonConfig({ env: MODE }), {
     moduleIds: 'named',
   },
   devServer: {
-    contentBase: './<%= DIST_DIR %>',
+    static: {
+      directory: './<%= DIST_DIR %>',
+    },
     port: <%= devServerPort %>,
     proxy: [
       {
@@ -81,9 +83,6 @@ module.exports = async env => webpackMerge(await commonConfig({ env: MODE }), {
       }
 <%_ } _%>
     ],
-    watchOptions: {
-      ignored: /node_modules/
-    },
     historyApiFallback: true
   },
   plugins: [


### PR DESCRIPTION
`npm start` not working

![image](https://user-images.githubusercontent.com/9989211/131257932-b3eaef9a-372d-4a94-8381-fe646adfeffb.png)

![image](https://user-images.githubusercontent.com/9989211/131257940-2849300a-2666-4203-ae56-a93ceeaa0d17.png)

Migration webpack-dev-server https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
