### PR TITLE
fix: Update cypress e2e npm scripts

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -146,15 +146,15 @@
     "e2e": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:headless": "<%= clientPackageManager %> run e2e:protractor:headless",
     <%_ } else if ((cypressTests && !protractorTests) || (protractorTests && cypressTests)) {  _%>
-    "e2e": "<%= clientPackageManager %> run e2e:cypress",
-    "e2e:headless": "<%= clientPackageManager %> run e2e:cypress:headless",
+    "e2e": "<%= clientPackageManager %> run e2e:cypress:headed",
+    "e2e:headless": "<%= clientPackageManager %> run e2e:cypress",
     <%_ } _%>
     <%_ if (protractorTests) { _%>
     "e2e:protractor:headless": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:protractor": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
     <%_ } _%>
     <%_ if (cypressTests) { _%>
-    "e2e:cypress:headless": "<%= clientPackageManager %> run e2e:cypress -- --headless",
+    "e2e:cypress:headed": "<%= clientPackageManager %> run e2e:cypress -- --headed",
     "e2e:cypress": "cypress run --browser chrome --record ${CYPRESS_ENABLE_RECORD:-false}",
     "cypress": "cypress open",
     <%_ } _%>

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -180,15 +180,15 @@
     "e2e": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:headless": "<%= clientPackageManager %> run e2e:protractor:headless",
 <%_ } else if ((cypressTests && !protractorTests) || (protractorTests && cypressTests)) {  _%>
-    "e2e": "<%= clientPackageManager %> run e2e:cypress",
-    "e2e:headless": "<%= clientPackageManager %> run e2e:cypress:headless",
+    "e2e": "<%= clientPackageManager %> run e2e:cypress:headed",
+    "e2e:headless": "<%= clientPackageManager %> run e2e:cypress",
 <%_ } _%>
 <%_ if (protractorTests) { _%>
     "e2e:protractor:headless": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:protractor": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
 <%_ } _%>
 <%_ if (cypressTests) { _%>
-    "e2e:cypress:headless": "<%= clientPackageManager %> run e2e:cypress -- --headless",
+    "e2e:cypress:headed": "<%= clientPackageManager %> run e2e:cypress -- --headed",
     "e2e:cypress": "cypress run --browser chrome --record ${CYPRESS_ENABLE_RECORD:-false}",
     "cypress": "cypress open",
 <%_ } _%>

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -164,15 +164,15 @@
     "e2e": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:headless": "<%= clientPackageManager %> run e2e:protractor:headless",
 <%_ } else if ((cypressTests && !protractorTests) || (protractorTests && cypressTests)) {  _%>
-    "e2e": "<%= clientPackageManager %> run e2e:cypress",
-    "e2e:headless": "<%= clientPackageManager %> run e2e:cypress:headless",
+    "e2e": "<%= clientPackageManager %> run e2e:cypress:headed",
+    "e2e:headless": "<%= clientPackageManager %> run e2e:cypress",
 <%_ } _%>
 <%_ if (protractorTests) { _%>
     "e2e:protractor:headless": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:protractor": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
 <%_ } _%>
 <%_ if (cypressTests) { _%>
-    "e2e:cypress:headless": "<%= clientPackageManager %> run e2e:cypress -- --headless",
+    "e2e:cypress:headed": "<%= clientPackageManager %> run e2e:cypress -- --headed",
     "e2e:cypress": "cypress run --browser chrome --record ${CYPRESS_ENABLE_RECORD:-false}",
     "cypress": "cypress open",
 <%_ } _%>

--- a/generators/cypress/index.js
+++ b/generators/cypress/index.js
@@ -169,7 +169,7 @@ module.exports = class extends BaseBlueprintGenerator {
           },
           scripts: {
             'cypress:audits': 'cypress open --config-file cypress-audits.json',
-            'e2e:cypress:audits:headless': 'npm run e2e:cypress -- --headless --config-file cypress-audits.json',
+            'e2e:cypress:audits:headless': 'npm run e2e:cypress --config-file cypress-audits.json',
             // eslint-disable-next-line no-template-curly-in-string
             'e2e:cypress:audits': 'cypress run --browser chrome --record ${CYPRESS_ENABLE_RECORD:-false} --config-file cypress-audits.json',
           },
@@ -187,7 +187,7 @@ module.exports = class extends BaseBlueprintGenerator {
           scripts: {
             'clean-coverage': 'rimraf .nyc_output coverage',
             'pree2e:cypress:coverage': 'npm run clean coverage && npm run ci:server:await',
-            'e2e:cypress:coverage': 'npm run e2e:cypress',
+            'e2e:cypress:coverage': 'npm run e2e:cypress:headed',
             'poste2e:cypress:coverage': 'nyc report',
             'prewebapp:instrumenter': 'npm run clean-www && npm run clean-coverage',
             'webapp:instrumenter': 'ng build --configuration instrumenter',


### PR DESCRIPTION
<!--
PR description.
-->
Update cypress e2e scripts to consider default headless mode and add a new npm script to execute tests in headed mode (default mode in JHipster).

Related #16127 


Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
