### PR TITLE
Add relationships and reactive support to custom entity packages.

### DIFF
--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -56,7 +56,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-matrix
   applications:
-    name: ${{ matrix.app-sample }}
+    name: ${{ matrix.suite }}
     runs-on: ${{ matrix.os }}
     needs: build-matrix
     defaults:
@@ -80,59 +80,70 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         cache: [angular]
-        app-sample:
+        suite:
           - webflux-mongodb
           - webflux-mongodb-es-session
           - webflux-mongodb-oauth2
           - webflux-gateway-jwt
           - webflux-gateway-oauth2
           - webflux-psql
+          - webflux-psql-additional
           - webflux-mariadb-gradle
           - webflux-couchbase
         include:
-          - app-sample: webflux-mongodb
+          - suite: webflux-mongodb
+            app-sample: webflux-mongodb
             entity: mongodb
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-sample: webflux-mongodb-es-session
+          - suite: webflux-mongodb-es-session
+            app-sample: webflux-mongodb-es-session
             entity: mongodb
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-sample: webflux-mongodb-oauth2
+          - suite: webflux-mongodb-oauth2
+            app-sample: webflux-mongodb-oauth2
             entity: mongodb
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-sample: webflux-gateway-jwt
+          - suite: webflux-gateway-jwt
+            app-sample: webflux-gateway-jwt
             entity: none
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-sample: webflux-gateway-oauth2
+          - suite: webflux-gateway-oauth2
+            app-sample: webflux-gateway-oauth2
             entity: none
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-sample: webflux-psql
+          - suite: webflux-psql
+            app-sample: webflux-psql
             entity: sql
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-sample: webflux-mariadb-gradle
+          - suite: webflux-psql-additional
+            jdl-sample: webflux-psql,custom-domain
+          - suite: webflux-mariadb-gradle
+            app-sample: webflux-mariadb-gradle
             entity: sqllight
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-sample: webflux-couchbase
+          - suite: webflux-couchbase
+            app-sample: webflux-couchbase
             entity: couchbase
             environment: prod
             war: 0
@@ -151,11 +162,12 @@ jobs:
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
-          entities-sample: ${{ matrix.entity }}
-          application-sample: ${{ matrix.app-sample }}
-          application-environment: ${{ matrix.environment }}
+          entities-sample: ${{ matrix.entity || 'none' }}
+          jdl-sample: ${{ matrix.jdl-sample || '' }}
+          application-sample: ${{ matrix.app-sample || 'jdl' }}
+          application-environment: ${{ matrix.environment || 'prod' }}
           application-packaging: ${{ (matrix.war == 1 && 'war') || 'jar' }}
-          enable-testcontainers: ${{ matrix.testcontainers == 1 }}
+          enable-testcontainers: ${{ matrix.testcontainers != 0 }}
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}

--- a/generators/bootstrap/index.js
+++ b/generators/bootstrap/index.js
@@ -237,6 +237,7 @@ module.exports = class extends BaseGenerator {
       relationships: [],
       changelogDate,
       fields: userEntityDefinition ? userEntityDefinition.fields || [] : [],
+      dto: true,
     };
 
     loadRequiredConfigIntoEntity(user, this.jhipsterConfig);

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -201,6 +201,10 @@ const serverFiles = {
           renameTo: generator => `${generator.entityAbsoluteFolder}/repository/${generator.entityClass}RepositoryInternalImpl.java`,
         },
         {
+          file: 'package/repository/EntitySqlHelper_reactive.java',
+          renameTo: generator => `${generator.entityAbsoluteFolder}/repository/${generator.entityClass}SqlHelper.java`,
+        },
+        {
           file: 'package/repository/rowmapper/EntityRowMapper.java',
           renameTo: generator => `${generator.entityAbsoluteFolder}/repository/rowmapper/${generator.entityClass}RowMapper.java`,
         },

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -157,6 +157,7 @@ module.exports = class extends BaseBlueprintGenerator {
       },
 
       processUniqueEntityTypes() {
+        this.reactiveOtherEntities = new Set(this.reactiveEagerRelations.map(rel => rel.otherEntity));
         this.reactiveUniqueEntityTypes = new Set(this.reactiveEagerRelations.map(rel => rel.otherEntityNameCapitalized));
         this.reactiveUniqueEntityTypes.add(this.entityClass);
       },

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.jhi.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.jhi.ejs
@@ -80,6 +80,10 @@ Object.keys(uniqueEnums).forEach(function(element) { _%>
 import <%= entityAbsolutePackage %>.domain.enumeration.<%= element %>;
 <%_ }); _%>
 
