### PR TITLE
use jdk11 as default heroku jdk

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -192,7 +192,7 @@ module.exports = class extends BaseBlueprintGenerator {
             name: 'herokuJavaVersion',
             message: 'Which Java version would you like to use to build and run your app ?',
             choices: constants.JAVA_COMPATIBLE_VERSIONS.map(version => ({ value: version })),
-            default: 1,
+            default: constants.JAVA_VERSION,
           },
         ];
 


### PR DESCRIPTION
Following https://github.com/jhipster/generator-jhipster/pull/16624 correct the default jdk choice.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
