### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -25,20 +25,20 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+      - "dependabot/**"
+      - "skip_ci*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/react/**'
-      - 'generators/*client/templates/vue/**'
+      - "package*.json"
+      - "generators/*client/templates/react/**"
+      - "generators/*client/templates/vue/**"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/react/**'
-      - 'generators/*client/templates/vue/**'
+      - "package*.json"
+      - "generators/*client/templates/react/**"
+      - "generators/*client/templates/vue/**"
 jobs:
   build-matrix:
     runs-on: ubuntu-20.04
@@ -48,11 +48,11 @@ jobs:
       server: ${{ steps.build.outputs.server }}
       any: ${{ steps.build.outputs.any }}
     steps:
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 2
-      - name: 'Build matrix'
+      - name: "Build matrix"
         id: build
         uses: ./.github/actions/build-matrix
   applications:
@@ -63,17 +63,7 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}/app
     if: >-
-      !contains(github.event.head_commit.message, '[react]') &&
-      !contains(github.event.head_commit.message, '[vue]') &&
-      !contains(github.event.pull_request.title, '[react]') &&
-      !contains(github.event.pull_request.title, '[vue]') &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[ci skip]') &&
-      github.event.action != 'closed' &&
-      !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') &&
-      needs.build-matrix.outputs.any != 'false'
+      !contains(github.event.head_commit.message, '[react]') && !contains(github.event.head_commit.message, '[vue]') && !contains(github.event.pull_request.title, '[react]') && !contains(github.event.pull_request.title, '[vue]') && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && github.event.action != 'closed' && !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') && needs.build-matrix.outputs.any != 'false'
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -104,7 +94,7 @@ jobs:
           - app-sample: ngx-default-additional
             entity: none
             jhi-app-sample: ngx-default
-            jdl-entity: '*'
+            jdl-entity: "*"
             environment: prod
             war: 0
             e2e: 1
@@ -180,12 +170,12 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -198,11 +188,12 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
+          cache: npm
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -213,7 +204,7 @@ jobs:
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-${{ matrix.cache }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -221,7 +212,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         if: contains(matrix.app-sample, 'gradle')
         uses: actions/cache@v2.1.6
         with:
@@ -232,32 +223,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
-      - name: 'TOOLS: configure tools installed by the system'
+      - name: "TOOLS: configure tools installed by the system"
         run: $JHI_SCRIPTS/03-system.sh
-      - name: 'TOOLS: configure git'
+      - name: "TOOLS: configure git"
         run: $JHI_SCRIPTS/04-git-config.sh
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
+      - name: "GENERATION: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
-      - name: 'GENERATION: config'
+      - name: "GENERATION: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
-      - name: 'GENERATION: project'
+      - name: "GENERATION: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies ${{ matrix.extra-args }} ${{ matrix.new-extra-args }}
-      - name: 'GENERATION: jhipster info'
+      - name: "GENERATION: jhipster info"
         run: $JHI_SCRIPTS/14-jhipster-info.sh
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
-      - name: 'MERGE: generate base'
+      - name: "MERGE: generate base"
         continue-on-error: true
         id: base-app
         if: github.event.pull_request
         uses: ./generator-jhipster/.github/actions/compare-base
         with:
-          extra-args: '--skip-jhipster-dependencies ${{ matrix.extra-args }}'
-      - name: 'MERGE: compare changes'
+          extra-args: "--skip-jhipster-dependencies ${{ matrix.extra-args }}"
+      - name: "MERGE: compare changes"
         continue-on-error: true
         id: compare
         if: steps.base-app.outcome == 'success'
@@ -267,42 +258,42 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+      - name: "TESTS: Start docker-compose containers for e2e and backend tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers == 0
         run: npm run ci:e2e:prepare
-      - name: 'TESTS: backend'
+      - name: "TESTS: backend"
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 1 && needs.build-matrix.outputs.server != 'false'
         run: npm run ci:backend:test
-      - name: 'TESTS: frontend'
+      - name: "TESTS: frontend"
         if: steps.compare.outputs.equals != 'true' && needs.build-matrix.outputs.client != 'false'
         run: npm run ci:frontend:test
-      - name: 'TESTS: packaging'
+      - name: "TESTS: packaging"
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:package
-      - name: 'TESTS: Start docker-compose containers for e2e tests'
+      - name: "TESTS: Start docker-compose containers for e2e tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers != 0
         run: npm run ci:e2e:prepare
-      - name: 'E2E: Run'
+      - name: "E2E: Run"
         id: e2e
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:run --if-present
-      - name: 'E2E: Teardown'
+      - name: "E2E: Teardown"
         if: always() && matrix.e2e == 1 && steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:teardown
-      - name: 'BACKEND: Store failure logs'
+      - name: "BACKEND: Store failure logs"
         uses: actions/upload-artifact@v2
         if: always() && steps.backend.outcome == 'failure'
         with:
           name: log-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: "E2E: Store failure screenshots"
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
           name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
+      - name: "ANALYSIS: Sonar analysis"
         if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 0
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -22,11 +22,11 @@ on:
   workflow_dispatch:
     inputs:
       key:
-        description: 'Cache key'
+        description: "Cache key"
         required: false
-        default: '-new'
+        default: "-new"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 jobs:
   npm_cache:
     name: Create cache
@@ -35,11 +35,11 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}/app
     steps:
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2
         with:
           path: generator-jhipster
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -48,7 +48,8 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
-      - name: 'SETUP: load npm cache'
+          cache: npm
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -57,14 +58,14 @@ jobs:
           key: ${{ runner.os }}-node-${{ steps.setup.outputs.date }}${{ github.event.inputs.key }}
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}${{ github.event.inputs.key }}
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -75,7 +76,7 @@ jobs:
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
 
       # generator-jhipster npm
-      - name: 'Install generator-jhipster npm version'
+      - name: "Install generator-jhipster npm version"
         run: npm install -g npm@${{ steps.setup.outputs.npm-version }}
       - name: Cache generator-jhipster node_modules
         run: npm ci
@@ -109,34 +110,34 @@ jobs:
         continue-on-error: true
         working-directory: ${{ github.workspace }}/generator-jhipster/generators/client/templates/vue
 
-      - name: 'mvn: install JHipster'
+      - name: "mvn: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
         continue-on-error: true
 
       # maven
-      - name: 'mvn: config'
+      - name: "mvn: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
         continue-on-error: true
-      - name: 'mvn: project'
+      - name: "mvn: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies --skip-install --workspaces
         continue-on-error: true
-      - name: 'mvn: install workspaces deps'
+      - name: "mvn: install workspaces deps"
         run: npm install --force
         continue-on-error: true
-      - name: 'mvn: build cache'
+      - name: "mvn: build cache"
         run: npm run backend:build-cache || true
         continue-on-error: true
 
       # gradle
-      - name: 'gradle: config'
+      - name: "gradle: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
         continue-on-error: true
-      - name: 'gradle: project'
+      - name: "gradle: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies --skip-install --workspaces
         continue-on-error: true
-      - name: 'gradle: install workspaces deps'
+      - name: "gradle: install workspaces deps"
         run: npm install --force
         continue-on-error: true
-      - name: 'gradle: build cache'
+      - name: "gradle: build cache"
         run: npm run backend:build-cache || true
         continue-on-error: true

--- a/.github/workflows/devserver.yml
+++ b/.github/workflows/devserver.yml
@@ -25,27 +25,27 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+      - "dependabot/**"
+      - "skip_ci*"
     paths:
-      - 'generators/*client/**'
+      - "generators/*client/**"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
     paths:
-      - 'generators/*client/**'
+      - "generators/*client/**"
 jobs:
   build-matrix:
     runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 2
-      - name: 'Build matrix'
+      - name: "Build matrix"
         id: build
         uses: ./.github/actions/build-matrix
         with:
@@ -65,12 +65,12 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -83,11 +83,12 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
+          cache: npm
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -98,7 +99,7 @@ jobs:
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-${{ matrix.cache }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -106,7 +107,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         if: contains(matrix.app-sample, 'gradle')
         uses: actions/cache@v2.1.6
         with:
@@ -117,43 +118,43 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
-      - name: 'TOOLS: configure tools installed by the system'
+      - name: "TOOLS: configure tools installed by the system"
         run: $JHI_SCRIPTS/03-system.sh
-      - name: 'TOOLS: configure git'
+      - name: "TOOLS: configure git"
         run: $JHI_SCRIPTS/04-git-config.sh
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
+      - name: "GENERATION: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
-      - name: 'GENERATION: config'
+      - name: "GENERATION: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
-      - name: 'GENERATION: project'
+      - name: "GENERATION: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies ${{ matrix.extra-args }} ${{ matrix.new-extra-args }}
-      - name: 'GENERATION: jhipster info'
+      - name: "GENERATION: jhipster info"
         run: $JHI_SCRIPTS/14-jhipster-info.sh
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'E2E: Run'
+      - name: "E2E: Run"
         id: e2e
         run: npm run e2e:devserver --if-present
-      - name: 'E2E: Teardown'
+      - name: "E2E: Teardown"
         if: always() && matrix.e2e == 1 && steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:teardown
-      - name: 'BACKEND: Store failure logs'
+      - name: "BACKEND: Store failure logs"
         uses: actions/upload-artifact@v2
         if: always() && steps.backend.outcome == 'failure'
         with:
           name: log-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: "E2E: Store failure screenshots"
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
           name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
+      - name: "ANALYSIS: Sonar analysis"
         if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 0
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -25,11 +25,11 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
+      - "dependabot/**"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
 jobs:
   generator-jhipster:
     if: >-
@@ -48,7 +48,8 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ matrix.node_version }}
-      - name: 'SETUP: load npm cache'
+          cache: npm
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -58,7 +59,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
-      - name: 'install required npm version'
+      - name: "install required npm version"
         run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - run: git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue) <%an>%Creset' --abbrev-commit
         shell: bash
@@ -71,8 +72,4 @@ jobs:
       - run: npm run prettier:check
       - run: npm test
         if: >-
-          !contains(github.event.head_commit.message, '[ci skip]') &&
-          !contains(github.event.head_commit.message, '[skip ci]') &&
-          !contains(github.event.pull_request.title, '[skip ci]') &&
-          !contains(github.event.pull_request.title, '[ci skip]') &&
-          (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci'))
+          !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci'))

--- a/.github/workflows/incremental-changelog.yml
+++ b/.github/workflows/incremental-changelog.yml
@@ -25,19 +25,19 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+      - "dependabot/**"
+      - "skip_ci*"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
     paths:
-      - 'jdl/**'
-      - 'utils/**'
-      - 'test-integration/incremental-changelog-samples/**'
-      - 'generators/entity/**'
-      - 'generators/database-changelog/**'
-      - 'generators/database-changelog-liquibase/**'
+      - "jdl/**"
+      - "utils/**"
+      - "test-integration/incremental-changelog-samples/**"
+      - "generators/entity/**"
+      - "generators/database-changelog/**"
+      - "generators/database-changelog-liquibase/**"
 jobs:
   applications:
     name: ${{ matrix.app-type }}
@@ -46,13 +46,7 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}/app
     if: >-
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[ci skip]') &&
-      github.event.action != 'closed' &&
-      (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
-      !contains(github.event.pull_request.user.login, 'dependabot')
+      !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && github.event.action != 'closed' && (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) && !contains(github.event.pull_request.user.login, 'dependabot')
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -72,11 +66,11 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2
         with:
           path: generator-jhipster
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -88,11 +82,12 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
+          cache: npm
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -103,7 +98,7 @@ jobs:
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-${{ matrix.cache }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -111,7 +106,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         if: contains(matrix.app-type, 'gradle')
         uses: actions/cache@v2.1.6
         with:
@@ -122,53 +117,53 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
-      - name: 'TOOLS: configure tools installed by the system'
+      - name: "TOOLS: configure tools installed by the system"
         run: $JHI_SCRIPTS/03-system.sh
-      - name: 'TOOLS: configure git'
+      - name: "TOOLS: configure git"
         run: $JHI_SCRIPTS/04-git-config.sh
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
+      - name: "GENERATION: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
-      - name: 'GENERATION: config'
+      - name: "GENERATION: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
-      - name: 'GENERATION: project'
+      - name: "GENERATION: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --with-entities --force --skip-jhipster-dependencies --creation-timestamp '2020-01-01'
         env:
           JHI_SAMPLES: ${{ github.workspace }}/generator-jhipster/test-integration/incremental-changelog-samples
-      - name: 'GENERATION: incremental project'
+      - name: "GENERATION: incremental project"
         run: $JHI_SCRIPTS/12-generate-project.sh --incremental-changelog --with-entities --force
         env:
           JHI_SAMPLES: ${{ github.workspace }}/generator-jhipster/test-integration/incremental-changelog-samples
           JHI_APP: ${{ matrix.app-type }}-post
-      - name: 'GENERATION: incremental changes'
+      - name: "GENERATION: incremental changes"
         run: |
           git add .
           git -c color.ui=always diff --cached
-      - name: 'GENERATION: jhipster info'
+      - name: "GENERATION: jhipster info"
         run: $JHI_SCRIPTS/14-jhipster-info.sh
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers'
+      - name: "TESTS: Start docker-compose containers"
         run: $JHI_SCRIPTS/20-docker-compose.sh
-      - name: 'TESTS: backend'
+      - name: "TESTS: backend"
         run: $JHI_SCRIPTS/21-tests-backend.sh
-      - name: 'TESTS: frontend'
+      - name: "TESTS: frontend"
         run: $JHI_SCRIPTS/22-tests-frontend.sh
-      - name: 'TESTS: packaging'
+      - name: "TESTS: packaging"
         run: $JHI_SCRIPTS/23-package.sh
-      - name: 'E2E: Run'
+      - name: "E2E: Run"
         id: e2e
         run: $JHI_SCRIPTS/24-tests-e2e.sh
-      - name: 'E2E: Store failure screenshots'
+      - name: "E2E: Store failure screenshots"
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
           name: screenshots-${{ matrix.app-type }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
+      - name: "ANALYSIS: Sonar analysis"
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -25,16 +25,16 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+      - "dependabot/**"
+      - "skip_ci*"
     paths-ignore:
-      - 'package*.json'
+      - "package*.json"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
     paths-ignore:
-      - 'package*.json'
+      - "package*.json"
 jobs:
   build-matrix:
     runs-on: ubuntu-20.04
@@ -44,11 +44,11 @@ jobs:
       server: ${{ steps.build.outputs.server }}
       any: ${{ steps.build.outputs.any }}
     steps:
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 2
-      - name: 'Build matrix'
+      - name: "Build matrix"
         id: build
         uses: ./.github/actions/build-matrix
   applications:
@@ -59,13 +59,7 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}/app
     if: >-
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[ci skip]') &&
-      github.event.action != 'closed' &&
-      !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') &&
-      needs.build-matrix.outputs.any != 'false'
+      !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && github.event.action != 'closed' && !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') && needs.build-matrix.outputs.any != 'false'
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -91,12 +85,12 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -107,11 +101,12 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
+          cache: npm
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -122,7 +117,7 @@ jobs:
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-${{ matrix.cache }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -130,7 +125,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         if: contains(matrix.app-sample, 'gradle')
         uses: actions/cache@v2.1.6
         with:
@@ -141,39 +136,39 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
-      - name: 'TOOLS: configure tools installed by the system'
+      - name: "TOOLS: configure tools installed by the system"
         run: $JHI_SCRIPTS/03-system.sh
-      - name: 'TOOLS: configure git'
+      - name: "TOOLS: configure git"
         run: $JHI_SCRIPTS/04-git-config.sh
       # Update global NPM for workspaces support
-      - name: 'Install required NPM version'
+      - name: "Install required NPM version"
         run: npm install -g npm@${{ steps.setup.outputs.npm-version }} || true
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
+      - name: "GENERATION: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
-      - name: 'GENERATION: config'
+      - name: "GENERATION: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
-      - name: 'GENERATION: project'
+      - name: "GENERATION: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies ${{ matrix.extra-args }} ${{ matrix.new-extra-args }}
-      - name: 'GENERATION: workspace git'
+      - name: "GENERATION: workspace git"
         run: |
           git add .
           git commit -m "Commit workspaces"
-      - name: 'GENERATION: jhipster info'
+      - name: "GENERATION: jhipster info"
         run: $JHI_SCRIPTS/14-jhipster-info.sh
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
-      - name: 'MERGE: generate base'
+      - name: "MERGE: generate base"
         continue-on-error: true
         id: base-app
         if: github.event.pull_request
         uses: ./generator-jhipster/.github/actions/compare-base
         with:
-          extra-args: '--skip-jhipster-dependencies ${{ matrix.extra-args }}'
-      - name: 'MERGE: compare changes'
+          extra-args: "--skip-jhipster-dependencies ${{ matrix.extra-args }}"
+      - name: "MERGE: compare changes"
         continue-on-error: true
         id: compare
         if: steps.base-app.outcome == 'success'
@@ -183,33 +178,33 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: backend'
+      - name: "TESTS: backend"
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 1 && needs.build-matrix.outputs.server != 'false'
         run: npm run ci:backend:test
-      - name: 'TESTS: frontend'
+      - name: "TESTS: frontend"
         if: steps.compare.outputs.equals != 'true' && needs.build-matrix.outputs.client != 'false'
         run: npm run ci:frontend:test
-      - name: 'TESTS: packaging'
+      - name: "TESTS: packaging"
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:package
-      - name: 'TESTS: Start docker-compose containers for e2e tests'
+      - name: "TESTS: Start docker-compose containers for e2e tests"
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:prepare
-      - name: 'E2E: Run'
+      - name: "E2E: Run"
         id: e2e
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:run --if-present
-      - name: 'E2E: Teardown'
+      - name: "E2E: Teardown"
         if: always() && matrix.e2e == 1 && steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:teardown
-      - name: 'BACKEND: Store failure logs'
+      - name: "BACKEND: Store failure logs"
         uses: actions/upload-artifact@v2
         if: always() && steps.backend.outcome == 'failure'
         with:
           name: log-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: "E2E: Store failure screenshots"
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
@@ -218,7 +213,7 @@ jobs:
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
-      - name: 'ANALYSIS: Sonar analysis'
+      - name: "ANALYSIS: Sonar analysis"
         if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 0
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:

--- a/.github/workflows/lock-maintenance.yml
+++ b/.github/workflows/lock-maintenance.yml
@@ -2,8 +2,7 @@ name: Package lock maintenance
 on:
   schedule:
     - cron: 0 0 * * 6
-  workflow_dispatch:
-
+  workflow_dispatch: null
 jobs:
   build:
     name: Bump transitional dependencies
@@ -11,15 +10,10 @@ jobs:
     steps:
       - uses: actions/setup-node@v2.4.1
         with:
-          node-version: '14'
+          node-version: "14"
+          cache: npm
       - run: npm install -g npm@latest
       - uses: actions/checkout@v2.3.4
-      - uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
-          restore-keys: |
-            ${{ runner.os }}-node-
       - name: Create commit
         run: |
           rm package-lock.json
@@ -31,7 +25,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3.10.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'Bump transitional dependencies'
-          title: 'Bump transitional dependencies'
+          commit-message: "Bump transitional dependencies"
+          title: "Bump transitional dependencies"
           body: Weekly transitional dependencies bump.
-          labels: 'theme: dependencies'
+          labels: "theme: dependencies"

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -25,20 +25,20 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+      - "dependabot/**"
+      - "skip_ci*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/angular/**'
-      - 'generators/*client/templates/vue/**'
+      - "package*.json"
+      - "generators/*client/templates/angular/**"
+      - "generators/*client/templates/vue/**"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/angular/**'
-      - 'generators/*client/templates/vue/**'
+      - "package*.json"
+      - "generators/*client/templates/angular/**"
+      - "generators/*client/templates/vue/**"
 jobs:
   build-matrix:
     runs-on: ubuntu-20.04
@@ -48,11 +48,11 @@ jobs:
       server: ${{ steps.build.outputs.server }}
       any: ${{ steps.build.outputs.any }}
     steps:
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 2
-      - name: 'Build matrix'
+      - name: "Build matrix"
         id: build
         uses: ./.github/actions/build-matrix
   applications:
@@ -63,17 +63,7 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}/app
     if: >-
-      !contains(github.event.head_commit.message, '[angular]') &&
-      !contains(github.event.head_commit.message, '[vue]') &&
-      !contains(github.event.pull_request.title, '[angular]') &&
-      !contains(github.event.pull_request.title, '[vue]') &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[ci skip]') &&
-      github.event.action != 'closed' &&
-      !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') &&
-      needs.build-matrix.outputs.any != 'false'
+      !contains(github.event.head_commit.message, '[angular]') && !contains(github.event.head_commit.message, '[vue]') && !contains(github.event.pull_request.title, '[angular]') && !contains(github.event.pull_request.title, '[vue]') && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && github.event.action != 'closed' && !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') && needs.build-matrix.outputs.any != 'false'
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -135,12 +125,12 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -152,11 +142,12 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
+          cache: npm
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -167,7 +158,7 @@ jobs:
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-${{ matrix.cache }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -175,7 +166,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         if: contains(matrix.app-sample, 'gradle')
         uses: actions/cache@v2.1.6
         with:
@@ -186,32 +177,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
-      - name: 'TOOLS: configure tools installed by the system'
+      - name: "TOOLS: configure tools installed by the system"
         run: $JHI_SCRIPTS/03-system.sh
-      - name: 'TOOLS: configure git'
+      - name: "TOOLS: configure git"
         run: $JHI_SCRIPTS/04-git-config.sh
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
+      - name: "GENERATION: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
-      - name: 'GENERATION: config'
+      - name: "GENERATION: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
-      - name: 'GENERATION: project'
+      - name: "GENERATION: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies ${{ matrix.extra-args }} ${{ matrix.new-extra-args }}
-      - name: 'GENERATION: jhipster info'
+      - name: "GENERATION: jhipster info"
         run: $JHI_SCRIPTS/14-jhipster-info.sh
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
-      - name: 'MERGE: generate base'
+      - name: "MERGE: generate base"
         continue-on-error: true
         id: base-app
         if: github.event.pull_request
         uses: ./generator-jhipster/.github/actions/compare-base
         with:
-          extra-args: '--skip-jhipster-dependencies ${{ matrix.extra-args }}'
-      - name: 'MERGE: compare changes'
+          extra-args: "--skip-jhipster-dependencies ${{ matrix.extra-args }}"
+      - name: "MERGE: compare changes"
         continue-on-error: true
         id: compare
         if: steps.base-app.outcome == 'success'
@@ -221,42 +212,42 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+      - name: "TESTS: Start docker-compose containers for e2e and backend tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers == 0
         run: npm run ci:e2e:prepare
-      - name: 'TESTS: backend'
+      - name: "TESTS: backend"
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 1 && needs.build-matrix.outputs.server != 'false'
         run: npm run ci:backend:test
-      - name: 'TESTS: frontend'
+      - name: "TESTS: frontend"
         if: steps.compare.outputs.equals != 'true' && needs.build-matrix.outputs.client != 'false'
         run: npm run ci:frontend:test
-      - name: 'TESTS: packaging'
+      - name: "TESTS: packaging"
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:package
-      - name: 'TESTS: Start docker-compose containers for e2e tests'
+      - name: "TESTS: Start docker-compose containers for e2e tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers != 0
         run: npm run ci:e2e:prepare
-      - name: 'E2E: Run'
+      - name: "E2E: Run"
         id: e2e
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:run --if-present
-      - name: 'E2E: Teardown'
+      - name: "E2E: Teardown"
         if: always() && matrix.e2e == 1 && steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:teardown
-      - name: 'BACKEND: Store failure logs'
+      - name: "BACKEND: Store failure logs"
         uses: actions/upload-artifact@v2
         if: always() && steps.backend.outcome == 'failure'
         with:
           name: log-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: "E2E: Store failure screenshots"
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
           name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
+      - name: "ANALYSIS: Sonar analysis"
         if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 0
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -25,20 +25,20 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+      - "dependabot/**"
+      - "skip_ci*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/angular/**'
-      - 'generators/*client/templates/react/**'
+      - "package*.json"
+      - "generators/*client/templates/angular/**"
+      - "generators/*client/templates/react/**"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/angular/**'
-      - 'generators/*client/templates/react/**'
+      - "package*.json"
+      - "generators/*client/templates/angular/**"
+      - "generators/*client/templates/react/**"
 jobs:
   build-matrix:
     runs-on: ubuntu-20.04
@@ -48,11 +48,11 @@ jobs:
       server: ${{ steps.build.outputs.server }}
       any: ${{ steps.build.outputs.any }}
     steps:
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 2
-      - name: 'Build matrix'
+      - name: "Build matrix"
         id: build
         uses: ./.github/actions/build-matrix
   applications:
@@ -63,17 +63,7 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}/app
     if: >-
-      !contains(github.event.head_commit.message, '[angular]') &&
-      !contains(github.event.head_commit.message, '[react]') &&
-      !contains(github.event.pull_request.title, '[angular]') &&
-      !contains(github.event.pull_request.title, '[react]') &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[ci skip]') &&
-      github.event.action != 'closed' &&
-      !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') &&
-      needs.build-matrix.outputs.any != 'false'
+      !contains(github.event.head_commit.message, '[angular]') && !contains(github.event.head_commit.message, '[react]') && !contains(github.event.pull_request.title, '[angular]') && !contains(github.event.pull_request.title, '[react]') && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && github.event.action != 'closed' && !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') && needs.build-matrix.outputs.any != 'false'
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -141,12 +131,12 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -158,11 +148,12 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
+          cache: npm
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -173,7 +164,7 @@ jobs:
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-${{ matrix.cache }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -181,7 +172,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         if: contains(matrix.app-sample, 'gradle')
         uses: actions/cache@v2.1.6
         with:
@@ -192,32 +183,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
-      - name: 'TOOLS: configure tools installed by the system'
+      - name: "TOOLS: configure tools installed by the system"
         run: $JHI_SCRIPTS/03-system.sh
-      - name: 'TOOLS: configure git'
+      - name: "TOOLS: configure git"
         run: $JHI_SCRIPTS/04-git-config.sh
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
+      - name: "GENERATION: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
-      - name: 'GENERATION: config'
+      - name: "GENERATION: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
-      - name: 'GENERATION: project'
+      - name: "GENERATION: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies ${{ matrix.extra-args }} ${{ matrix.new-extra-args }}
-      - name: 'GENERATION: jhipster info'
+      - name: "GENERATION: jhipster info"
         run: $JHI_SCRIPTS/14-jhipster-info.sh
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
-      - name: 'MERGE: generate base'
+      - name: "MERGE: generate base"
         continue-on-error: true
         id: base-app
         if: github.event.pull_request
         uses: ./generator-jhipster/.github/actions/compare-base
         with:
-          extra-args: '--skip-jhipster-dependencies ${{ matrix.extra-args }}'
-      - name: 'MERGE: compare changes'
+          extra-args: "--skip-jhipster-dependencies ${{ matrix.extra-args }}"
+      - name: "MERGE: compare changes"
         continue-on-error: true
         id: compare
         if: steps.base-app.outcome == 'success'
@@ -227,42 +218,42 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+      - name: "TESTS: Start docker-compose containers for e2e and backend tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers == 0
         run: npm run ci:e2e:prepare
-      - name: 'TESTS: backend'
+      - name: "TESTS: backend"
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 1 && needs.build-matrix.outputs.server != 'false'
         run: npm run ci:backend:test
-      - name: 'TESTS: frontend'
+      - name: "TESTS: frontend"
         if: steps.compare.outputs.equals != 'true' && needs.build-matrix.outputs.client != 'false'
         run: npm run ci:frontend:test
-      - name: 'TESTS: packaging'
+      - name: "TESTS: packaging"
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:package
-      - name: 'TESTS: Start docker-compose containers for e2e tests'
+      - name: "TESTS: Start docker-compose containers for e2e tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers != 0
         run: npm run ci:e2e:prepare
-      - name: 'E2E: Run'
+      - name: "E2E: Run"
         id: e2e
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:run --if-present
-      - name: 'E2E: Teardown'
+      - name: "E2E: Teardown"
         if: always() && matrix.e2e == 1 && steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:teardown
-      - name: 'BACKEND: Store failure logs'
+      - name: "BACKEND: Store failure logs"
         uses: actions/upload-artifact@v2
         if: always() && steps.backend.outcome == 'failure'
         with:
           name: log-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: "E2E: Store failure screenshots"
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
           name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
+      - name: "ANALYSIS: Sonar analysis"
         if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 0
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -25,20 +25,20 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+      - "dependabot/**"
+      - "skip_ci*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/react/**'
-      - 'generators/*client/templates/vue/**'
+      - "package*.json"
+      - "generators/*client/templates/react/**"
+      - "generators/*client/templates/vue/**"
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
     paths-ignore:
-      - 'package*.json'
-      - 'generators/*client/templates/react/**'
-      - 'generators/*client/templates/vue/**'
+      - "package*.json"
+      - "generators/*client/templates/react/**"
+      - "generators/*client/templates/vue/**"
 jobs:
   build-matrix:
     runs-on: ubuntu-20.04
@@ -48,11 +48,11 @@ jobs:
       server: ${{ steps.build.outputs.server }}
       any: ${{ steps.build.outputs.any }}
     steps:
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 2
-      - name: 'Build matrix'
+      - name: "Build matrix"
         id: build
         uses: ./.github/actions/build-matrix
   applications:
@@ -63,17 +63,7 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}/app
     if: >-
-      !contains(github.event.head_commit.message, '[react]') &&
-      !contains(github.event.head_commit.message, '[vue]') &&
-      !contains(github.event.pull_request.title, '[react]') &&
-      !contains(github.event.pull_request.title, '[vue]') &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[skip ci]') &&
-      !contains(github.event.pull_request.title, '[ci skip]') &&
-      github.event.action != 'closed' &&
-      !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') &&
-      needs.build-matrix.outputs.any != 'false'
+      !contains(github.event.head_commit.message, '[react]') && !contains(github.event.head_commit.message, '[vue]') && !contains(github.event.pull_request.title, '[react]') && !contains(github.event.pull_request.title, '[vue]') && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]') && github.event.action != 'closed' && !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci') && needs.build-matrix.outputs.any != 'false'
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -142,12 +132,12 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
-      - name: 'SETUP: Checkout generator-jhipster'
+      - name: "SETUP: Checkout generator-jhipster"
         uses: actions/checkout@v2.3.4
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
+      - name: "SETUP: environment"
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
@@ -159,11 +149,12 @@ jobs:
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
+          cache: npm
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: "SETUP: load npm cache"
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -174,7 +165,7 @@ jobs:
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-${{ matrix.cache }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-node-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load maven cache'
+      - name: "SETUP: load maven cache"
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -182,7 +173,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-maven-${{ steps.setup.outputs.date }}
-      - name: 'SETUP: load gradle cache'
+      - name: "SETUP: load gradle cache"
         if: contains(matrix.app-sample, 'gradle')
         uses: actions/cache@v2.1.6
         with:
@@ -193,32 +184,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}-
             ${{ runner.os }}-gradle-${{ steps.setup.outputs.date }}
-      - name: 'TOOLS: configure tools installed by the system'
+      - name: "TOOLS: configure tools installed by the system"
         run: $JHI_SCRIPTS/03-system.sh
-      - name: 'TOOLS: configure git'
+      - name: "TOOLS: configure git"
         run: $JHI_SCRIPTS/04-git-config.sh
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
+      - name: "GENERATION: install JHipster"
         run: $JHI_SCRIPTS/10-install-jhipster.sh
-      - name: 'GENERATION: config'
+      - name: "GENERATION: config"
         run: $JHI_SCRIPTS/11-generate-config.sh
-      - name: 'GENERATION: project'
+      - name: "GENERATION: project"
         run: $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies ${{ matrix.extra-args }} ${{ matrix.new-extra-args }}
-      - name: 'GENERATION: jhipster info'
+      - name: "GENERATION: jhipster info"
         run: $JHI_SCRIPTS/14-jhipster-info.sh
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
-      - name: 'MERGE: generate base'
+      - name: "MERGE: generate base"
         continue-on-error: true
         id: base-app
         if: github.event.pull_request
         uses: ./generator-jhipster/.github/actions/compare-base
         with:
-          extra-args: '--skip-jhipster-dependencies ${{ matrix.extra-args }}'
-      - name: 'MERGE: compare changes'
+          extra-args: "--skip-jhipster-dependencies ${{ matrix.extra-args }}"
+      - name: "MERGE: compare changes"
         continue-on-error: true
         id: compare
         if: steps.base-app.outcome == 'success'
@@ -228,42 +219,42 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+      - name: "TESTS: Start docker-compose containers for e2e and backend tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers == 0
         run: npm run ci:e2e:prepare
-      - name: 'TESTS: backend'
+      - name: "TESTS: backend"
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 1 && needs.build-matrix.outputs.server != 'false'
         run: npm run ci:backend:test
-      - name: 'TESTS: frontend'
+      - name: "TESTS: frontend"
         if: steps.compare.outputs.equals != 'true' && needs.build-matrix.outputs.client != 'false'
         run: npm run ci:frontend:test
-      - name: 'TESTS: packaging'
+      - name: "TESTS: packaging"
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:package
-      - name: 'TESTS: Start docker-compose containers for e2e tests'
+      - name: "TESTS: Start docker-compose containers for e2e tests"
         if: steps.compare.outputs.equals != 'true' && matrix.testcontainers != 0
         run: npm run ci:e2e:prepare
-      - name: 'E2E: Run'
+      - name: "E2E: Run"
         id: e2e
         if: steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:run --if-present
-      - name: 'E2E: Teardown'
+      - name: "E2E: Teardown"
         if: always() && matrix.e2e == 1 && steps.compare.outputs.equals != 'true'
         run: npm run ci:e2e:teardown
-      - name: 'BACKEND: Store failure logs'
+      - name: "BACKEND: Store failure logs"
         uses: actions/upload-artifact@v2
         if: always() && steps.backend.outcome == 'failure'
         with:
           name: log-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: "E2E: Store failure screenshots"
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
           name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
+      - name: "ANALYSIS: Sonar analysis"
         if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 0
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
