### PR TITLE
[vue] Add error handling toast

### DIFF
--- a/generators/client/files-vue.js
+++ b/generators/client/files-vue.js
@@ -68,6 +68,7 @@ const vueFiles = {
         'shims-vue.d.ts',
         'constants.ts',
         'main.ts',
+        'shared/alert/alert.service.ts',
         'shared/config/axios-interceptor.ts',
         'shared/config/config.ts',
         'shared/config/config-bootstrap-vue.ts',

--- a/generators/client/files-vue.js
+++ b/generators/client/files-vue.js
@@ -232,6 +232,7 @@ const vueFiles = {
         'spec/app/core/error/error.component.spec.ts',
         'spec/app/core/jhi-navbar/jhi-navbar.component.spec.ts',
         'spec/app/core/ribbon/ribbon.component.spec.ts',
+        'spec/app/shared/alert/alert.service.spec.ts',
         'spec/app/shared/config/axios-interceptor.spec.ts',
         'spec/app/shared/data/data-utils.service.spec.ts',
       ],

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-edit.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-edit.component.ts.ejs
@@ -2,6 +2,7 @@ import { email, maxLength, minLength, required } from 'vuelidate/lib/validators'
 import { Component, Inject, Vue } from 'vue-property-decorator';
 import UserManagementService from './user-management.service';
 import { IUser, User } from '@/shared/model/user.model';
+import AlertService from '@/shared/alert/alert.service';
 
 const loginValidator = (value: string) => {
   if (!value) {
@@ -37,6 +38,8 @@ const validations: any = {
 })
 export default class <%=jhiPrefixCapitalized%>UserManagementEdit extends Vue {
   @Inject('userService') private userManagementService: () => UserManagementService;
+  @Inject('alertService') private alertService: () => AlertService;
+
   public userAccount: IUser;
   public isSaving = false;
   public authorities: any[] = [];
@@ -87,6 +90,9 @@ export default class <%=jhiPrefixCapitalized%>UserManagementEdit extends Vue {
           solid: true,
           autoHideDelay: 5000,
         });
+      }).catch(error => {
+        this.isSaving = true;
+        this.alertService().showHttpError(this,error.response);
       });
     } else {
 <%_ if (!enableTranslation) { _%>
@@ -101,6 +107,9 @@ export default class <%=jhiPrefixCapitalized%>UserManagementEdit extends Vue {
           solid: true,
           autoHideDelay: 5000,
         });
+      }).catch(error => {
+        this.isSaving = true;
+        this.alertService().showHttpError(this,error.response);
       });
     }
   }

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-view.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-view.component.ts.ejs
@@ -1,10 +1,13 @@
 import Vue from 'vue';
 import { Component, Inject } from 'vue-property-decorator';
 import UserManagementService from './user-management.service';
+import AlertService from '@/shared/alert/alert.service';
 
 @Component
 export default class <%=jhiPrefixCapitalized%>UserManagementView extends Vue {
   @Inject('userService') private userManagementService: () => UserManagementService;
+  @Inject('alertService') private alertService: () => AlertService;
+
   public user: any = null;
 
   beforeRouteEnter(to, from, next) {
@@ -17,6 +20,8 @@ export default class <%=jhiPrefixCapitalized%>UserManagementView extends Vue {
   public init(userId: <% if (userPrimaryKeyTypeString || userPrimaryKeyTypeUUID) { %>string<% } else { %>number<% } %>): void {
     this.userManagementService().get(userId).then(res => {
       this.user = res.data;
+    }).catch(error => {
+      this.alertService().showHttpError(this,error.response);
     });
   }
 }

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -1,12 +1,15 @@
 import { Component, Inject, Vue } from 'vue-property-decorator';
 import Vue2Filters from 'vue2-filters';
 import UserManagementService from './user-management.service';
+import AlertService from '@/shared/alert/alert.service';
 
 @Component({
   mixins: [Vue2Filters.mixin]
 })
 export default class <%=jhiPrefixCapitalized%>UserManagementComponent extends Vue {
   @Inject('userService') private userManagementService: () => UserManagementService;
+  @Inject('alertService') private alertService: () => AlertService;
+
   public error = '';
   public success = '';
   public users: any[] = [];
@@ -110,6 +113,8 @@ _%>
       this.removeId = null;
       this.loadAll();
       this.closeDialog();
+    }).catch(error => {
+      this.alertService().showHttpError(this,error.response);
     });
   }
 

