### PR TITLE
support destinationPath when generateKeyStore

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1862,16 +1862,22 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
    */
   generateKeyStore() {
     const done = this.async();
-    const keyStoreFile = `${SERVER_MAIN_RES_DIR}config/tls/keystore.p12`;
+    
+    let keystoreFolder = `${SERVER_MAIN_RES_DIR}config/tls/`;
+    if (this.destinationPath) {
+      keystoreFolder = this.destinationPath(keystoreFolder);
+    }
+    const keyStoreFile = `${keystoreFolder}/keystore.p12`;
+    
     if (this.fs.exists(keyStoreFile)) {
       this.log(chalk.cyan(`\nKeyStore '${keyStoreFile}' already exists. Leaving unchanged.\n`));
       done();
     } else {
       try {
-        shelljs.mkdir('-p', `${SERVER_MAIN_RES_DIR}config/tls`);
+        shelljs.mkdir('-p', keystoreFolder);
       } catch (error) {
         // noticed that on windows the shelljs.mkdir tends to sometimes fail
-        fs.mkdir(`${SERVER_MAIN_RES_DIR}config/tls`, { recursive: true }, err => {
+        fs.mkdir(keystoreFolder, { recursive: true }, err => {
           if (err) throw err;
         });
       }


### PR DESCRIPTION

when try to change use destinationPath to change the destination folder, the keystore file generate in wrong path.

use "this.destinationPath" to wrap  the "keyStoreFile"


Please make sure the below checklist is followed for Pull Requests.

- [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ X] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
