### PR TITLE
Remove WebFluxAutoConfiguration for Spring Native compatibility

### DIFF
--- a/generators/server/templates/src/main/java/package/config/LocaleConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/LocaleConfiguration.java.ejs
@@ -47,7 +47,6 @@ public class LocaleConfiguration implements WebMvcConfigurer {
 <%_ } else { _%>
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -70,7 +69,6 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 @Configuration
-@Import(WebFluxAutoConfiguration.class)
 public class LocaleConfiguration {
 
     @Bean(name = "localeContextResolver")


### PR DESCRIPTION
Importing WebFluxAutoConfiguration doesn't seem necessary and it causes issues with Spring Native.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.