--- a/generators/client/templates/vue/src/main/webapp/app/main.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/main.ts.ejs
@@ -24,6 +24,7 @@ import UserManagementService from '@/admin/user-management/user-management.servi
 <%_ } _%>
 import LoginService from './account/login.service';
 import AccountService from './account/account.service';
+import AlertService from './shared/alert/alert.service';
 
 import '../content/scss/vendor.scss';
 <%_ if (enableTranslation) { _%>
@@ -120,7 +121,8 @@ new Vue({
     translationService: () => translationService,
 <%_ } _%>
     // jhipster-needle-add-entity-service-to-main - JHipster will import entities services here
-    accountService: () => accountService
+    accountService: () => accountService,
+    alertService: () => new AlertService()
 
   },
 <%_ if (enableTranslation) { _%>    i18n,<%_ } _%>

--- a/generators/client/templates/vue/src/main/webapp/app/shared/alert/alert.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/shared/alert/alert.service.ts.ejs
@@ -1,0 +1,61 @@
+import Vue from 'vue';
+
+export default class AlertService {
+  public showError(instance: Vue, message: string, params?: any) {
+    <%_ if (enableTranslation) { _%>
+    const alertMessage = instance.$t(message, params);
+    <%_ } else {_%>
+    const alertMessage = message;
+    <%_ } _%>
+    instance.$root.$bvToast.toast(alertMessage.toString(), {
+      toaster: 'b-toaster-top-center',
+      title: 'Error',
+      variant: 'danger',
+      solid: true,
+      autoHideDelay: 5000,
+    });
+  }
+
+  public showHttpError(instance: Vue, httpErrorResponse: any) {
+    switch (httpErrorResponse.status) {
+      case 0:
+        this.showError(instance,<% if (enableTranslation) { %> 'error.server.not.reachable'<% } else { %> 'Server not reachable'<% } %>);
+        break;
+
+      case 400: {
+        const arr = Object.keys(httpErrorResponse.headers);
+        let errorHeader: string | null = null;
+<%_ if (enableTranslation) { _%>
+            let entityKey: string | null = null;
+<%_ } _%>
+        for (const entry of arr) {
+          if (entry.toLowerCase().endsWith('app-error')) {
+            errorHeader = httpErrorResponse.headers[entry];
+<%_ if (enableTranslation) { _%>
+            } else if (entry.toLowerCase().endsWith('app-params')) {
+              entityKey = httpErrorResponse.headers[entry];
+<%_ } _%>
+            }
+        }
+        if (errorHeader) {
+<%_ if (enableTranslation) { _%>
+          const alertData = entityKey ? { entityName: instance.$t(`global.menu.entities.${entityKey}`) } : undefined;
+<%_ } _%>
+          this.showError(instance, errorHeader<% if (enableTranslation) { %>, alertData<% } %>);
+        } else if (httpErrorResponse.data !== '' && httpErrorResponse.data.fieldErrors) {  
+          this.showError(instance, <% if (enableTranslation) { %>httpErrorResponse.data.message<% } else { %>'Validation error'<% } %>);
+        } else {
+          this.showError(instance, httpErrorResponse.data.message);
+        }
+        break;
+      }
+
+      case 404:
+        this.showError(instance, <% if (enableTranslation) { %>'error.http.404'<% } else { %>'Not found'<% } %>);
+        break;
+
+      default:
+        this.showError(instance, httpErrorResponse.data.message);
+    }
+  }
+}

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
@@ -11,6 +11,7 @@ import UserManagementEdit from '@/admin/user-management/user-management-edit.vue
 import UserManagementEditClass from '@/admin/user-management/user-management-edit.component';
 import UserManagementService from '@/admin/user-management/user-management.service';
 import VueRouter from 'vue-router';
+import AlertService from '@/shared/alert/alert.service';
 
 const localVue = createLocalVue();
 localVue.use(VueRouter);
@@ -42,7 +43,8 @@ describe('UserManagementEdit Component', () => {
 <%_ } _%>
       localVue,
       provide: {
-        userService: () => new UserManagementService()
+        userService: () => new UserManagementService(),
+        alertService: () => new AlertService()
       }
     });
     userManagementEdit = wrapper.vm;

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
@@ -44,7 +44,7 @@ describe('UserManagementEdit Component', () => {
       localVue,
       provide: {
         userService: () => new UserManagementService(),
-        alertService: () => new AlertService()
+        alertService: () => new AlertService(),
       }
     });
     userManagementEdit = wrapper.vm;

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
@@ -11,6 +11,7 @@ import UserManagementView from '@/admin/user-management/user-management-view.vue
 import UserManagementViewClass from '@/admin/user-management/user-management-view.component';
 import UserManagementService from '@/admin/user-management/user-management.service';
 import {Authority} from '@/shared/security/authority';
