### PR TITLE
Add modernizer-maven-plugin to detect legacy/deprecated API usage

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -160,6 +160,7 @@
         <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
 <%_ } _%>
         <git-commit-id-plugin.version>5.0.0</git-commit-id-plugin.version>
+        <modernizer-maven-plugin.version>2.3.0</modernizer-maven-plugin.version>
         <jacoco-maven-plugin.version><%= JACOCO_VERSION %></jacoco-maven-plugin.version>
         <jib-maven-plugin.version><%= JIB_VERSION %></jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
@@ -962,6 +963,10 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+            </plugin>
 <%_ if (enableSwaggerCodegen) { _%>
             <plugin>
                 <!--
@@ -1134,6 +1139,23 @@
                             <includeOnlyProperty>^git.commit.id.describe$</includeOnlyProperty>
                             <includeOnlyProperty>^git.branch$</includeOnlyProperty>
                         </includeOnlyProperties>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.gaul</groupId>
+                    <artifactId>modernizer-maven-plugin</artifactId>
+                    <version>${modernizer-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>modernizer</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>modernizer</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                      <javaVersion>${java.version}</javaVersion>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration_couchbase.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration_couchbase.java.ejs
@@ -29,8 +29,6 @@ import com.github.couchmove.Couchmove;
 
 import <%= packageName %>.config.couchbase.CustomCouchbaseRepositoryFactoryBean;
 
-import org.apache.commons.codec.binary.Base64;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.couchbase.CouchbaseProperties;
@@ -269,7 +267,7 @@ public class DatabaseConfiguration extends AbstractCouchbaseConfiguration {
 
         @Override
         public byte[] convert(String source) {
-            return Base64.decodeBase64(source);
+            return Base64.getDecoder().decode(source);
         }
     }
 

--- a/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
@@ -77,7 +77,6 @@ import org.zalando.problem.spring.webflux.advice.ProblemHandling;
 import javax.servlet.*;
     <%_ if (!skipClient) { _%>
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.*;
@@ -164,13 +163,7 @@ public class WebConfigurer implements <% if (!reactive) { %>ServletContextInitia
      * Resolve path prefix to static resources.
      */
     private String resolvePathPrefix() {
-        String fullExecutablePath;
-        try {
-            fullExecutablePath = decode(this.getClass().getResource("").getPath(), StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            /* try without decoding if this ever happens */
-            fullExecutablePath = this.getClass().getResource("").getPath();
-        }
+        String fullExecutablePath = decode(this.getClass().getResource("").getPath(), StandardCharsets.UTF_8);
         String rootPath = Paths.get(".").toUri().normalize().getPath();
         String extractedPath = fullExecutablePath.replace(rootPath, "");
         int extractionEndIndex = extractedPath.indexOf("<%= BUILD_DIR %>");

--- a/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
@@ -249,7 +249,7 @@ import javax.servlet.http.HttpServletRequest;
   <%_ } _%>
 import javax.validation.Valid;
   <%_ if (authenticationTypeSession && !reactive) { _%>
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.net.URLDecoder;
   <%_ } _%>
   <%_ if (reactive) { _%>
@@ -458,11 +458,11 @@ public class AccountResource {
      *   cookie.
      *
      * @param series the series of an existing session.
-     * @throws UnsupportedEncodingException if the series couldn't be URL decoded.
+     * @throws IllegalArgumentException if the series couldn't be URL decoded.
      */
     @DeleteMapping("/account/sessions/{series}")
-    public void invalidateSession(@PathVariable String series) throws UnsupportedEncodingException {
-        String decodedSeries = URLDecoder.decode(series, "UTF-8");
+    public void invalidateSession(@PathVariable String series) {
+        String decodedSeries = URLDecoder.decode(series, StandardCharsets.UTF_8);
         SecurityUtils.getCurrentUserLogin()
             .flatMap(userRepository::findOneByLogin)
             .ifPresent(u ->


### PR DESCRIPTION
and fix one issue in the generated code

Modernizer Maven Plugin detects uses of legacy APIs which modern Java versions supersede - 
More about it here: https://github.com/gaul/modernizer-maven-plugin

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
