### PR TITLE
Add lock-maintenance workflow. [skip ci]

### DIFF
--- a/.github/workflows/lock-maintenance.yml
+++ b/.github/workflows/lock-maintenance.yml
@@ -1,0 +1,37 @@
+name: Package lock maintenance
+on:
+  schedule:
+    - cron: 0 0 * * 6
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Bump transitional dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2.4.0
+        with:
+          node-version: '14'
+      - run: npm install -g npm@latest
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Create commit
+        run: |
+          rm package-lock.json
+          npm install
+          git add .
+          ./test-integration/scripts/04-git-config.sh
+          git commit -a -m "Bump transitional dependencies" || true
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3.8.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Bump transitional dependencies'
+          title: 'Bump transitional dependencies'
+          body: Weekly transitional dependencies bump.
+          labels: 'theme: dependencies'


### PR DESCRIPTION
Weekly bump transitional dependencies.

Package lock needs to be updated in order to keep transitional dependencies updated.
`npm install generator-jhipster` always installs latest transitional dependencies, we should not lag behind.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