+import AlertService from '@/shared/alert/alert.service';
 
 const localVue = createLocalVue();
 
@@ -32,7 +33,7 @@ describe('UserManagementView Component', () => {
   let userManagementView: UserManagementViewClass;
 
   beforeEach(() => {
-    wrapper = shallowMount<UserManagementViewClass>(UserManagementView, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, provide: { userService: () => new UserManagementService() } });
+    wrapper = shallowMount<UserManagementViewClass>(UserManagementView, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, provide: { userService: () => new UserManagementService(), alertService: () => new AlertService() } });
     userManagementView = wrapper.vm;
   });
 

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
@@ -33,7 +33,7 @@ describe('UserManagementView Component', () => {
   let userManagementView: UserManagementViewClass;
 
   beforeEach(() => {
-    wrapper = shallowMount<UserManagementViewClass>(UserManagementView, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, provide: { userService: () => new UserManagementService(), alertService: () => new AlertService() } });
+    wrapper = shallowMount<UserManagementViewClass>(UserManagementView, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, provide: { userService: () => new UserManagementService(), alertService: () => new AlertService(), } });
     userManagementView = wrapper.vm;
   });
 

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -10,6 +10,7 @@ import * as config from '@/shared/config/config';
 import UserManagement from '@/admin/user-management/user-management.vue';
 import UserManagementClass from '@/admin/user-management/user-management.component';
 import UserManagementService from '@/admin/user-management/user-management.service';
+import AlertService from '@/shared/alert/alert.service';
 
 const localVue = createLocalVue();
 
@@ -57,7 +58,8 @@ describe('UserManagement Component', () => {
         bModal: true
       },
       provide: {
-        userService: () => new UserManagementService()
+        userService: () => new UserManagementService(),
+        alertService: () => new AlertService()
       }
     });
     userManagement = wrapper.vm;

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -59,7 +59,7 @@ describe('UserManagement Component', () => {
       },
       provide: {
         userService: () => new UserManagementService(),
-        alertService: () => new AlertService()
+        alertService: () => new AlertService(),
       }
     });
     userManagement = wrapper.vm;

