### PR TITLE
Revert "chore(deps): bump react-router-dom from 5.3.0 to 6.0.0 in /generators/client/templates/react"

### DIFF
--- a/generators/client/templates/react/package.json
+++ b/generators/client/templates/react/package.json
@@ -16,7 +16,7 @@
     "react-loadable": "5.5.0",
     "react-redux": "7.2.6",
     "react-redux-loading-bar": "5.0.2",
-    "react-router-dom": "6.0.0",
+    "react-router-dom": "5.3.0",
     "react-toastify": "8.0.3",
     "react-transition-group": "4.4.2",
     "reactstrap": "8.10.1",


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#16907