### PR TITLE
[Angular] Remove deprecated msSaveOrOpenBlob

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/util/data-util.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/data-util.service.ts.ejs
@@ -57,17 +57,10 @@ export class DataUtils {
     const blob = new Blob([byteArray], {
       type: contentType,
     });
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (window.navigator.msSaveOrOpenBlob) {
-      // To support IE
-      window.navigator.msSaveOrOpenBlob(blob);
-    } else {
-      // Other browsers
-      const fileURL = window.URL.createObjectURL(blob);
-      const win = window.open(fileURL);
-      win!.onload = function() {
+    const fileURL = window.URL.createObjectURL(blob);
+    const win = window.open(fileURL);
+    win!.onload = function() {
         URL.revokeObjectURL(fileURL);
-      }  
     }
   }
 


### PR DESCRIPTION
Same as #16076
[msSaveOrOpenBlob ](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/msSaveOrOpenBlob) is deprecated and #16069 will faill.

[createObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) is supported since IE 10 (2012), so is safe to remove msSaveOrOpenBlob.


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