--- a/generators/client/templates/vue/src/test/javascript/spec/app/shared/alert/alert.service.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/shared/alert/alert.service.spec.ts.ejs
@@ -1,0 +1,124 @@
+import sinon from 'sinon';
+
+import AlertService from '@/shared/alert/alert.service';
+import Vue from 'vue';
+import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
+<%_ if (enableTranslation) { _%>
+const translationStub = sinon.stub();
+<%_ } _%> 
+const toastStub = sinon.stub();
+
+const vueInstance = {
+  <% if (enableTranslation) { %>$t: translationStub,<% } %>
+  $root: {
+    $bvToast: {
+      toast: toastStub,
+    },
+  },
+};
+
+describe('Alert Service test suite', () => {
+  let alertService: AlertService;
+
+  beforeEach(() => {
+    <%_ if (enableTranslation) { _%>
+    translationStub.reset();
+    <%_ } _%> 
+    toastStub.reset();
+    alertService = new AlertService();
+  });
+
+  it('should show error toast with translation/message', async () => {
+    const message = 'translatedMessage';
+    <%_ if (enableTranslation) { _%>
+    const translationKey = 'err.code';
+
+    // GIVEN
+    translationStub.withArgs(translationKey).returns(message);
+    <%_ } _%>
+    
+    // WHEN
+    alertService.showError((<any>vueInstance) as Vue, <% if (enableTranslation) { %>translationKey<%} else {%>message<% } %>);
+
+    //THEN
+    <%_ if (enableTranslation) { _%>
+    expect(translationStub.withArgs(translationKey).callCount).toEqual(1);
+    <%_ } _%>
+    expect(
+      toastStub.calledOnceWith(message, {
+        toaster: 'b-toaster-top-center',
+        title: 'Error',
+        variant: 'danger',
+        solid: true,
+        autoHideDelay: 5000,
+      })
+    ).toBeTruthy();
+  });
+
+  it('should show not reachable toast when http status = 0', async () => {
+    <%_ if (enableTranslation) { _%>
+    const translationKey = 'error.server.not.reachable';
+    <%_ } _%>
+    const message = 'Server not reachable';
+    const httpErrorResponse = {
+      status: 0,
+    };
+    <%_ if (enableTranslation) { _%>
+    // GIVEN
+    translationStub.withArgs(translationKey).returns(message);
+    <%_ } _%>
+
+    // WHEN
+    alertService.showHttpError((<any>vueInstance) as Vue, httpErrorResponse);
+
+    //THEN
+    <%_ if (enableTranslation) { _%>
+    expect(translationStub.withArgs(translationKey).callCount).toEqual(1);
+    <%_ } _%>
+    expect(
+      toastStub.calledOnceWith(message, {
+        toaster: 'b-toaster-top-center',
+        title: 'Error',
+        variant: 'danger',
+        solid: true,
+        autoHideDelay: 5000,
+      })
+    ).toBeTruthy();
+  });
+
+  it('should show parameterized error toast when http status = 400 and entity headers', async () => {
+    <%_ if (enableTranslation) { _%>
+    const translationKey = 'error.update';
+    <%_ } _%>
+    const message = 'Updation Error';
+    const httpErrorResponse = {
+      status: 400,
+      headers: {
+        'x-jhipsterapp-error': <% if (enableTranslation) { %>translationKey<% } else {%>message<% } %>,
+        'x-jhipsterapp-params': 'dummyEntity',
+      },
+    };
+    <%_ if (enableTranslation) { _%>
+    // GIVEN
+    translationStub.withArgs(translationKey).returns(message);
+    translationStub.withArgs('global.menu.entities.dummyEntity').returns('DummyEntity');
+    <%_ } _%>
+
+    // WHEN
+    alertService.showHttpError((<any>vueInstance) as Vue, httpErrorResponse);
+
+    //THEN
+    <%_ if (enableTranslation) { _%>
+    expect(translationStub.withArgs(translationKey, { entityName: 'DummyEntity' }).callCount).toEqual(1);
+    <%_ } _%>
+    expect(
+      toastStub.calledOnceWith(message, {
+        toaster: 'b-toaster-top-center',
+        title: 'Error',
+        variant: 'danger',
+        solid: true,
+        autoHideDelay: 5000,
+      })
+    ).toBeTruthy();
+  });
+});

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.component.ts.ejs
@@ -5,10 +5,13 @@ import JhiDataUtils from '@/shared/data/data-utils.service';
 <% } %>
 import { I<%= entityAngularName %> } from '@/shared/model/<%= entityModelFileName %>.model';
 import <%= entityAngularName %>Service from './<%= entityFileName %>.service';
