### PR TITLE
Don't overwrite .yo-rc.json at blueprint.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -265,7 +265,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
     }
 
     // Write new definitions to memfs
-    if (this.options.applicationWithEntities) {
+    if (!this.fromBlueprint && this.options.applicationWithEntities) {
       this.config.set({
         ...this.config.getAll(),
         ...this.options.applicationWithEntities.config,


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster-quarkus/pull/223#issuecomment-903716516

Currently:
1. Config are written at main generator
2. Custom options are written at main generator
3. Config are written again at blueprint, overwriting custom options.

Remove third step.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
