### PR TITLE
Force `npm install` to workaround eslint peer dependency conflict. [skip ci]

### DIFF
--- a/.github/workflows/lock-maintenance.yml
+++ b/.github/workflows/lock-maintenance.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     name: Bump transitional dependencies
+    if: github.repository == 'jhipster/generator-jhipster'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2.4.1
@@ -23,7 +24,7 @@ jobs:
       - name: Create commit
         run: |
           rm package-lock.json
-          npm install
+          npm install || npm install --force
           git add .
           ./test-integration/scripts/04-git-config.sh
           git commit -a -m "Bump transitional dependencies" || true


### PR DESCRIPTION
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
