### PR TITLE
Revert "Add consistency to search requests"

### DIFF
--- a/generators/entity-server/templates/couchbase/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/couchbase/src/main/java/package/repository/EntityRepository.java.ejs
@@ -123,7 +123,6 @@ public interface <%= entityClass %>Repository extends JHipsterCouchbaseRepositor
     } _%>
 
 <%_ if (searchEngineCouchbase) { _%>
-    @ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
   <%_ if (relationships.length === 0) { _%>
     @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND SEARCH(#{#n1ql.bucket}, #{[0]}) #{[1]}")
   <%_ } else { _%>

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -1736,6 +1736,10 @@ _%>
             .thenReturn(Stream.of(<%= persistInstance %>));
       <%_ } _%>
     <%_ } _%>
+  <%_ } else if (searchEngineCouchbase) { _%>
+
+        // Wait for the <%= entityInstance %> to be indexed
+        TestUtil.retryUntilNotEmpty(() -> <%= entityInstance %>Repository.search("id:" + <%= entityInstance %>.get<%= primaryKey.nameCapitalized %>())<% if (reactive) { %>.collectList().block()<% } %>);
   <%_ } _%>
 
         // Search the <%= entityInstance %>

--- a/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
@@ -297,7 +297,6 @@ public interface UserRepository extends <% if (databaseTypeSql) { %>JpaRepositor
   <%_ } _%>
 
   <%_ if (searchEngineCouchbase) { _%>
-    @ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
     @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND SEARCH(#{n1ql.bucket}, #{[0]) #{[1]}")
     <%= listOrFlux %><User> search(String queryString, String pageableStatement);
 

--- a/generators/server/templates/src/test/java/package/web/rest/TestUtil.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/TestUtil.java.ejs
@@ -48,6 +48,14 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 <%_ } _%>
+<%_ if (searchEngineCouchbase) { _%>
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.time.Duration;
+import reactor.core.publisher.Mono;
+<%_ } _%>
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -249,6 +257,20 @@ public final class TestUtil {
         TypedQuery<T> allQuery = em.createQuery(all);
         return allQuery.getResultList();
     }
+<%_ } _%>
+<%_ if (searchEngineCouchbase) { _%>
+    public static <T> void retryUntilNotEmpty(Callable<Iterable<T>> iterableCallable) {
+        Mono.defer(
+                () -> Mono.fromCallable(iterableCallable)
+                    .flatMapIterable(Function.identity())
+                    .next()
+                    .switchIfEmpty(Mono.error(new NoSuchElementException()))
+            )
+            .retry()
+            .timeout(Duration.ofSeconds(5))
+            .block();
+    }
+
 <%_ } _%>
 
     private TestUtil() {}


### PR DESCRIPTION
It seems that I was wrong here https://github.com/jhipster/generator-jhipster/pull/16102#issuecomment-910468828: the tests were passing because we are testing only using id. The `REQUEST_PLUS` consistency is still not available to N1QL Search requests.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