+import AlertService from '@/shared/alert/alert.service';
 
 @Component
 export default class <%= entityAngularName %>Details extends <% if (fieldsContainBlob) { %>mixins(JhiDataUtils)<% } else { %>Vue<% } %> {
   @Inject('<%= entityInstance %>Service') private <%= entityInstance %>Service: () => <%= entityAngularName %>Service;
+  @Inject('alertService') private alertService: () => AlertService;
+
   public <%= entityInstance %>: I<%= entityAngularName %> = {};
 
   beforeRouteEnter(to, from, next) {
@@ -22,6 +25,8 @@ export default class <%= entityAngularName %>Details extends <% if (fieldsContai
   public retrieve<%= entityAngularName %>(<%= entityInstance %>Id) {
     this.<%= entityInstance %>Service().find(<%= entityInstance %>Id).then((res) => {
       this.<%= entityInstance %> = res;
+    }).catch(error => {
+      this.alertService().showHttpError(this,error.response);
     });
   }
 

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
@@ -51,6 +51,8 @@ import { DATE_TIME_LONG_FORMAT } from '@/shared/date/filters';
   <%_ } _%>
 <%_ } _%>
 
+import AlertService from '@/shared/alert/alert.service';
+
 <%_ const importEntitiesSeen = [entityAngularName];
   let hasManyToMany = false;
   for (relationship of relationships) { _%>
@@ -124,6 +126,8 @@ _%>
 })
 export default class <%= entityAngularName %>Update extends <% if (fieldsContainBlob) { %>mixins(JhiDataUtils)<% } else { %>Vue<% } %> {
   @Inject('<%= entityInstance %>Service') private <%= entityInstance %>Service: () => <%= entityAngularName %>Service;
+  @Inject('alertService') private alertService: () => AlertService;
+
   public <%= entityInstance %>: I<%= entityAngularName %> = new <%= entityAngularName %>();
   <%_
     const entitiesSeen = [entityAngularName];
@@ -199,7 +203,10 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
           variant: 'info',
           solid: true,
           autoHideDelay: 5000,
-        });
+        })
+      }).catch(error => {
+          this.isSaving = false;
+          this.alertService().showHttpError(this,error.response);
       });
     } else {
       this.<%= entityInstance %>Service().create(this.<%= entityInstance %>).then((param) => {
@@ -217,7 +224,10 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
           solid: true,
           autoHideDelay: 5000,
         });
-      });
+      }).catch(error => {
+          this.isSaving = false;
+          this.alertService().showHttpError(this,error.response);
+      });;
     }
   }
 
@@ -264,6 +274,8 @@ _%>
       res.<%= fieldName %> = new Date(res.<%= fieldName %>);
 <%_ } } _%>
       this.<%= entityInstance %> = res;
+    }).catch(error => {
+      this.alertService().showHttpError(this,error.response);
     });
   }
 

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.component.ts.ejs
@@ -7,12 +7,15 @@ import { I<%= entityAngularName %> } from '@/shared/model/<%= entityModelFileNam
 import JhiDataUtils from '@/shared/data/data-utils.service';
 <% } %>
 import <%= entityAngularName %>Service from './<%= entityFileName %>.service';
+import AlertService from '@/shared/alert/alert.service';
 
 @Component({
   mixins: [Vue2Filters.mixin]
 })
 export default class <%= entityAngularName %> extends <% if (fieldsContainBlob || paginationInfiniteScroll) { %>mixins(JhiDataUtils)<% } else { %>Vue<% } %> {
   @Inject('<%= entityInstance %>Service') private <%= entityInstance %>Service: () => <%= entityAngularName %>Service;
+  @Inject('alertService') private alertService: () => AlertService;
+
 <%_ if (searchEngine) { _%>
   public currentSearch = '';
 <%_ } _%>
@@ -114,6 +117,7 @@ export default class <%= entityAngularName %> extends <% if (fieldsContainBlob |
   <%_ } _%>
       }, err => {
         this.isFetching = false;
+        this.alertService().showHttpError(this,err.response);
       });
       return;
     }
@@ -146,6 +150,7 @@ export default class <%= entityAngularName %> extends <% if (fieldsContainBlob |
 <%_ } _%>
     }, err => {
       this.isFetching = false;
+      this.alertService().showHttpError(this,err.response);
     });
   }
 
@@ -182,6 +187,8 @@ export default class <%= entityAngularName %> extends <% if (fieldsContainBlob |
       this.retrieveAll<%= entityAngularName %>s();
   <%_ } _%>
       this.closeDialog();
+    }).catch(error => {
+      this.alertService().showHttpError(this,error.response);
     });
   }
 

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-details.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-details.component.spec.ts.ejs
@@ -29,6 +29,7 @@ import <%= entityAngularName %>DetailComponent from '@/entities/<%= entityFolder
 import <%= entityAngularName %>Class from '@/entities/<%= entityFolderName %>/<%= entityFileName %>-details.component';
 import <%= entityAngularName %>Service from '@/entities/<%= entityFolderName %>/<%= entityFileName %>.service';
 import router from '@/router';
