### PR TITLE
Improve OIDC user handling

### DIFF
--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -65,6 +65,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
   <%_ if (!applicationTypeMicroservice) { _%>
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
   <%_ } _%>
 import java.util.*;
@@ -319,7 +320,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 // each scope as a GrantedAuthority, which we don't care about.
                 if (authority instanceof OidcUserAuthority) {
                     OidcUserAuthority oidcUserAuthority = (OidcUserAuthority) authority;
-                    mappedAuthorities.addAll(SecurityUtils.extractAuthorityFromClaims(oidcUserAuthority.getUserInfo().getClaims()));
+                    OidcUserInfo userInfo = oidcUserAuthority.getUserInfo();
+                    if (userInfo != null) {
+                        mappedAuthorities.addAll(SecurityUtils.extractAuthorityFromClaims(userInfo.getClaims()));
+                    }
                 }
             });
             return mappedAuthorities;

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -911,7 +911,7 @@ public class UserService {
                     updateUser(user.getFirstName(), user.getLastName(), user.getEmail(),
                         user.getLangKey(), user.getImageUrl());
                 }
-                // no last updated info, blindly update
+            // no last updated info, blindly update
             } else {
                 log.debug("Updating user '{}' in local database", user.getLogin());
                 updateUser(user.getFirstName(), user.getLastName(), user.getEmail(),
@@ -1042,8 +1042,6 @@ public class UserService {
         }
         if (details.get("email") != null) {
             user.setEmail(((String) details.get("email")).toLowerCase());
-        } else {
-            user.setEmail((String) details.get("sub"));
         }
         if (details.get("langKey") != null) {
             user.setLangKey((String) details.get("langKey"));


### PR DESCRIPTION
<!--
PR description.
-->

This PR contains some minor improvements for OIDC user handling, which I experienced recently connecting to Microsofts ADFS.

- Check if user info is not null before extracting authorities from it
- Remove else branch for setting the email of a user; the `sub` does not contain an email address and leads to a validation exception on the user entity because of the `@Email` annotation
- If the user already exists in the database, add existing (additional) roles to the returned object; this enables to maintain some roles in the app itself

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
