### PR TITLE
Since Prettier 2.4 jsxBracketSameLine is deprecated

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -9,7 +9,7 @@ useTabs: false
 arrowParens: avoid
 
 # jsx and tsx rules:
-jsxBracketSameLine: false
+bracketSameLine: false
 
 # java rules:
 overrides:

--- a/generators/common/templates/.prettierrc.ejs
+++ b/generators/common/templates/.prettierrc.ejs
@@ -9,7 +9,7 @@ useTabs: false
 arrowParens: avoid
 
 # jsx and tsx rules:
-jsxBracketSameLine: false
+bracketSameLine: false
 <%_ if (!skipServer) { _%>
 
 # java rules:


### PR DESCRIPTION
`jsxBracketSameLine` =>  `bracketSameLine`
https://prettier.io/blog/2021/09/09/2.4.0.html

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