+<%_ for (const otherEntity of otherEntities.filter(otherEntity => otherEntity.entityPackage !== entityPackage)) { _%>
+import <%= otherEntity.entityAbsoluteClass %>;
+<%_ } _%>
+
 <%_ if (typeof javadoc === 'undefined') { _%>
 /**
  * A <%= persistClass %>.

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepositoryInternalImpl_reactive.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepositoryInternalImpl_reactive.java.ejs
@@ -59,7 +59,7 @@ import org.springframework.r2dbc.core.RowsFetchSpec;
 import <%= entityAbsolutePackage %>.domain.<%= persistClass %>;
 <% relationships.forEach(function(rel) {
   if (rel.relationshipManyToMany && rel.ownerSide) { _%>
-import <%= entityAbsolutePackage %>.domain.<%= asEntity(rel.otherEntityNameCapitalized) %>;
+import <%= rel.otherEntity.entityAbsolutePackage %>.domain.<%= rel.otherEntity.persistClass %>;
   <%_ } _%>
 <%_ }); _%>
 <%_ Object.keys(uniqueEnums).forEach(function(element) { _%>
@@ -67,12 +67,15 @@ import <%= entityAbsolutePackage %>.domain.<%= asEntity(rel.otherEntityNameCapit
 import <%= entityAbsolutePackage %>.domain.enumeration.<%= element %>;
 <%_ }); _%>
 
-<%_ reactiveUniqueEntityTypes.forEach(function(element) { _%>
-import <%= entityAbsolutePackage %>.repository.rowmapper.<%= element %>RowMapper;
+<%_ [...reactiveOtherEntities, entity].forEach(otherEntity => { _%>
+import <%= otherEntity.entityAbsolutePackage %>.repository.rowmapper.<%= otherEntity.entityClass %>RowMapper;
+  <%_ if (otherEntity.entityPackage !== entityPackage) { _%>
+import <%= otherEntity.entityAbsolutePackage %>.repository.<%= otherEntity.entityClass %>SqlHelper;
+  <%_ } _%>
 <%_ }); _%>
-import <%= entityAbsolutePackage %>.service.EntityManager;
+import <%= packageName %>.service.EntityManager;
 <%_ if (fieldsContainOwnerManyToMany) { _%>
-import <%= entityAbsolutePackage %>.service.EntityManager.LinkTable;
+import <%= packageName %>.service.EntityManager.LinkTable;
 <%_ } _%>
 
 import reactor.core.publisher.Flux;
@@ -246,24 +249,4 @@ _%>
     }
 
 <%_ } _%>
-}
-
-class <%= entityClass %>SqlHelper {
-    static List<Expression> getColumns(Table table, String columnPrefix) {
-        List<Expression> columns = new ArrayList<>();
-<%_ fields.forEach(function(field) {
-    let col = field.fieldNameAsDatabaseColumn;
-    _%>
-        columns.add(Column.aliased("<%= col %>", table, columnPrefix + "_<%= col %>"));
-   <%_  if ((field.fieldTypeBinary) && !field.blobContentTypeText) { _%>
-        columns.add(Column.aliased("<%= col %>_content_type", table, columnPrefix + "_<%= col %>_content_type"));
-   <%_  } _%>
-<%_ }); _%>
-
-<%_ reactiveRegularEagerRelations.forEach(function(rel) { _%>
-        columns.add(Column.aliased("<%= getColumnName(rel.relationshipName) %>_id", table, columnPrefix + "_<%= getColumnName(rel.relationshipName) %>_id"));
-<%_ }); _%>
-        return columns;
-    }
-
 }

--- a/generators/entity-server/templates/src/main/java/package/repository/EntitySqlHelper_reactive.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntitySqlHelper_reactive.java.ejs
@@ -1,0 +1,46 @@
+<%#
+ Copyright 2013-2021 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= entityAbsolutePackage %>.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.Expression;
+import org.springframework.data.relational.core.sql.Table;
+
+public class <%= entityClass %>SqlHelper {
+
+    public static List<Expression> getColumns(Table table, String columnPrefix) {
+        List<Expression> columns = new ArrayList<>();
+<%_ fields.forEach(function(field) {
+    let col = field.fieldNameAsDatabaseColumn;
+    _%>
+        columns.add(Column.aliased("<%= col %>", table, columnPrefix + "_<%= col %>"));
+   <%_  if ((field.fieldTypeBinary) && !field.blobContentTypeText) { _%>
+        columns.add(Column.aliased("<%= col %>_content_type", table, columnPrefix + "_<%= col %>_content_type"));
+   <%_  } _%>
+<%_ }); _%>
+
+<%_ reactiveRegularEagerRelations.forEach(function(rel) { _%>
+        columns.add(Column.aliased("<%= getColumnName(rel.relationshipName) %>_id", table, columnPrefix + "_<%= getColumnName(rel.relationshipName) %>_id"));
+<%_ }); _%>
+        return columns;
+    }
+}

--- a/generators/entity-server/templates/src/main/java/package/repository/rowmapper/EntityRowMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/rowmapper/EntityRowMapper.java.ejs
@@ -39,7 +39,7 @@ import <%= entityAbsolutePackage %>.domain.<%= persistClass %>;
 <%_ Object.keys(uniqueEnums).forEach(function(element) { _%>
 import <%= entityAbsolutePackage %>.domain.enumeration.<%= element %>;
 <%_ }); _%>
-import <%= entityAbsolutePackage %>.service.ColumnConverter;
+import <%= packageName %>.service.ColumnConverter;
 
 import io.r2dbc.spi.Row;
 

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -60,6 +60,10 @@ import javax.persistence.Lob;
 import <%= entityAbsolutePackage %>.domain.enumeration.<%= element %>;
 <%_ }); _%>
 
+<%_ for (const otherEntity of otherEntities.filter(otherEntity => otherEntity.entityPackage !== entityPackage)) { _%>
+import <%= `${otherEntity.entityAbsolutePackage}.service.dto.${otherEntity.dtoClass}` %>;
+<%_ } _%>
+
 /**
  * A DTO for the {@link <%= entityAbsolutePackage %>.domain.<%= persistClass %>} entity.
  */

--- a/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -38,8 +38,12 @@ _%>
 import java.util.Set;
 <%_ } _%>
 
