### PR TITLE
Handle Auth0 claims when acting as an OAuth 2.0 resource server

### DIFF
--- a/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
@@ -34,6 +34,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -91,20 +92,8 @@ public class CustomClaimConverter implements Converter<Map<String, Object>, Map<
                     String[] name = user.get("name").asText().split("\\s+");
                     if (name.length > 0) {
                         convertedClaims.put("given_name", name[0]);
-                        if (name.length == 2) {
-                            convertedClaims.put("family_name", name[1]);
-                        } else {
-                            StringBuilder lastName = new StringBuilder();
-                            int i = 1;
-                            while (i < name.length) {
-                                lastName.append(name[i]);
-                                i++;
-                                if (i < name.length) {
-                                    lastName.append(" ");
-                                }
-                            }
-                            convertedClaims.put("family_name", lastName.toString());
-                        }
+                        convertedClaims.put("family_name",
+                            String.join(" ", Arrays.copyOfRange(name, 1, name.length)));
                     }
                 }
                 if (user.has("groups")) {

--- a/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
@@ -83,6 +83,15 @@ public class CustomClaimConverter implements Converter<Map<String, Object>, Map<
                 if (user.has("family_name")) {
                     convertedClaims.put("family_name", user.get("family_name").asText());
                 }
+                if (user.has("email")) {
+                    convertedClaims.put("email", user.get("email").asText());
+                }
+                // Allow full name in a name claim - happens with Auth0
+                if (user.has("name")) {
+                    String[] name = user.get("name").asText().split("\\s+");
+                    convertedClaims.put("given_name", name[0]);
+                    convertedClaims.put("family_name", name[1]);
+                }
                 if (user.has("groups")) {
                     List<String> groups = StreamSupport.stream(user.get("groups").spliterator(), false)
                         .map(JsonNode::asText)

--- a/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
@@ -89,8 +89,23 @@ public class CustomClaimConverter implements Converter<Map<String, Object>, Map<
                 // Allow full name in a name claim - happens with Auth0
                 if (user.has("name")) {
                     String[] name = user.get("name").asText().split("\\s+");
-                    convertedClaims.put("given_name", name[0]);
-                    convertedClaims.put("family_name", name[1]);
+                    if (name.length > 0) {
+                        convertedClaims.put("given_name", name[0]);
+                        if (name.length == 2) {
+                            convertedClaims.put("family_name", name[1]);
+                        } else {
+                            StringBuilder lastName = new StringBuilder();
+                            int i = 1;
+                            while (i < name.length) {
+                                lastName.append(name[i]);
+                                i++;
+                                if (i < name.length) {
+                                    lastName.append(" ");
+                                }
+                            }
+                            convertedClaims.put("family_name", lastName.toString());
+                        }
+                    }
                 }
                 if (user.has("groups")) {
                     List<String> groups = StreamSupport.stream(user.get("groups").spliterator(), false)

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -1022,6 +1022,7 @@ public class UserService {
         if (details.get("preferred_username") != null) {
             username = ((String) details.get("preferred_username")).toLowerCase();
         }
+        // handle resource server JWT, where sub claim is email and uid is ID
         if (details.get("uid") != null) {
             user.setId((String) details.get("uid"));
             user.setLogin(sub);

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -1047,7 +1047,8 @@ public class UserService {
         }
         if (details.get("email") != null) {
             user.setEmail(((String) details.get("email")).toLowerCase());
-        } else if (sub.contains("|") && (username != null && username.contains("@")) { // special handling for Auth0
+        } else if (sub.contains("|") && (username != null && username.contains("@")) {
+            // special handling for Auth0
             user.setEmail(username);
         } else {
             user.setEmail(sub);

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -1017,15 +1017,17 @@ public class UserService {
     private static <%= databaseTypeNo ? asDto('AdminUser') : asEntity('User') %> getUser(Map<String, Object> details) {
         <%= databaseTypeNo ? asDto('AdminUser') : asEntity('User') %> user = new <%= databaseTypeNo ? asDto('AdminUser') : asEntity('User') %>();
         Boolean activated = Boolean.TRUE;
+        String sub = String.valueOf(details.get("sub"));
+        String username = String.valueOf(details.get("preferred_username")).toLowerCase();
         // handle resource server JWT, where sub claim is email and uid is ID
         if (details.get("uid") != null) {
             user.setId((String) details.get("uid"));
-            user.setLogin((String) details.get("sub"));
+            user.setLogin(sub);
         } else {
-            user.setId((String) details.get("sub"));
+            user.setId(sub);
         }
         if (details.get("preferred_username") != null) {
-            user.setLogin(((String) details.get("preferred_username")).toLowerCase());
+            user.setLogin(username);
         } else if (user.getLogin() == null) {
             user.setLogin(user.getId());
         }
@@ -1042,8 +1044,10 @@ public class UserService {
         }
         if (details.get("email") != null) {
             user.setEmail(((String) details.get("email")).toLowerCase());
+        } else if (sub.contains("|")) { // special handling for Auth0
+            user.setEmail(username);
         } else {
-            user.setEmail((String) details.get("sub"));
+            user.setEmail(sub);
         }
         if (details.get("langKey") != null) {
             user.setLangKey((String) details.get("langKey"));

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -1018,15 +1018,17 @@ public class UserService {
         <%= databaseTypeNo ? asDto('AdminUser') : asEntity('User') %> user = new <%= databaseTypeNo ? asDto('AdminUser') : asEntity('User') %>();
         Boolean activated = Boolean.TRUE;
         String sub = String.valueOf(details.get("sub"));
-        String username = String.valueOf(details.get("preferred_username")).toLowerCase();
-        // handle resource server JWT, where sub claim is email and uid is ID
+        String username = null;
+        if (details.get("preferred_username") != null) {
+            username = ((String) details.get("preferred_username")).toLowerCase();
+        }
         if (details.get("uid") != null) {
             user.setId((String) details.get("uid"));
             user.setLogin(sub);
         } else {
             user.setId(sub);
         }
-        if (details.get("preferred_username") != null) {
+        if (username != null) {
             user.setLogin(username);
         } else if (user.getLogin() == null) {
             user.setLogin(user.getId());
@@ -1044,7 +1046,7 @@ public class UserService {
         }
         if (details.get("email") != null) {
             user.setEmail(((String) details.get("email")).toLowerCase());
-        } else if (sub.contains("|")) { // special handling for Auth0
+        } else if (sub.contains("|") && (username != null && username.contains("@")) { // special handling for Auth0
             user.setEmail(username);
         } else {
             user.setEmail(sub);

--- a/generators/server/templates/src/test/java/package/security/oauth2/CustomClaimConverterIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/oauth2/CustomClaimConverterIT.java.ejs
@@ -171,6 +171,7 @@ class CustomClaimConverterIT {
         claims.put("sub", "123");
         // AND
         ObjectNode user = mapper.createObjectNode();
+        user.put("preferred_username", USERNAME);
         user.put("name", FULL_NAME);
         mockHttpGetUserInfo(user);
 
@@ -190,6 +191,7 @@ class CustomClaimConverterIT {
         claims.put("sub", "123");
         // AND
         ObjectNode user = mapper.createObjectNode();
+        user.put("preferred_username", USERNAME);
         user.put("email", EMAIL);
         mockHttpGetUserInfo(user);
 

--- a/generators/server/templates/src/test/java/package/security/oauth2/CustomClaimConverterIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/oauth2/CustomClaimConverterIT.java.ejs
@@ -51,6 +51,7 @@ class CustomClaimConverterIT {
     private static final String NAME = "John";
     private static final String FAMILY_NAME = "Doe";
     private static final String FULL_NAME = NAME + " " + FAMILY_NAME;
+    private static final String NAME_SUFFIX = "Sr.";
     private static final String EMAIL = "john.doe@gmail.com";
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -181,6 +182,27 @@ class CustomClaimConverterIT {
                 .containsEntry("preferred_username", USERNAME)
                 .containsEntry("given_name", NAME)
                 .containsEntry("family_name", FAMILY_NAME);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testConvert_withLastNameMultipleWords() {
+        // GIVEN
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("sub", "123");
+        // AND
+        ObjectNode user = mapper.createObjectNode();
+        user.put("preferred_username", USERNAME);
+        user.put("name", FULL_NAME + " " + NAME_SUFFIX);
+        mockHttpGetUserInfo(user);
+
+        assertThatCode(() ->  {
+            Map<String, Object> convertedClaims = customClaimConverter.convert(claims);
+            System.out.println(convertedClaims);
+            assertThat(convertedClaims)
+                .containsEntry("preferred_username", USERNAME)
+                .containsEntry("given_name", NAME)
+                .containsEntry("family_name", FAMILY_NAME + " " + NAME_SUFFIX);
         }).doesNotThrowAnyException();
     }
 

--- a/generators/server/templates/src/test/java/package/security/oauth2/CustomClaimConverterIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/oauth2/CustomClaimConverterIT.java.ejs
@@ -50,6 +50,8 @@ class CustomClaimConverterIT {
     private static final String USERNAME = "admin";
     private static final String NAME = "John";
     private static final String FAMILY_NAME = "Doe";
+    private static final String FULL_NAME = NAME + " " + FAMILY_NAME;
+    private static final String EMAIL = "john.doe@gmail.com";
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -159,6 +161,43 @@ class CustomClaimConverterIT {
             assertThat(convertedClaims)
                 .containsEntry("preferred_username", USERNAME)
                 .doesNotContainKeys("given_name", "family_name");
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testConvert_withName() {
+        // GIVEN
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("sub", "123");
+        // AND
+        ObjectNode user = mapper.createObjectNode();
+        user.put("name", FULL_NAME);
+        mockHttpGetUserInfo(user);
+
+        assertThatCode(() ->  {
+            Map<String, Object> convertedClaims = customClaimConverter.convert(claims);
+            assertThat(convertedClaims)
+                .containsEntry("preferred_username", USERNAME)
+                .containsEntry("given_name", NAME)
+                .containsEntry("family_name", FAMILY_NAME);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testConvert_withEmail() {
+        // GIVEN
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("sub", "123");
+        // AND
+        ObjectNode user = mapper.createObjectNode();
+        user.put("email", EMAIL);
+        mockHttpGetUserInfo(user);
+
+        assertThatCode(() ->  {
+            Map<String, Object> convertedClaims = customClaimConverter.convert(claims);
+            assertThat(convertedClaims)
+                .containsEntry("preferred_username", USERNAME)
+                .containsEntry("email", EMAIL);
         }).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
Add logic to handle `name` and `email` claims when acting as a resource server. Makes it so Ionic4J will work with Auth0. 

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

