### PR TITLE
chore: Refactor OAuth2 logout url preparation logic

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/login/login.service.ts.ejs
@@ -80,20 +80,7 @@ export class LoginService {
   logout(): void {
 <%_ if (authenticationTypeOauth2) { _%>
     this.authServerProvider.logout().subscribe((logout: Logout) => {
-      let logoutUrl = logout.logoutUrl;
-      const redirectUri = `${location.origin}${this.location.prepareExternalUrl('/')}`;
-
-      // if Keycloak, uri has protocol/openid-connect/token
-      if (logoutUrl.includes('/protocol')) {
-        logoutUrl = logoutUrl + '?redirect_uri=' + redirectUri;
-      } else if(logoutUrl.includes('auth0.com')) {
-        // Auth0
-        logoutUrl = `${logoutUrl}?client_id=${logout.clientId}&returnTo=${redirectUri}`;
-      } else {
-        // Okta
-        logoutUrl = logoutUrl + '?id_token_hint=' + logout.idToken + '&post_logout_redirect_uri=' + redirectUri;
-      }
-      window.location.href = logoutUrl;
+      window.location.href = logout.logoutUrl;
     });
 <%_ } else { _%>
     this.authServerProvider.logout().subscribe({ complete: () => this.accountService.authenticate(null) });

--- a/generators/client/templates/angular/src/main/webapp/app/login/logout.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/login/logout.model.ts.ejs
@@ -17,5 +17,5 @@
  limitations under the License.
 -%>
 export class Logout {
-  constructor(public idToken: string, public logoutUrl: string, public clientId: string) {}
+  constructor(public logoutUrl: string) {}
 }

--- a/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
@@ -23,21 +23,12 @@ import { logout } from 'app/shared/reducers/authentication';
 
 export const Logout = () => {
   const logoutUrl = useAppSelector(state => state.authentication.logoutUrl);
-  const idToken = useAppSelector(state => state.authentication.idToken);
-  const clientId = useAppSelector(state => state.authentication.clientId);
   const dispatch = useAppDispatch();
 
   useLayoutEffect(() => {
     dispatch(logout());
     if (logoutUrl) {
-      // if Keycloak, logoutUrl has protocol/openid-connect in it
-      if (logoutUrl.includes('/protocol')) {
-        window.location.href = `${logoutUrl}?redirect_uri=${window.location.origin}`;
-      } else if(logoutUrl.includes('auth0.com')) {
-        window.location.href = `${logoutUrl}?client_id=${clientId}&returnTo=${window.location.origin}`;
-      } else {
-        window.location.href = `${logoutUrl}?id_token_hint=${idToken}&post_logout_redirect_uri=${window.location.origin}`;
-      }
+      window.location.href = logoutUrl;
     }
   });
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.spec.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.spec.ts.ejs
@@ -145,7 +145,7 @@ describe('Authentication reducer tests', () => {
 
   describe('Other cases', () => {
     it('should properly reset the current state when a logout is requested', () => {
-      <%_ if (authenticationTypeOauth2) { _%>const payload = { data: { idToken: 'xyz', clientId: 'abxyz', logoutUrl: 'http://localhost:8080/logout' } };<%_ } _%>
+      <%_ if (authenticationTypeOauth2) { _%>const payload = { data: { logoutUrl: 'http://localhost:8080/logout' } };<%_ } _%>
       const toTest = authentication(undefined,
       <%_ if (authenticationTypeJwt) { _%>
       logoutSession()

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -42,8 +42,6 @@ export const initialState = {
   errorMessage: null as unknown as string, // Errors returned from server side
   redirectMessage: null as unknown as string,
   sessionHasBeenFetched: false,
-  idToken: null as unknown as string,
-  clientId: null as unknown as string,
   logoutUrl: null as unknown as string,
 };
 
@@ -219,8 +217,6 @@ export const AuthenticationSlice = createSlice({
         <%_ if (!authenticationTypeOauth2) { _%>
         showModalLogin: true
         <%_ } else { _%>
-        idToken: action.payload.data.idToken,
-        clientId: action.payload.data.clientId,
         logoutUrl: action.payload.data.logoutUrl
         <%_ } _%>
       }))

--- a/generators/client/templates/vue/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -49,20 +49,7 @@ export default class JhiNavbar extends Vue {
       this.$store.commit('logout');
       this.$router.push('/');
   <%_ if (authenticationTypeOauth2) { _%>
-      const data = response.data;
-      let logoutUrl = data.logoutUrl;
-      // if Keycloak, uri has protocol/openid-connect/token
-      if (logoutUrl.indexOf('/protocol') > -1) {
-        logoutUrl = logoutUrl + '?redirect_uri=' + window.location.origin;
-      } else if(logoutUrl.includes('auth0.com')) {
-        // Auth0
-        logoutUrl = `${logoutUrl}?client_id=${data.clientId}&returnTo=${window.location.origin}`;
-      } else {
-        // Okta
-        logoutUrl = logoutUrl + '?id_token_hint=' +
-        data.idToken + '&post_logout_redirect_uri=' + window.location.origin;
-      }
-      window.location.href = logoutUrl;
+      window.location.href = response.data.logoutUrl;
   <%_ } _%>
     });
 <%_ } else { _%>

--- a/generators/cypress/templates/src/test/javascript/cypress/support/oauth2.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/support/oauth2.ts.ejs
@@ -133,41 +133,26 @@ Cypress.Commands.add('oktaLogin', (oauth2Data: any, username, password) => {
 
 Cypress.Commands.add('oauthLogout', () => {
   cy.getCookie('XSRF-TOKEN')
-    .then(csrfCookie => {
+    .then(csrfCookie => cy.location().then(loc$ => cy.request({
+          method: 'POST',
+          url: `api/logout`,
+          headers: {
+            'X-XSRF-TOKEN': csrfCookie?.value,
+            origin: loc$.origin,
+          },
+        })
+    ))
+    .then(res => {
+      expect(res.status).to.eq(200);
       return cy.request({
-        method: 'POST',
-        url: `api/logout`,
-        headers: {
-          'X-XSRF-TOKEN': csrfCookie?.value,
-        },
-      })
-  })
-  .then(res => {
-    expect(res.status).to.eq(200)
-    let logoutUrl = res.body.logoutUrl
-    let redirectUri
-    cy.location().then(loc$ => {
-      redirectUri = loc$.origin
-      // Keycloak: uri has protocol/openid-connect/token
-      if (logoutUrl.includes('/protocol')) {
-        logoutUrl = `${logoutUrl}?redirect_uri=${redirectUri}`
-      } else if (logoutUrl.includes('auth0.com')) {
-        // Auth0
-        logoutUrl = `${logoutUrl}?client_id=${res.body.clientId}&returnTo=${window.location.origin}`;
-      } else {
-        // Else, Okta
-        logoutUrl = `${logoutUrl}?id_token_hint=${res.body.idToken}&post_logout_redirect_uri=${redirectUri}`
-      }
-      return cy.request({
-        url: logoutUrl,
+        url: res.body.logoutUrl,
         followRedirect: true,
-      })
+      });
     })
-  })
-  .then(res => {
-    expect(res.status).to.eq(200)
-    cy.visit('/')
-  })
+    .then(res => {
+      expect(res.status).to.eq(200);
+      cy.visit('/');
+    });
 });
 
 Cypress.Commands.add('clearCache', () => {

--- a/generators/server/templates/src/main/java/package/web/rest/LogoutResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/LogoutResource.java.ejs
@@ -27,9 +27,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 <%_ if (!reactive) { _%>
 import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
+import org.springframework.http.HttpHeaders;
 <%_ } else { _%>
 import org.springframework.web.server.WebSession;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.core.publisher.Mono;
 <%_ } _%>
 import java.util.Map;
@@ -53,51 +54,68 @@ public class LogoutResource {
 <%_ } _%>
      * @param idToken the ID token.
 <%_ if (reactive) { _%>
+     * @param request a {@link ServerHttpRequest} request.
      * @param session the current {@link WebSession}.
 <%_ } _%>
-     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and a body with a global logout URL and ID token.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and a body with a global logout URL.
      */
     @PostMapping("/api/logout")
 <%_ if (!reactive) { _%>
     public ResponseEntity<?> logout(HttpServletRequest request,
                                     @AuthenticationPrincipal(expression = "idToken") OidcIdToken idToken) {
-        String logoutUrl;
+        StringBuilder logoutUrl = new StringBuilder();
+
         String issuerUri = this.registration.getProviderDetails().getIssuerUri();
         if (issuerUri.contains("auth0.com")) {
-            logoutUrl = issuerUri.endsWith("/") ? issuerUri + "v2/logout" : issuerUri + "/v2/logout";
+            logoutUrl.append(issuerUri.endsWith("/") ? issuerUri + "v2/logout" : issuerUri + "/v2/logout");
         } else {
-            logoutUrl = this.registration.getProviderDetails()
-                .getConfigurationMetadata()
-                .get("end_session_endpoint")
-                .toString();
+            logoutUrl.append(this.registration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString());
         }
 
-        Map<String, String> logoutDetails = new HashMap<>();
-        logoutDetails.put("logoutUrl", logoutUrl);
-        logoutDetails.put("idToken", idToken.getTokenValue());
-        logoutDetails.put("clientId", this.registration.getClientId());
+        String originUrl = request.getHeader(HttpHeaders.ORIGIN);
+
+        if (logoutUrl.indexOf("/protocol") > -1) {
+            logoutUrl.append("?redirect_uri=").append(originUrl);
+        } else if (logoutUrl.indexOf("auth0.com") > -1) {
+            // Auth0
+            logoutUrl.append("?client_id=").append(this.registration.getClientId()).append("&returnTo=").append(originUrl);
+        } else {
+            // Okta
+            logoutUrl.append("?id_token_hint=").append(idToken.getTokenValue()).append("&post_logout_redirect_uri=").append(originUrl);
+        }
+
         request.getSession().invalidate();
-        return ResponseEntity.ok().body(logoutDetails);
+        return ResponseEntity.ok().body(Map.of("logoutUrl", logoutUrl.toString()));
     }
 <%_ } else { _%>
-    public Mono<Map<String, String>> logout(@AuthenticationPrincipal(expression = "idToken") OidcIdToken idToken, WebSession session) {
-        return session.invalidate().then(
-            this.registration
-                .map(oidc -> Map.of(
-                    "clientId", oidc.getClientId(),
-                    "logoutUrl", prepareLogoutUri(oidc.getProviderDetails()),
-                    "idToken", idToken.getTokenValue())
-                )
-        );
+    public Mono<Map<String, String>> logout(@AuthenticationPrincipal(expression = "idToken") OidcIdToken idToken, ServerHttpRequest request, WebSession session) {
+        return session
+            .invalidate()
+            .then(
+                this.registration.map(oidc -> prepareLogoutUri(request, oidc, idToken))
+            );
     }
 
-    private String prepareLogoutUri(ClientRegistration.ProviderDetails providerDetails) {
-        if (providerDetails.getIssuerUri().contains("auth0.com")) {
-            String issuerUri = providerDetails.getIssuerUri();
-            return issuerUri.endsWith("/") ? issuerUri + "v2/logout" : issuerUri + "/v2/logout";
+    private Map<String, String> prepareLogoutUri(ServerHttpRequest request, ClientRegistration clientRegistration, OidcIdToken idToken) {
+        StringBuilder logoutUrl = new StringBuilder();
+        String issuerUri = clientRegistration.getProviderDetails().getIssuerUri();
+        if (issuerUri.contains("auth0.com")) {
+            logoutUrl.append(issuerUri.endsWith("/") ? issuerUri + "v2/logout" : issuerUri + "/v2/logout");
         } else {
-            return providerDetails.getConfigurationMetadata().get("end_session_endpoint").toString();
+            logoutUrl.append(clientRegistration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString());
         }
+
+        String originUrl = request.getHeaders().getOrigin();
+        if (logoutUrl.indexOf("/protocol") > -1) {
+            logoutUrl.append("?redirect_uri=").append(originUrl);
+        } else if (logoutUrl.indexOf("auth0.com") > -1) {
+            // Auth0
+            logoutUrl.append("?client_id=").append(clientRegistration.getClientId()).append("&returnTo=").append(originUrl);
+        } else {
+            // Okta
+            logoutUrl.append("?id_token_hint=").append(idToken.getTokenValue()).append("&post_logout_redirect_uri=").append(originUrl);
+        }
+        return Map.of("logoutUrl", logoutUrl.toString());
     }
 
 <%_ } _%>

--- a/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
@@ -34,6 +34,7 @@ import <%= packageName %>.security.AuthoritiesConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.<% if (reactive) { %>Reactive<% } %>OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -103,27 +104,27 @@ class LogoutResourceIT {
 
     @Test
     void getLogoutInformation() <% if (!reactive) { %>throws Exception <% } %>{
+        final String ORIGIN_URL = "http://localhost:8080";
 <%_ if (!reactive) { _%>
         String logoutUrl = this.registrations.findByRegistrationId("oidc").getProviderDetails()
             .getConfigurationMetadata().get("end_session_endpoint").toString();
-        restLogoutMockMvc.perform(post("/api/logout"))
+        logoutUrl = logoutUrl + "?id_token_hint=" + ID_TOKEN + "&post_logout_redirect_uri=" + ORIGIN_URL;
+        restLogoutMockMvc.perform(post("http://localhost:8080/api/logout").header(HttpHeaders.ORIGIN, ORIGIN_URL))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.logoutUrl").value(logoutUrl))
-            .andExpect(jsonPath("$.idToken").value(ID_TOKEN));
 <%_ } else { _%>
         String logoutUrl = this.registrations.findByRegistrationId("oidc")
             .map(oidc -> oidc.getProviderDetails().getConfigurationMetadata()
                 .get("end_session_endpoint").toString()).block();
-
+        logoutUrl = logoutUrl + "?id_token_hint=" + ID_TOKEN + "&post_logout_redirect_uri=" + ORIGIN_URL;
         this.webTestClient.mutateWith(csrf())
             .mutateWith(mockAuthentication(registerAuthenticationToken(authorizedClientService, clientRegistration, authenticationToken(claims))))
-            .post().uri("/api/logout").exchange()
+            .post().uri("http://localhost:8080/api/logout").header(HttpHeaders.ORIGIN, ORIGIN_URL).exchange()
             .expectStatus().isOk()
             .expectHeader().contentType(MediaType.APPLICATION_JSON_VALUE)
             .expectBody()
-            .jsonPath("$.logoutUrl").isEqualTo(logoutUrl.toString())
-            .jsonPath("$.idToken").isEqualTo(ID_TOKEN);
+            .jsonPath("$.logoutUrl").isEqualTo(logoutUrl);
 <%_ } _%>
     }
 }

--- a/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
@@ -112,7 +112,7 @@ class LogoutResourceIT {
         restLogoutMockMvc.perform(post("http://localhost:8080/api/logout").header(HttpHeaders.ORIGIN, ORIGIN_URL))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(jsonPath("$.logoutUrl").value(logoutUrl))
+            .andExpect(jsonPath("$.logoutUrl").value(logoutUrl));
 <%_ } else { _%>
         String logoutUrl = this.registrations.findByRegistrationId("oidc")
             .map(oidc -> oidc.getProviderDetails().getConfigurationMetadata()


### PR DESCRIPTION
<!--
PR description.
-->

Refactor OAuth2 logout REST API to prepare absolute logout URL on the server-side. With this change, we shall not need to change the API contract (to send additional data in response) and client code (to read/parse additional data to prepare the final URL) to support a new OAuth2 provider. 


Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