-import <%= entityAbsolutePackage %>.domain.*;
+import <%= entityAbsoluteClass %>;
 import <%= entityAbsolutePackage %>.service.dto.<%= dtoClass %>;
+
+<%_ for (const otherEntity of _.uniq(dtoReferences.filter(ref => ref.relationship).map(ref => ref.relationship.otherEntity).filter(otherEntity => otherEntity.entityPackage !== entityPackage))) { _%>
+import <%= `${otherEntity.entityAbsolutePackage}.service.mapper.${otherEntity.entityClass}Mapper` %>;
+<%_ } _%>
 
 import org.mapstruct.*;
 <%_ if (uuidMapMethod) { _%>

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -84,7 +84,7 @@ import <%= entityAbsolutePackage %>.repository.UserRepository;
 <%_ } _%>
 import <%= entityAbsolutePackage %>.repository.<%= entityClass %>Repository;
 <%_ if (databaseTypeSql && reactive) { _%>
-import <%= entityAbsolutePackage %>.service.EntityManager;
+import <%= packageName %>.service.EntityManager;
 <%_ } _%>
 <%_ if (isUsingMapsId && (!dtoMapstruct && serviceNo)) { _%>
 import <%= entityAbsolutePackage %>.repository.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -752,6 +752,10 @@ class EntityGenerator extends BaseBlueprintGenerator {
         this.context.user = this.configOptions.sharedEntities.User;
       },
 
+      loadOtherEntities() {
+        this.context.otherEntities = _.uniq(this.context.relationships.map(rel => rel.otherEntity));
+      },
+
       processOtherReferences() {
         this.context.otherReferences = this.context.otherRelationships.map(relationship => relationship.reference);
         this.context.allReferences

--- a/generators/server/files-sql.js
+++ b/generators/server/files-sql.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2013-2021 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const { SERVER_MAIN_SRC_DIR } = require('../generator-constants');
+
+const sqlFiles = {
+  reactiveJavaUserManagement: [
+    {
+      condition: generator => generator.reactive && (!generator.skipUserManagement || generator.authenticationTypeOauth2),
+      path: SERVER_MAIN_SRC_DIR,
+      templates: [
+        {
+          file: 'package/repository/UserSqlHelper.java',
+          renameTo: generator => `${generator.javaDir}repository/UserSqlHelper.java`,
+        },
+      ],
+    },
+  ],
+};
+
+function writeSqlFiles() {
+  return {
+    async writeSqlFiles() {
+      if (!this.databaseTypeSql) return;
+
+      await this.writeFiles({
+        sections: sqlFiles,
+        rootTemplatesPath: ['sql/reactive', 'sql'],
+      });
+    },
+  };
+}
+
+module.exports = {
+  sqlFiles,
+  writeSqlFiles,
+};

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -30,6 +30,7 @@ const { KAFKA } = require('../../jdl/jhipster/message-broker-types');
 const { CONSUL, EUREKA } = require('../../jdl/jhipster/service-discovery-types');
 const { addSectionsCondition, mergeSections } = require('../utils');
 const { writeCouchbaseFiles } = require('./files-couchbase');
+const { writeSqlFiles } = require('./files-sql');
 
 /* Constants use throughout */
 const NO_DATABASE = databaseTypes.NO;
@@ -1736,6 +1737,8 @@ function writeFiles() {
     },
 
     ...writeCouchbaseFiles(),
+
+    ...writeSqlFiles(),
   };
 }
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -366,9 +366,17 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
       ...super._missingPreDefault(),
 
       loadUserManagementEntities() {
+        // TODO v8 move to preparingEntities priority.
         if (!this.configOptions.sharedEntities) return;
         // Make user entity available to templates.
-        this.user = this.configOptions.sharedEntities.User;
+        const user = (this.user = this.configOptions.sharedEntities.User);
+        if (!user) return;
+
+        const { packageName, packageFolder } = this;
+        const { persistClass } = user;
+        user.entityAbsolutePackage = packageName;
+        user.entityAbsoluteFolder = packageFolder;
+        user.entityAbsoluteClass = `${packageName}.domain.${persistClass}`;
       },
 
       loadDomains() {

--- a/generators/server/templates/sql/reactive/src/main/java/package/repository/UserSqlHelper.java.ejs
+++ b/generators/server/templates/sql/reactive/src/main/java/package/repository/UserSqlHelper.java.ejs
@@ -1,0 +1,48 @@
+<%#
+ Copyright 2013-2021 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.Expression;
+import org.springframework.data.relational.core.sql.Table;
+
+public class UserSqlHelper {
+    public static List<Expression> getColumns(Table table, String columnPrefix) {
+        List<Expression> columns = new ArrayList<>();
+        columns.add(Column.aliased("id", table, columnPrefix + "_id"));
+        columns.add(Column.aliased("login", table, columnPrefix + "_login"));
+  <%_ if (!authenticationTypeOauth2) { _%>
+        columns.add(Column.aliased("password_hash", table, columnPrefix + "_password"));
+  <%_ } _%>
+        columns.add(Column.aliased("first_name", table, columnPrefix + "_first_name"));
+        columns.add(Column.aliased("last_name", table, columnPrefix + "_last_name"));
+        columns.add(Column.aliased("email", table, columnPrefix + "_email"));
+        columns.add(Column.aliased("activated", table, columnPrefix + "_activated"));
+        columns.add(Column.aliased("lang_key", table, columnPrefix + "_lang_key"));
+        columns.add(Column.aliased("image_url", table, columnPrefix + "_image_url"));
+  <%_ if (!authenticationTypeOauth2) { _%>
+        columns.add(Column.aliased("activation_key", table, columnPrefix + "_activation_key"));
+        columns.add(Column.aliased("reset_key", table, columnPrefix + "_reset_key"));
+        columns.add(Column.aliased("reset_date", table, columnPrefix + "_reset_date"));
+  <%_ } _%>
+        return columns;
+    }
+}

--- a/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
@@ -464,29 +464,6 @@ class UserRepositoryInternalImpl implements UserRepositoryInternal {
     }
 }
 
