### PR TITLE
Add gradle-modernizer-plugin to detect legacy/deprecated API usage

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -45,6 +45,7 @@ plugins {
 <%_ } _%>
     id "org.sonarqube"
     id "io.spring.nohttp"
+    id "com.github.andygoossens.gradle-modernizer-plugin"
     //jhipster-needle-gradle-plugins - JHipster will add additional gradle plugins here
 }
 
@@ -126,6 +127,11 @@ test {
     // see https://github.com/jhipster/generator-jhipster/pull/2771 and https://github.com/jhipster/generator-jhipster/pull/4484
     // ignoreFailures true
     reports.html.enabled = false
+}
+
+modernizer {
+    failOnViolations = true
+    includeTestClasses = true
 }
 
 task integrationTest(type: Test) {

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -74,6 +74,7 @@ openapiPluginVersion=5.2.1
 <%_ } _%>
 noHttpPluginVersion=0.0.8
 checkstyleVersion=8.45.1
+modernizerPluginVersion=1.6.0
 
 # jhipster-needle-gradle-property - JHipster will add additional properties here
 

--- a/generators/server/templates/settings.gradle.ejs
+++ b/generators/server/templates/settings.gradle.ejs
@@ -39,6 +39,7 @@ pluginManagement {
 <%_ } _%>
         id 'org.sonarqube' version "${sonarqubePluginVersion}"
         id "io.spring.nohttp" version "${noHttpPluginVersion}"
+        id 'com.github.andygoossens.gradle-modernizer-plugin' version "${modernizerPluginVersion}"
     }
 }
 


### PR DESCRIPTION
This plugin is a wrapper around modernizer-maven-plugin, but works in Gradle.
 
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
