### PR TITLE
Fix triage and cleanup labeler actions

### DIFF
--- a/.github/workflows/label-cleanup.yml
+++ b/.github/workflows/label-cleanup.yml
@@ -29,11 +29,11 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const issue = { owner: context.issue.owner, repo: context.issue.repo, issue_number: context.issue.number }
-            github.issues.listLabelsOnIssue({...issue}).then(response => {
+            github.rest.issues.listLabelsOnIssue({...issue}).then(response => {
               const labels = response.data
               for (const label of labels) {
                   if (label.name == 'area: needs-reproduction' || label.name == 'area: waiting for information' || label.name.includes('status: ')) {
-                      github.issues.removeLabel({...issue, name: label.name})
+                      github.rest.issues.removeLabel({...issue, name: label.name})
                   }
               }
             })

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,7 +29,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const issue = { owner: context.issue.owner, repo: context.issue.repo, issue_number: context.issue.number }
-            github.issues.listLabelsOnIssue({...issue}).then(response => {
+            github.rest.issues.listLabelsOnIssue({...issue}).then(response => {
               const labels = response.data
               let missingLabel = [], missingArea = true, missingTheme = true
               for (const label of labels) {
@@ -47,6 +47,6 @@ jobs:
                 missingLabel.push('theme: undefined')
               }
               if (missingArea || missingTheme) {
-                  github.issues.addLabels({...issue, labels: missingLabel})
+                  github.rest.issues.addLabels({...issue, labels: missingLabel})
               }
             })


### PR DESCRIPTION
Label cleanup and triage actions are failing after an upgrade (https://github.com/jhipster/generator-jhipster/commit/a0ffa3017c5b21b78f4794a67afc9011554a9c62)
After upgrade to github-actions v5, the api for issues has changed to
`github.rest.issues` instead of `github.issues` https://github.com/actions/github-script#breaking-changes-in-v5

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