-class UserSqlHelper {
-    static List<Expression> getColumns(Table table, String columnPrefix) {
-        List<Expression> columns = new ArrayList<>();
-        columns.add(Column.aliased("id", table, columnPrefix + "_id"));
-        columns.add(Column.aliased("login", table, columnPrefix + "_login"));
-  <%_ if (!authenticationTypeOauth2) { _%>
-        columns.add(Column.aliased("password_hash", table, columnPrefix + "_password"));
-  <%_ } _%>
-        columns.add(Column.aliased("first_name", table, columnPrefix + "_first_name"));
-        columns.add(Column.aliased("last_name", table, columnPrefix + "_last_name"));
-        columns.add(Column.aliased("email", table, columnPrefix + "_email"));
-        columns.add(Column.aliased("activated", table, columnPrefix + "_activated"));
-        columns.add(Column.aliased("lang_key", table, columnPrefix + "_lang_key"));
-        columns.add(Column.aliased("image_url", table, columnPrefix + "_image_url"));
-  <%_ if (!authenticationTypeOauth2) { _%>
-        columns.add(Column.aliased("activation_key", table, columnPrefix + "_activation_key"));
-        columns.add(Column.aliased("reset_key", table, columnPrefix + "_reset_key"));
-        columns.add(Column.aliased("reset_date", table, columnPrefix + "_reset_date"));
-  <%_ } _%>
-        return columns;
-    }
-}
-
 <%_ } else if (databaseTypeCassandra) { _%>
 @Repository
 public class UserRepository {

--- a/test-integration/jdl-samples/webflux-psql/webflux-psql.jdl
+++ b/test-integration/jdl-samples/webflux-psql/webflux-psql.jdl
@@ -1,0 +1,8 @@
+application {
+  config {
+    reactive true
+    testFrameworks [cypress]
+    creationTimestamp 1617901618886
+  }
+  entities *
+}

--- a/test-integration/samples/jdl-entities/custom-domain.jdl
+++ b/test-integration/samples/jdl-entities/custom-domain.jdl
@@ -1,13 +1,21 @@
 @ChangelogDate(20200804035400)
 @EntityPackage(custom)
-entity CustomPackageParent
+entity CustomPackageParent {
+  parentName String
+}
 
 @ChangelogDate(20200804035401)
-@EntityPackage(custom)
-entity CustomPackageChild
+@EntityPackage(child)
+entity CustomPackageChild {
+  childName String
+}
 
 relationship OneToMany {
   CustomPackageParent to CustomPackageChild
+}
+
+relationship ManyToOne {
+  CustomPackageChild to User
 }
 
 dto CustomPackageParent, CustomPackageChild with mapstruct

--- a/test-integration/scripts/12-generate-project.sh
+++ b/test-integration/scripts/12-generate-project.sh
@@ -16,7 +16,11 @@ if [[ "$JHI_ENTITY" == "jdl" ]]; then
     # Generate with JDL
     #-------------------------------------------------------------------------------
     mkdir -p "$JHI_FOLDER_APP"
-    cp -f "$JHI_SAMPLES"/"$JHI_APP"/*.jdl "$JHI_FOLDER_APP"/
+    IFS=','
+    for i in `echo "$JHI_APP"`
+    do
+        cp -f "$JHI_SAMPLES"/"$i"/*.jdl "$JHI_FOLDER_APP"/
+    done
     cd "$JHI_FOLDER_APP"
     ls -la "$JHI_FOLDER_APP"/
     eval "$JHI_CLI import-jdl *.jdl --no-insight $@"
@@ -27,15 +31,25 @@ elif [[ "$JHI_APP" == "jdl" ]]; then
     #-------------------------------------------------------------------------------
     mkdir -p "$JHI_FOLDER_APP"
 
-    if [[ -f "$JHI_JDL_APP" ]]; then
-        cp -f "$JHI_JDL_APP" "$JHI_FOLDER_APP"/
+    IFS=','
+    for i in `echo "$JHI_JDL_APP"`
+    do
+        if [[ -f "$i" ]]; then
+            cp -f "$i" "$JHI_FOLDER_APP"/
 
-    elif [[ -d "$JHI_JDL_APP" ]]; then
-        cp -f "$JHI_JDL_APP"/*.jdl "$JHI_FOLDER_APP"/
+        elif [[ -d "$i" ]]; then
+            cp -f "$i"/*.jdl "$JHI_FOLDER_APP"/
 
-    else
-        cp -f "$JHI_JDL_SAMPLES"/"$JHI_JDL_APP"/*.jdl "$JHI_FOLDER_APP"/
-    fi
+        elif [[ -d "$JHI_SAMPLES/jdl-entities/$i" ]]; then
+            cp -f "$JHI_SAMPLES/jdl-entities/$i/*.jdl" "$JHI_FOLDER_APP"/
+
+        elif [[ -f "$JHI_SAMPLES/jdl-entities/$i.jdl" ]]; then
+            cp -f "$JHI_SAMPLES/jdl-entities/$i.jdl" "$JHI_FOLDER_APP"/
+
+        else
+            cp -f "$JHI_JDL_SAMPLES"/"$i"/*.jdl "$JHI_FOLDER_APP"/
+        fi
+    done
 
     ls -la "$JHI_FOLDER_APP"/
 

--- a/utils/entity.js
+++ b/utils/entity.js
@@ -31,7 +31,7 @@ const { OAUTH2 } = require('../jdl/jhipster/authentication-types');
 const { CommonDBTypes } = require('../jdl/jhipster/field-types');
 
 const { BOOLEAN, LONG, STRING, UUID } = CommonDBTypes;
-const { MAPSTRUCT } = MapperTypes;
+const { NO: NO_DTO, MAPSTRUCT } = MapperTypes;
 const { PAGINATION, INFINITE_SCROLL } = PaginationTypes;
 const { SERVICE_IMPL } = ServiceTypes;
 const NO_SERVICE = ServiceTypes.NO;
@@ -40,6 +40,7 @@ const NO_MAPPER = MapperTypes.NO;
 
 const BASE_TEMPLATE_DATA = {
   primaryKey: undefined,
+  entityPackage: undefined,
   skipUiGrouping: false,
   haveFieldWithJavadoc: false,
   existingEnum: false,
@@ -136,7 +137,7 @@ function prepareEntityForTemplates(entityWithConfig, generator) {
     entityNamePlural: pluralize(entityName),
   });
 
-  const dto = entityWithConfig.dto === MAPSTRUCT;
+  const dto = entityWithConfig.dto && entityWithConfig.dto !== NO_DTO;
   if (dto) {
     _.defaults(entityWithConfig, {
       dtoClass: generator.asDto(entityWithConfig.entityClass),


### PR DESCRIPTION
Followup to https://github.com/jhipster/generator-jhipster/pull/16041.
- Change webflux workflow to allow a sample to use more than one JDL files.
Having JDLs instead of .yo-rc.json and .jhipster/* entities is cleaner and easier to maintain.
- Split EntitySqlHelper class to a file, so it can be imported by another package.
- Create separated files-sql.json for modularity.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
