### PR TITLE
enabled build cache when gradle enterprise is selected

### DIFF
--- a/generators/server/templates/settings.gradle.ejs
+++ b/generators/server/templates/settings.gradle.ejs
@@ -61,5 +61,14 @@ gradleEnterprise {
         publishAlways()
     }
 }
+
+buildCache {
+    local { enabled = true }
+    remote(HttpBuildCache) {
+        push = true
+        enabled = false // Disabled as this might not always desired
+        url = '<%= gradleEnterpriseHost %>/cache/' // note the trailing slash!
+    }
+}
 <%_ } _%>  
 rootProject.name = "<%= dasherizedBaseName %>"


### PR DESCRIPTION
Generate build cache confguration when gradle enterprise is selected.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
