### PR TITLE
Add a try catch when load the namespace from the env for blueprints t…

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -159,8 +159,17 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
    * Alternative templatePath that fetches from the blueprinted generator, instead of the blueprint.
    */
   jhipsterTemplatePath(...args) {
-    this._jhipsterGenerator = this._jhipsterGenerator || this.env.requireNamespace(this.options.namespace).generator;
-    return this.fetchFromInstalledJHipster(this._jhipsterGenerator, 'templates', ...args);
+    try {
+      this._jhipsterGenerator = this._jhipsterGenerator || this.env.requireNamespace(this.options.namespace).generator;
+      return this.fetchFromInstalledJHipster(this._jhipsterGenerator, 'templates', ...args);
+    } catch (error) {
+      this.warning(
+        `The Namespace ${this.options.namespace} is not correct. Please check your configuration and ensure your blueprint folder start with "generator-"`
+      );
+      this.log(error);
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
…emplate loading


If the blueprint folder doesn't match with the Yeoman requirements (starting with "generator-") the namespace loading can fail. 

Link to https://github.com/jhipster/generator-jhipster/pull/15970


@mshima not sure this is what you had in mind. Let me know if we should change something.


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