+import AlertService from '@/shared/alert/alert.service';
 
 const localVue = createLocalVue();
 localVue.use(VueRouter);
@@ -51,7 +52,7 @@ describe('Component Tests', () => {
     beforeEach(() => {
       <%= entityInstance %>ServiceStub = sinon.createStubInstance<<%= entityAngularName %>Service>(<%= entityAngularName %>Service);
 
-      wrapper = shallowMount<<%= entityAngularName %>Class>(<%= entityAngularName %>DetailComponent, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, router, provide: { <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub } });
+      wrapper = shallowMount<<%= entityAngularName %>Class>(<%= entityAngularName %>DetailComponent, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, router, provide: { <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub, alertService: () => new AlertService() } });
       comp = wrapper.vm;
     });
 

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-details.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-details.component.spec.ts.ejs
@@ -52,7 +52,7 @@ describe('Component Tests', () => {
     beforeEach(() => {
       <%= entityInstance %>ServiceStub = sinon.createStubInstance<<%= entityAngularName %>Service>(<%= entityAngularName %>Service);
 
-      wrapper = shallowMount<<%= entityAngularName %>Class>(<%= entityAngularName %>DetailComponent, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, router, provide: { <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub, alertService: () => new AlertService() } });
+      wrapper = shallowMount<<%= entityAngularName %>Class>(<%= entityAngularName %>DetailComponent, { store, <% if (enableTranslation) { %>i18n, <% } %>localVue, router, provide: { <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub, alertService: () => new AlertService(), } });
       comp = wrapper.vm;
     });
 

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
@@ -91,7 +91,7 @@ describe('Component Tests', () => {
         router,
         provide: {
           <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub,
-          alertService: () => new AlertService() 
+          alertService: () => new AlertService(),
 <%_
   const entitiesSeen = [entityAngularName];
   for (relationship of relationships) { _%>

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
@@ -55,6 +55,7 @@ import <%= otherEntityAngularName %>Service from '@/entities/<%= otherEntityClie
     <%_ importEntitiesSeen.push(otherEntityAngularName); _%>
   <%_ } _%>
 <%_ } _%>
+import AlertService from '@/shared/alert/alert.service';
 
 const localVue = createLocalVue();
 
@@ -90,6 +91,7 @@ describe('Component Tests', () => {
         router,
         provide: {
           <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub,
+          alertService: () => new AlertService() 
 <%_
   const entitiesSeen = [entityAngularName];
   for (relationship of relationships) { _%>

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.component.spec.ts.ejs
@@ -27,6 +27,7 @@ import * as config from '@/shared/config/config';
 import <%= entityAngularName %>Component from '@/entities/<%= entityFolderName %>/<%= entityFileName %>.vue';
 import <%= entityAngularName %>Class from '@/entities/<%= entityFolderName %>/<%= entityFileName %>.component';
 import <%= entityAngularName %>Service from '@/entities/<%= entityFolderName %>/<%= entityFileName %>.service';
+import AlertService from '@/shared/alert/alert.service';
 
 const localVue = createLocalVue();
 
@@ -70,7 +71,8 @@ describe('Component Tests', () => {
         localVue,
         stubs: {<%_ if (!paginationNo) { _%>jhiItemCount:true, bPagination:true,<%_ } _%> bModal: bModalStub as any},
         provide: {
-          <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub
+          <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub,
+          alertService: () => new AlertService() 
         }
       });
       comp = wrapper.vm;

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.component.spec.ts.ejs
@@ -72,7 +72,7 @@ describe('Component Tests', () => {
         stubs: {<%_ if (!paginationNo) { _%>jhiItemCount:true, bPagination:true,<%_ } _%> bModal: bModalStub as any},
         provide: {
           <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub,
-          alertService: () => new AlertService() 
+          alertService: () => new AlertService(),
         }
       });
       comp = wrapper.vm;


### PR DESCRIPTION
Add error handling for multiple scenarios in Vue with a toast.

Approach:- The errors are being shown in the toast through a service instead of interceptor to allow users more choice over generated code to pick and choose errors they wish to show/handle.

Fix #16393

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
