### PR TITLE
Add support to esm blueprints.

### DIFF
--- a/cli/jhipster-command.js
+++ b/cli/jhipster-command.js
@@ -74,9 +74,9 @@ class JHipsterCommand extends Command {
    * @private
    * Override _parseCommand to execute a callback before parsing.
    */
-  _parseCommand(operands, unknown) {
+  async _parseCommand(operands, unknown) {
     if (this._lazyBuildCommandCallBack) {
-      this._lazyBuildCommandCallBack(operands, unknown);
+      await this._lazyBuildCommandCallBack(operands, unknown);
     }
     return super._parseCommand(operands, unknown);
   }

--- a/cli/program.js
+++ b/cli/program.js
@@ -93,7 +93,7 @@ const buildCommands = ({ program, commands = {}, envBuilder, env, loadCommand })
       .excessArgumentsCallback(function (receivedArgs) {
         rejectExtraArgs(program, this.name(), receivedArgs);
       })
-      .lazyBuildCommand(function (operands) {
+      .lazyBuildCommand(async function (operands) {
         logger.debug(`cmd: lazyBuildCommand ${cmdName} ${operands}`);
         const command = this;
         if (cmdName === 'run') {
@@ -103,25 +103,27 @@ const buildCommands = ({ program, commands = {}, envBuilder, env, loadCommand })
             namespace => `${namespace.startsWith(JHIPSTER_NS) ? '' : `${JHIPSTER_NS}-`}${namespace}`
           );
           envBuilder.lookupGenerators(command.generatorNamespaces.map(namespace => `generator-${namespace.split(':')[0]}`));
-          command.generatorNamespaces.forEach(namespace => {
-            if (!env.getPackagePath(namespace)) {
-              logger.fatal(chalk.red(`\nGenerator ${namespace} not found.\n`));
-            }
-            const generator = env.create(namespace, { options: { help: true } });
-            this.addGeneratorArguments(generator._arguments).addGeneratorOptions(generator._options);
-          });
+          await Promise.all(
+            command.generatorNamespaces.map(async namespace => {
+              if (!(await env.getPackagePath(namespace))) {
+                logger.fatal(chalk.red(`\nGenerator ${namespace} not found.\n`));
+              }
+              const generator = await env.create(namespace, { options: { help: true } });
+              this.addGeneratorArguments(generator._arguments).addGeneratorOptions(generator._options);
+            })
+          );
           return;
         }
         if (!opts.cliOnly || cmdName === 'jdl') {
           if (opts.blueprint) {
             // Blueprint only command.
-            const generator = env.create(`${packageNameToNamespace(opts.blueprint)}:${cmdName}`, { options: { help: true } });
+            const generator = await env.create(`${packageNameToNamespace(opts.blueprint)}:${cmdName}`, { options: { help: true } });
             command.addGeneratorArguments(generator._arguments).addGeneratorOptions(generator._options);
           } else {
             const generatorName = cmdName === 'jdl' ? 'app' : cmdName;
             // Register jhipster upstream options.
             if (cmdName !== 'jdl') {
-              const generator = env.create(`${JHIPSTER_NS}:${cmdName}`, { options: { help: true } });
+              const generator = await env.create(`${JHIPSTER_NS}:${cmdName}`, { options: { help: true } });
               command.addGeneratorArguments(generator._arguments).addGeneratorOptions(generator._options);
 
               const usagePath = path.resolve(generator.sourceRoot(), '../USAGE');
@@ -130,34 +132,34 @@ const buildCommands = ({ program, commands = {}, envBuilder, env, loadCommand })
               }
             }
             if (cmdName === 'jdl' || program.opts().fromJdl) {
-              const appGenerator = env.create(`${JHIPSTER_NS}:app`, { options: { help: true } });
+              const appGenerator = await env.create(`${JHIPSTER_NS}:app`, { options: { help: true } });
               command.addGeneratorOptions(appGenerator._options, chalk.gray(' (application)'));
 
-              const workspacesGenerator = env.create(`${JHIPSTER_NS}:workspaces`, { options: { help: true } });
+              const workspacesGenerator = await env.create(`${JHIPSTER_NS}:workspaces`, { options: { help: true } });
               command.addGeneratorOptions(workspacesGenerator._options, chalk.gray(' (workspaces)'));
             }
 
             // Register blueprint specific options.
-            envBuilder.getBlueprintsNamespaces().forEach(blueprintNamespace => {
-              const generatorNamespace = `${blueprintNamespace}:${generatorName}`;
-              if (!env.get(generatorNamespace)) {
-                return;
-              }
-              const blueprintName = blueprintNamespace.replace(/^jhipster-/, '');
-              try {
-                command.addGeneratorOptions(
-                  env.create(generatorNamespace, { options: { help: true } })._options,
-                  chalk.yellow(` (blueprint option: ${blueprintName})`)
-                );
-              } catch (error) {
-                logger.info(`Error parsing options for generator ${generatorNamespace}, error: ${error}`);
-              }
-            });
+            await Promise.all(
+              envBuilder.getBlueprintsNamespaces().map(async blueprintNamespace => {
+                const generatorNamespace = `${blueprintNamespace}:${generatorName}`;
+                if (!(await env.get(generatorNamespace))) {
+                  return;
+                }
+                const blueprintName = blueprintNamespace.replace(/^jhipster-/, '');
+                const blueprintGenerator = await env.create(generatorNamespace, { options: { help: true } });
+                try {
+                  command.addGeneratorOptions(blueprintGenerator._options, chalk.yellow(` (blueprint option: ${blueprintName})`));
+                } catch (error) {
+                  logger.info(`Error parsing options for generator ${generatorNamespace}, error: ${error}`);
+                }
+              })
+            );
           }
         }
         command.addHelpText('after', moreInfo);
       })
-      .action((...everything) => {
+      .action(async (...everything) => {
         logger.debug('cmd: action');
         // [args, opts, command]
         const command = everything.pop();
@@ -177,7 +179,7 @@ const buildCommands = ({ program, commands = {}, envBuilder, env, loadCommand })
           logger.debug('Executing CLI only script');
           return loadCommand(cmdName)(args, options, env, envBuilder);
         }
-        env.composeWith('jhipster:bootstrap', options);
+        await env.composeWith('jhipster:bootstrap', options);
 
         if (cmdName === 'run') {
           return Promise.all(command.generatorNamespaces.map(generator => env.run(generator, options))).then(

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -405,16 +405,16 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
        * When composing in different tasks the result would be:
        * - composeCommon (app) -> initializing (common) -> prompting (common) -> ... -> composeServer (app) -> initializing (server) -> ...
        */
-      compose() {
-        this.composeWithJHipster(GENERATOR_COMMON, true);
+      async compose() {
+        await this.composeWithJHipster(GENERATOR_COMMON, true);
         if (!this.jhipsterConfig.skipServer) {
-          this.composeWithJHipster(GENERATOR_SERVER, true);
+          await this.composeWithJHipster(GENERATOR_SERVER, true);
         }
         if (!this.jhipsterConfig.skipClient) {
-          this.composeWithJHipster(GENERATOR_CLIENT, true);
+          await this.composeWithJHipster(GENERATOR_CLIENT, true);
         }
         if (!this.configOptions.skipI18n) {
-          this.composeWithJHipster(
+          await this.composeWithJHipster(
             GENERATOR_LANGUAGES,
             {
               regenerate: true,
@@ -444,20 +444,22 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
         this.config.set(config);
       },
 
-      composeEntities() {
+      async composeEntities() {
         if (!this.options.withEntities) return;
-        this.composeWithJHipster(GENERATOR_ENTITIES, { skipInstall: true }, true);
+        await this.composeWithJHipster(GENERATOR_ENTITIES, { skipInstall: true }, true);
       },
 
-      composePages() {
+      async composePages() {
         if (!this.jhipsterConfig.pages || this.jhipsterConfig.pages.length === 0 || this.configOptions.skipComposePage) return;
         this.configOptions.skipComposePage = true;
-        this.jhipsterConfig.pages.forEach(page => {
-          this.composeWithJHipster(page.generator || GENERATOR_PAGE, [page.name], {
-            skipInstall: true,
-            page,
-          });
-        });
+        await Promise.all(
+          this.jhipsterConfig.pages.map(page => {
+            return this.composeWithJHipster(page.generator || GENERATOR_PAGE, [page.name], {
+              skipInstall: true,
+              page,
+            });
+          })
+        );
       },
     };
   }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -25,6 +25,7 @@ const prompts = require('./prompts');
 const packagejs = require('../../package.json');
 const statistics = require('../statistics');
 const { appDefaultConfig } = require('../generator-defaults');
+const { GENERATOR_APP } = require('../generator-list');
 const { JHIPSTER_CONFIG_DIR, GENERATOR_JHIPSTER } = require('../generator-constants');
 const { MICROSERVICE } = require('../../jdl/jhipster/application-types');
 const { OptionNames } = require('../../jdl/jhipster/application-options');
@@ -38,8 +39,6 @@ const {
   GENERATOR_PAGE,
   GENERATOR_SERVER,
 } = require('../generator-list');
-
-let useBlueprints;
 
 module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -293,8 +292,12 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
     this.existingProject = this.jhipsterConfig.baseName !== undefined && this.jhipsterConfig.applicationType !== undefined;
     // preserve old jhipsterVersion value for cleanup which occurs after new config is written into disk
     this.jhipsterOldVersion = this.jhipsterConfig.jhipsterVersion;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('app');
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_APP);
+    }
   }
 
   _initializing() {
@@ -343,7 +346,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) {
+    if (this.delegateToBlueprint) {
       return;
     }
     return this._initializing();
@@ -358,7 +361,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return;
     return this._prompting();
   }
 
@@ -385,7 +388,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return;
     return this._configuring();
   }
 
@@ -460,7 +463,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get composing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return;
     return this._composing();
   }
 
@@ -479,7 +482,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return;
     return this._default();
   }
 
@@ -495,7 +498,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return;
     return this._writing();
   }
 
@@ -512,7 +515,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get install() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return;
     return this._install();
   }
 
@@ -556,7 +559,7 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return;
     return this._end();
   }
 

--- a/generators/aws/index.js
+++ b/generators/aws/index.js
@@ -28,12 +28,12 @@ const { BUILD_TOOL, BASE_NAME, PROD_DATABASE_TYPE } = OptionNames;
 
 const { MYSQL, POSTGRESQL, MARIADB } = require('../../jdl/jhipster/database-types');
 
-let useBlueprints;
 /* eslint-disable consistent-return */
 module.exports = class extends BaseBlueprintGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_AWS);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_AWS);
+    }
   }
 
   _initializing() {
@@ -90,7 +90,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -99,7 +99,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -128,7 +128,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -286,7 +286,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 };

--- a/generators/azure-app-service/index.js
+++ b/generators/azure-app-service/index.js
@@ -36,7 +36,6 @@ const AZURE_WEBAPP_MAVEN_PLUGIN_VERSION = '1.8.0';
 const AZURE_WEBAPP_RUNTIME = 'JAVA|11-java11';
 const AZURE_APP_INSIGHTS_STARTER_VERSION = '2.5.1';
 
-let useBlueprints;
 /* eslint-disable consistent-return */
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -63,7 +62,12 @@ module.exports = class extends BaseBlueprintGenerator {
     this.azureSpringCloudSkipBuild = this.options.skipBuild;
     this.azureSpringCloudSkipDeploy = this.options.skipDeploy || this.options.skipBuild;
     this.azureSpringCloudSkipInsights = this.options.skipInsights;
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_AZURE_APP_SERVICE);
+  }
+
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_AZURE_APP_SERVICE);
+    }
   }
 
   _initializing() {
@@ -99,7 +103,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -246,7 +250,7 @@ ${chalk.red('https://docs.microsoft.com/en-us/cli/azure/install-azure-cli/?WT.mc
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -265,7 +269,7 @@ ${chalk.red('https://docs.microsoft.com/en-us/cli/azure/install-azure-cli/?WT.mc
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -485,7 +489,7 @@ which is free for the first 30 days`);
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -506,7 +510,7 @@ which is free for the first 30 days`);
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -524,7 +528,7 @@ which is free for the first 30 days`);
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -648,7 +652,7 @@ You need a GitHub project correctly configured in order to use GitHub Actions.`
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/azure-spring-cloud/index.js
+++ b/generators/azure-spring-cloud/index.js
@@ -32,7 +32,6 @@ const NO_CACHE_PROVIDER = cacheTypes.NO;
 const { MAVEN } = require('../../jdl/jhipster/build-tool-types');
 const { GENERATOR_AZURE_SPRING_CLOUD } = require('../generator-list');
 
-let useBlueprints;
 /* eslint-disable consistent-return */
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -52,7 +51,12 @@ module.exports = class extends BaseBlueprintGenerator {
 
     this.azureSpringCloudSkipBuild = this.options.skipBuild;
     this.azureSpringCloudSkipDeploy = this.options.skipDeploy || this.options.skipBuild;
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_AZURE_SPRING_CLOUD);
+  }
+
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_AZURE_SPRING_CLOUD);
+    }
   }
 
   _initializing() {
@@ -89,7 +93,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -255,7 +259,7 @@ ${chalk.red('az extension add --name spring-cloud')}`
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -272,7 +276,7 @@ ${chalk.red('az extension add --name spring-cloud')}`
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -315,7 +319,7 @@ ${chalk.red('az extension add --name spring-cloud')}`
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -331,7 +335,7 @@ ${chalk.red('az extension add --name spring-cloud')}`
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -359,7 +363,7 @@ ${chalk.red('az extension add --name spring-cloud')}`
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -485,7 +489,7 @@ for more detailed information.`
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -29,8 +29,6 @@ const { GENERATOR_CI_CD } = require('../generator-list');
 
 const REACT = constants.SUPPORTED_CLIENT_FRAMEWORKS.REACT;
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
@@ -76,8 +74,12 @@ module.exports = class extends BaseBlueprintGenerator {
       defaults: false,
       description: 'Automatically configure CircleCI',
     });
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_CI_CD);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_CI_CD);
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -130,7 +132,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -143,7 +145,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -172,7 +174,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -203,7 +205,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -255,7 +257,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 };

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -44,8 +44,6 @@ const { CommonDBTypes } = require('../../jdl/jhipster/field-types');
 const TYPE_STRING = CommonDBTypes.STRING;
 const TYPE_UUID = CommonDBTypes.UUID;
 
-let useBlueprints;
-
 module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'namespace', ...features });
@@ -76,8 +74,12 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
     this.loadRuntimeOptions();
 
     this.existingProject = !!this.jhipsterConfig.clientFramework;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_CLIENT);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_CLIENT);
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -108,7 +110,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -124,7 +126,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -160,7 +162,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -185,7 +187,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get composing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._composing();
   }
 
@@ -243,7 +245,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -283,7 +285,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -314,7 +316,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -328,18 +330,18 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
         if (this.skipClient) return;
         switch (this.clientFramework) {
           case ANGULAR:
-            return writeAngularFiles.call(this, useBlueprints);
+            return writeAngularFiles.call(this);
           case REACT:
-            return writeReactFiles.call(this, useBlueprints);
+            return writeReactFiles.call(this);
           case VUE:
-            return writeVueFiles.call(this, useBlueprints);
+            return writeVueFiles.call(this);
           default:
           // do nothing by default
         }
       },
       writeCommonFiles() {
         if (this.skipClient) return;
-        return writeCommonFiles.call(this, useBlueprints);
+        return writeCommonFiles.call(this);
       },
 
       ...super._missingPostWriting(),
@@ -347,7 +349,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -392,7 +394,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 
@@ -414,7 +416,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -169,19 +169,19 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
   // Public API method used by the getter and also by Blueprints
   _composing() {
     return {
-      composeCommon() {
-        this.composeWithJHipster(GENERATOR_COMMON, true);
+      async composeCommon() {
+        await this.composeWithJHipster(GENERATOR_COMMON, true);
       },
-      composeCypress() {
+      async composeCypress() {
         const testFrameworks = this.jhipsterConfig.testFrameworks;
         if (!Array.isArray(testFrameworks) || !testFrameworks.includes(CYPRESS)) return;
-        this.composeWithJHipster(GENERATOR_CYPRESS, { existingProject: this.existingProject }, true);
+        await this.composeWithJHipster(GENERATOR_CYPRESS, { existingProject: this.existingProject }, true);
       },
-      composeLanguages() {
+      async composeLanguages() {
         // We don't expose client/server to cli, composing with languages is used for test purposes.
         if (this.jhipsterConfig.enableTranslation === false) return;
 
-        this.composeWithJHipster(GENERATOR_LANGUAGES, true);
+        await this.composeWithJHipster(GENERATOR_LANGUAGES, true);
       },
     };
   }

--- a/generators/cloudfoundry/index.js
+++ b/generators/cloudfoundry/index.js
@@ -35,12 +35,12 @@ const NO_DATABASE_TYPE = databaseTypes.NO;
 
 const exec = childProcess.exec;
 
-let useBlueprints;
 /* eslint-disable consistent-return */
 module.exports = class extends BaseBlueprintGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_CLOUDFOUNDRY);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_CLOUDFOUNDRY);
+    }
   }
 
   _initializing() {
@@ -66,7 +66,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -75,7 +75,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -115,7 +115,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -182,7 +182,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -232,7 +232,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -90,7 +90,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -197,7 +197,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 };

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -25,8 +25,6 @@ const prettierConfigFiles = require('./files').prettierConfigFiles;
 const constants = require('../generator-constants');
 const packageJson = require('../../package.json');
 
-let useBlueprints;
-
 module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'namespace', ...features });
@@ -37,8 +35,12 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
 
     this.loadStoredAppOptions();
     this.loadRuntimeOptions();
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('common');
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints('common');
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -64,7 +66,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -122,7 +124,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -137,7 +139,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -149,7 +151,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -173,7 +175,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 

--- a/generators/cypress/index.js
+++ b/generators/cypress/index.js
@@ -23,7 +23,6 @@ const constants = require('../generator-constants');
 const { GENERATOR_CYPRESS } = require('../generator-list');
 const { CYPRESS } = require('../../jdl/jhipster/test-framework-types');
 
-let useBlueprints;
 /* eslint-disable consistent-return */
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -34,8 +33,12 @@ module.exports = class extends BaseBlueprintGenerator {
     }
 
     this.loadRuntimeOptions();
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_CYPRESS);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_CYPRESS);
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -48,7 +51,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -75,7 +78,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -95,7 +98,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -110,7 +113,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -120,7 +123,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -139,7 +142,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -227,7 +230,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 };

--- a/generators/database-changelog-liquibase/index.js
+++ b/generators/database-changelog-liquibase/index.js
@@ -35,7 +35,6 @@ const { prepareFieldForTemplates } = require('../../utils/field');
 const { prepareRelationshipForTemplates } = require('../../utils/relationship');
 const { prepareFieldForLiquibaseTemplates } = require('../../utils/liquibase');
 
-let useBlueprints;
 /* eslint-disable consistent-return */
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -51,7 +50,12 @@ module.exports = class extends BaseBlueprintGenerator {
 
     // Set number of rows to be generated
     this.numberOfRows = 10;
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_DATABASE_CHANGELOG_LIQUIBASE);
+  }
+
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_DATABASE_CHANGELOG_LIQUIBASE);
+    }
   }
 
   _loading() {
@@ -69,7 +73,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -149,7 +153,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -194,7 +198,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get preparingRelationships() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparingRelationships();
   }
 
@@ -209,7 +213,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -253,7 +257,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     if (this.options.skipWriting) {
       return {};
     }
@@ -286,7 +290,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     if (this.options.skipWriting) {
       return {};
     }

--- a/generators/database-changelog/index.js
+++ b/generators/database-changelog/index.js
@@ -28,7 +28,6 @@ const BASE_CHANGELOG = {
   removedRelationships: [],
 };
 
-let useBlueprints;
 /* eslint-disable consistent-return */
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -45,7 +44,12 @@ module.exports = class extends BaseBlueprintGenerator {
     }
     this.info(`Creating changelog for entities ${this.options.entities}`);
     this.configOptions.oldSharedEntities = this.configOptions.oldSharedEntities || [];
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_DATABASE_CHANGELOG);
+  }
+
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_DATABASE_CHANGELOG);
+    }
   }
 
   _default() {
@@ -75,7 +79,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -34,13 +34,12 @@ const { GENERATOR_DOCKER_COMPOSE } = require('../generator-list');
 
 const NO_DATABASE = databaseTypes.NO;
 
-let useBlueprints;
-
 /* eslint-disable consistent-return */
 module.exports = class extends BaseDockerGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_DOCKER_COMPOSE);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_DOCKER_COMPOSE);
+    }
   }
 
   _initializing() {
@@ -81,7 +80,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -90,7 +89,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -118,7 +117,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -264,7 +263,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -277,7 +276,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -286,7 +285,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -313,7 +312,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/entities-client/index.js
+++ b/generators/entities-client/index.js
@@ -19,14 +19,17 @@
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const { GENERATOR_ENTITIES_CLIENT } = require('../generator-list');
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
     if (this.options.help) return;
     this.clientEntities = this.options.clientEntities;
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_ENTITIES_CLIENT);
+  }
+
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_ENTITIES_CLIENT);
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -39,7 +42,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    return useBlueprints ? undefined : this._initializing();
+    return this.delegateToBlueprint ? undefined : this._initializing();
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -52,7 +55,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    return useBlueprints ? undefined : this._loading();
+    return this.delegateToBlueprint ? undefined : this._loading();
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -67,7 +70,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    return useBlueprints ? undefined : this._default();
+    return this.delegateToBlueprint ? undefined : this._default();
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -82,6 +85,6 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get end() {
-    return useBlueprints ? undefined : this._end();
+    return this.delegateToBlueprint ? undefined : this._end();
   }
 };

--- a/generators/entities/index.js
+++ b/generators/entities/index.js
@@ -21,8 +21,6 @@ const { JHIPSTER_CONFIG_DIR } = require('../generator-constants');
 const { SQL } = require('../../jdl/jhipster/database-types');
 const { GENERATOR_ENTITIES, GENERATOR_ENTITIES_CLIENT, GENERATOR_ENTITY, GENERATOR_DATABASE_CHANGELOG } = require('../generator-list');
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'namespace', ...features });
@@ -75,10 +73,12 @@ module.exports = class extends BaseBlueprintGenerator {
       defaults: true,
       hide: true,
     });
+  }
 
-    if (this.options.help) return;
-
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_ENTITIES);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_ENTITIES);
+    }
 
     if (this.options.entitiesToImport) {
       const entities = this.jhipsterConfig.entities || [];
@@ -123,7 +123,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    return useBlueprints ? undefined : this._initializing();
+    if (this.delegateToBlueprint) return {};
+    return this._initializing();
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -159,7 +160,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get composing() {
-    return useBlueprints ? undefined : this._composing();
+    if (this.delegateToBlueprint) return {};
+    return this._composing();
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -185,7 +187,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    return useBlueprints ? undefined : this._default();
+    if (this.delegateToBlueprint) return {};
+    return this._default();
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -194,6 +197,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    return useBlueprints ? undefined : this._writing();
+    if (this.delegateToBlueprint) return {};
+    return this._writing();
   }
 };

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -29,16 +29,18 @@ const {
 const { GENERATOR_ENTITY_CLIENT } = require('../generator-list');
 const { POSTGRESQL, MARIADB } = require('../../jdl/jhipster/database-types');
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
 
     this.entity = this.options.context;
     this.jhipsterContext = this.options.jhipsterContext || this.options.context;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_ENTITY_CLIENT, { context: this.options.context });
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_ENTITY_CLIENT, { context: this.options.context });
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -84,7 +86,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -143,7 +145,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -166,7 +168,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -53,7 +53,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 

--- a/generators/entity-i18n/index.js
+++ b/generators/entity-i18n/index.js
@@ -23,7 +23,6 @@ const { GENERATOR_ENTITY_I_18_N } = require('../generator-list');
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
 /* constants used throughout */
-let useBlueprints;
 
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -31,8 +30,12 @@ module.exports = class extends BaseBlueprintGenerator {
 
     this.entity = this.options.context;
     this.jhipsterContext = this.options.jhipsterContext || this.options.context;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_ENTITY_I_18_N, { context: this.options.context });
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_ENTITY_I_18_N, { context: this.options.context });
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -47,7 +50,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -57,7 +60,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 };

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -27,7 +27,6 @@ const { SQL } = require('../../jdl/jhipster/database-types');
 const { isReservedTableName } = require('../../jdl/jhipster/reserved-keywords');
 
 /* constants used throughout */
-let useBlueprints;
 
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
@@ -36,8 +35,12 @@ module.exports = class extends BaseBlueprintGenerator {
     this.entity = this.options.context;
 
     this.jhipsterContext = this.options.jhipsterContext || this.options.context;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_ENTITY_SERVER, { context: this.options.context });
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_ENTITY_SERVER, { context: this.options.context });
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -51,7 +54,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -69,7 +72,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -98,7 +101,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get preparingFields() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparingFields();
   }
 
@@ -165,7 +168,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -178,7 +181,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -192,7 +195,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -460,9 +460,9 @@ class EntityGenerator extends BaseBlueprintGenerator {
   // Public API method used by the getter and also by Blueprints
   _composing() {
     return {
-      composeEntities() {
+      async composeEntities() {
         // We need to compose with others entities to update relationships.
-        this.composeWithJHipster(
+        await this.composeWithJHipster(
           GENERATOR_ENTITIES,
           {
             entities: this.options.singleEntity ? [this.context.name] : undefined,
@@ -517,22 +517,22 @@ class EntityGenerator extends BaseBlueprintGenerator {
         this.configOptions.sharedEntities[this.context.name] = this.context;
       },
 
-      composing() {
+      async composing() {
         if (this.options.skipWriting) return;
         const context = this.context;
         if (!context.skipServer) {
-          this.composeWithJHipster(GENERATOR_ENTITY_SERVER, this.arguments, {
+          await this.composeWithJHipster(GENERATOR_ENTITY_SERVER, this.arguments, {
             context,
           });
         }
 
         if (!context.skipClient || this.jhipsterConfig.applicationType === GATEWAY) {
-          this.composeWithJHipster(GENERATOR_ENTITY_CLIENT, this.arguments, {
+          await this.composeWithJHipster(GENERATOR_ENTITY_CLIENT, this.arguments, {
             context,
             skipInstall: this.options.skipInstall,
           });
           if (this.jhipsterConfig.enableTranslation) {
-            this.composeWithJHipster(GENERATOR_ENTITY_I_18_N, this.arguments, {
+            await this.composeWithJHipster(GENERATOR_ENTITY_I_18_N, this.arguments, {
               context,
               skipInstall: this.options.skipInstall,
             });

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -65,8 +65,6 @@ const SUPPORTED_VALIDATION_RULES = constants.SUPPORTED_VALIDATION_RULES;
 const ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
 const JHIPSTER_CONFIG_DIR = constants.JHIPSTER_CONFIG_DIR;
 
-let useBlueprints;
-
 class EntityGenerator extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'argument', ...features });
@@ -148,11 +146,9 @@ class EntityGenerator extends BaseBlueprintGenerator {
       desc: 'Regenerate only a single entity, relationships can be not correctly generated',
       type: Boolean,
     });
+  }
 
-    if (this.options.help) {
-      return;
-    }
-
+  async _postConstruct() {
     const name = _.upperFirst(this.options.name).replace('.json', '');
     this.entityStorage = this.getEntityConfig(name, true);
     this.entityConfig = this.entityStorage.createProxy();
@@ -169,14 +165,15 @@ class EntityGenerator extends BaseBlueprintGenerator {
       configurationFileExists: this.fs.exists(this.destinationPath(filename)),
     };
 
-    this._setupEntityOptions(this, this, this.context);
-    useBlueprints =
-      !this.fromBlueprint &&
-      this.instantiateBlueprints(GENERATOR_ENTITY, {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_ENTITY, {
         entityExisted,
         configExisted,
         arguments: [name],
       });
+    }
+
+    this._setupEntityOptions(this, this, this.context);
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -304,7 +301,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -326,7 +323,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -456,7 +453,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -482,7 +479,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get composing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._composing();
   }
 
@@ -546,7 +543,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -604,7 +601,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get preparingFields() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparingFields();
   }
 
@@ -630,7 +627,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -737,7 +734,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get preparingRelationships() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparingRelationships();
   }
 
@@ -838,7 +835,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -864,7 +861,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -894,7 +891,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get install() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._install();
   }
 
@@ -908,7 +905,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 

--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -35,11 +35,11 @@ const { MAVEN, GRADLE } = require('../../jdl/jhipster/build-tool-types');
 
 const NO_CACHE_PROVIDER = cacheProviders.NO;
 
-let useBlueprints;
 module.exports = class extends BaseBlueprintGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_GAE);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_GAE);
+    }
   }
 
   _initializing() {
@@ -121,7 +121,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -607,7 +607,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -748,7 +748,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -761,7 +761,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -831,7 +831,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -877,7 +877,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -230,14 +230,14 @@ module.exports = class JHipsterBaseBlueprintGenerator extends BaseGenerator {
    * Instantiates the blueprint generators, if any.
    * @param {string} subGen - sub generator
    * @param {any} extraOptions - extra options to pass to blueprint generator
-   * @return {true} useBlueprints - true if one or more blueprints generators have been constructed; false otherwise
+   * @return {boolean} - true if one or more blueprints generators have been constructed; false otherwise
    */
   instantiateBlueprints(subGen, extraOptions) {
     if (this.options.help) {
       // Ignore blueprint registered options.
       return false;
     }
-    let useBlueprints = false;
+    let delegateToBlueprint = false;
 
     if (!this.configOptions.blueprintConfigured) {
       this.configOptions.blueprintConfigured = true;
@@ -254,12 +254,12 @@ module.exports = class JHipsterBaseBlueprintGenerator extends BaseGenerator {
             this.jhipsterTemplatesFolders.unshift(blueprintGenerator.templatePath());
           } else {
             // If the blueprints does not sets sbsBlueprint property, ignore normal workflow.
-            useBlueprints = true;
+            delegateToBlueprint = true;
           }
         }
       });
     }
-    return useBlueprints;
+    return delegateToBlueprint;
   }
 
   /**

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -226,44 +226,6 @@ module.exports = class JHipsterBaseBlueprintGenerator extends BaseGenerator {
 
   /**
    * @private
-   * @deprecated
-   * Instantiates the blueprint generators, if any.
-   * @param {string} subGen - sub generator
-   * @param {any} extraOptions - extra options to pass to blueprint generator
-   * @return {boolean} - true if one or more blueprints generators have been constructed; false otherwise
-   */
-  instantiateBlueprints(subGen, extraOptions) {
-    if (this.options.help) {
-      // Ignore blueprint registered options.
-      return false;
-    }
-    let delegateToBlueprint = false;
-
-    if (!this.configOptions.blueprintConfigured) {
-      this.configOptions.blueprintConfigured = true;
-      this._configureBlueprints();
-    }
-
-    const blueprints = this.jhipsterConfig.blueprints;
-    if (blueprints && blueprints.length > 0) {
-      blueprints.forEach(blueprint => {
-        const blueprintGenerator = this._composeBlueprint(blueprint.name, subGen, extraOptions);
-        if (blueprintGenerator) {
-          if (blueprintGenerator.sbsBlueprint) {
-            // If sbsBlueprint, add templatePath to the original generator templatesFolder.
-            this.jhipsterTemplatesFolders.unshift(blueprintGenerator.templatePath());
-          } else {
-            // If the blueprints does not sets sbsBlueprint property, ignore normal workflow.
-            delegateToBlueprint = true;
-          }
-        }
-      });
-    }
-    return delegateToBlueprint;
-  }
-
-  /**
-   * @private
    * Composes with blueprint generators, if any.
    * @param {String} subGen - sub generator
    * @param {Object} extraOptions - extra options to pass to blueprint generator

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -315,7 +315,7 @@ module.exports = class JHipsterBaseBlueprintGenerator extends BaseGenerator {
    * @param {any} options - options to pass to blueprint generator
    * @return {Generator|undefined}
    */
-  _composeBlueprint(blueprint, subGen, extraOptions = {}) {
+  async _composeBlueprint(blueprint, subGen, extraOptions = {}) {
     blueprint = normalizeBlueprintName(blueprint);
     if (!this.configOptions.skipChecks && !this.options.skipChecks) {
       this._checkBlueprint(blueprint);
@@ -324,16 +324,17 @@ module.exports = class JHipsterBaseBlueprintGenerator extends BaseGenerator {
     const generatorName = packageNameToNamespace(blueprint);
     const generatorNamespace = `${generatorName}:${subGen}`;
     if (!this.env.isPackageRegistered(generatorName)) {
-      this.env.lookup({ filterPaths: true, packagePatterns: blueprint });
+      await this.env.lookup({ filterPaths: true, packagePatterns: blueprint });
     }
-    if (!this.env.get(generatorNamespace)) {
+    if (!(await this.env.get(generatorNamespace))) {
       this.debug(
-        `No blueprint found for blueprint ${chalk.yellow(blueprint)} and ${chalk.yellow(
-          subGen
+        `No blueprint found for blueprint ${chalk.yellow(blueprint)} and ${chalk.yellow(subGen)} with namespace ${chalk.yellow(
+          generatorNamespace
         )} subgenerator: falling back to default generator`
       );
       return undefined;
     }
+    this.debug(`Found blueprint ${chalk.yellow(blueprint)} and ${chalk.yellow(subGen)} with namespace ${chalk.yellow(generatorNamespace)}`);
 
     const finalOptions = {
       ...this.options,
@@ -342,7 +343,7 @@ module.exports = class JHipsterBaseBlueprintGenerator extends BaseGenerator {
       jhipsterContext: this,
     };
 
-    const blueprintGenerator = this.composeWith(generatorNamespace, finalOptions, true);
+    const blueprintGenerator = await this.composeWith(generatorNamespace, finalOptions, true);
     if (blueprintGenerator instanceof Error) {
       throw blueprintGenerator;
     }

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -39,8 +39,6 @@ const { EUREKA } = require('../../jdl/jhipster/service-discovery-types');
 const NO_CACHE_PROVIDER = cacheProviderOptions.NO;
 const execCmd = util.promisify(ChildProcess.exec);
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
@@ -64,8 +62,12 @@ module.exports = class extends BaseBlueprintGenerator {
     this.randomPassword = crypto.randomBytes(20).toString('hex');
     this.herokuSkipBuild = this.options.skipBuild;
     this.herokuSkipDeploy = this.options.skipDeploy || this.options.skipBuild;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_HEROKU);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_HEROKU);
+    }
   }
 
   _initializing() {
@@ -99,7 +101,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -248,7 +250,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -280,7 +282,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -300,7 +302,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -575,7 +577,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -622,7 +624,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -850,7 +852,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/kubernetes-helm/index.js
+++ b/generators/kubernetes-helm/index.js
@@ -36,11 +36,11 @@ const {
 } = require('../kubernetes-base');
 const statistics = require('../statistics');
 
-let useBlueprints;
 module.exports = class extends BaseDockerGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_KUBERNETES_HELM);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_KUBERNETES_HELM);
+    }
   }
 
   _initializing() {
@@ -59,7 +59,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -83,7 +83,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -111,7 +111,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -129,7 +129,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -138,7 +138,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -185,7 +185,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/kubernetes-knative/index.js
+++ b/generators/kubernetes-knative/index.js
@@ -41,11 +41,11 @@ const { GeneratorTypes } = require('../../jdl/jhipster/kubernetes-platform-types
 
 const { K8S } = GeneratorTypes;
 
-let useBlueprints;
 module.exports = class extends BaseDockerGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_KUBERNETES_KNATIVE);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_KUBERNETES_KNATIVE);
+    }
   }
 
   _initializing() {
@@ -85,7 +85,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -106,7 +106,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -134,7 +134,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -152,7 +152,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -161,7 +161,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -235,7 +235,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -35,11 +35,11 @@ const {
 } = require('../kubernetes-base');
 const statistics = require('../statistics');
 
-let useBlueprints;
 module.exports = class extends BaseDockerGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_KUBERNETES);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_KUBERNETES);
+    }
   }
 
   _initializing() {
@@ -56,7 +56,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -82,7 +82,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -110,7 +110,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -128,7 +128,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -137,7 +137,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -207,7 +207,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -31,8 +31,6 @@ const ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
 const REACT = constants.SUPPORTED_CLIENT_FRAMEWORKS.REACT;
 const VUE = constants.SUPPORTED_CLIENT_FRAMEWORKS.VUE;
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'namespace', ...features });
@@ -90,10 +88,12 @@ module.exports = class extends BaseBlueprintGenerator {
         }
       });
     }
+  }
 
-    useBlueprints =
-      !this.fromBlueprint &&
-      this.instantiateBlueprints('languages', { languages: this.languagesToApply, arguments: this.options.languages });
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints('languages', { languages: this.languagesToApply, arguments: this.options.languages });
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -118,7 +118,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -131,7 +131,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -170,7 +170,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -193,7 +193,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -214,7 +214,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -229,7 +229,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -258,7 +258,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -292,7 +292,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 };

--- a/generators/openapi-client/index.js
+++ b/generators/openapi-client/index.js
@@ -25,8 +25,6 @@ const prompts = require('./prompts');
 const { writeFiles, customizeFiles } = require('./files');
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
@@ -35,7 +33,12 @@ module.exports = class extends BaseBlueprintGenerator {
       type: Boolean,
       defaults: OpenAPIDefaultValues.REGEN,
     });
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_OPENAPI_CLIENT);
+  }
+
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_OPENAPI_CLIENT);
+    }
   }
 
   _initializing() {
@@ -55,7 +58,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -68,7 +71,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -101,7 +104,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -110,7 +113,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -119,7 +122,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 
@@ -146,7 +149,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   install() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._install();
   }
 
@@ -159,7 +162,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/openshift/index.js
+++ b/generators/openshift/index.js
@@ -38,13 +38,12 @@ const NO_DATABASE = databaseTypes.NO;
 const NO_SERVICE_DISCOVERY = serviceDiscoveryTypes.NO;
 const { EPHEMERAL, PERSISTENT } = StorageTypes;
 
-let useBlueprints;
-
 /* eslint-disable consistent-return */
 module.exports = class extends BaseDockerGenerator {
-  constructor(args, options, features) {
-    super(args, options, features);
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_OPENSHIFT);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_OPENSHIFT);
+    }
   }
 
   _initializing() {
@@ -90,7 +89,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -110,7 +109,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -159,7 +158,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -177,7 +176,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -186,7 +185,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -261,7 +260,7 @@ module.exports = class extends BaseDockerGenerator {
   }
 
   end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 

--- a/generators/page/index.js
+++ b/generators/page/index.js
@@ -27,8 +27,6 @@ const { PROTRACTOR } = require('../../jdl/jhipster/test-framework-types');
 
 const { VUE } = constants.SUPPORTED_CLIENT_FRAMEWORKS;
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
@@ -61,8 +59,12 @@ module.exports = class extends BaseBlueprintGenerator {
     this.loadRuntimeOptions();
 
     this.rootGenerator = this.env.rootGenerator() === this;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_PAGE);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_PAGE);
+    }
   }
 
   _initializing() {
@@ -81,7 +83,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -92,7 +94,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -110,7 +112,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -130,7 +132,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -147,7 +149,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -165,7 +167,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 
@@ -183,7 +185,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 };

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -54,8 +54,6 @@ const NO_CACHE = cacheTypes.NO;
 const NO_DATABASE = databaseTypes.NO;
 const NO_WEBSOCKET = websocketTypes.FALSE;
 
-let useBlueprints;
-
 module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'namespace', ...features });
@@ -75,11 +73,15 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
 
     // preserve old jhipsterVersion value for cleanup which occurs after new config is written into disk
     this.jhipsterOldVersion = this.jhipsterConfig.jhipsterVersion;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_SERVER);
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_SERVER);
+    }
 
     // Not using normal blueprints or this is a normal blueprint.
-    if (!useBlueprints || (this.fromBlueprint && this.sbsBlueprint)) {
+    if ((!this.fromBlueprint && !this.delegateToBlueprint) || (this.fromBlueprint && this.sbsBlueprint)) {
       this.setFeatures({
         customInstallTask: async function customInstallTask(preferredPm, defaultInstallTask) {
           const buildTool = this.jhipsterConfig.buildTool;
@@ -231,7 +233,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -251,7 +253,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -270,7 +272,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._configuring();
   }
 
@@ -290,7 +292,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get composing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._composing();
   }
 
@@ -310,7 +312,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -357,7 +359,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get preparing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._preparing();
   }
 
@@ -415,7 +417,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -428,7 +430,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 
@@ -600,7 +602,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._postWriting();
   }
 
@@ -632,7 +634,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   }
 
   get end() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._end();
   }
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -279,14 +279,14 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   // Public API method used by the getter and also by Blueprints
   _composing() {
     return {
-      composeCommon() {
-        this.composeWithJHipster(GENERATOR_COMMON, true);
+      async composeCommon() {
+        await this.composeWithJHipster(GENERATOR_COMMON, true);
       },
 
-      composeLanguages() {
+      async composeLanguages() {
         // We don't expose client/server to cli, composing with languages is used for test purposes.
         if (this.jhipsterConfig.enableTranslation === false) return;
-        this.composeWithJHipster(GENERATOR_LANGUAGES, true);
+        await this.composeWithJHipster(GENERATOR_LANGUAGES, true);
       },
     };
   }

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -45,8 +45,6 @@ const {
 const NO_CACHE_PROVIDER = cacheProviders.NO;
 const NO_MESSAGE_BROKER = messageBrokers.NO;
 
-let useBlueprints;
-
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
@@ -60,8 +58,12 @@ module.exports = class extends BaseBlueprintGenerator {
       description: 'default option',
     });
     this.defaultOption = this.options.default;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_SPRING_CONTROLLER, { arguments: [this.name] });
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_SPRING_CONTROLLER, { arguments: [this.name] });
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -94,7 +96,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -106,7 +108,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -120,7 +122,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -177,7 +179,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 };

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -27,7 +27,6 @@ const { GENERATOR_SPRING_SERVICE } = require('../generator-list');
 const { BASE_NAME, PACKAGE_NAME, PACKAGE_FOLDER, DATABASE_TYPE } = OptionNames;
 const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
 
-let useBlueprints;
 module.exports = class extends BaseBlueprintGenerator {
   constructor(args, options, features) {
     super(args, options, features);
@@ -41,8 +40,12 @@ module.exports = class extends BaseBlueprintGenerator {
       description: 'default option',
     });
     this.defaultOption = this.options.default;
+  }
 
-    useBlueprints = !this.fromBlueprint && this.instantiateBlueprints(GENERATOR_SPRING_SERVICE, { arguments: [this.name] });
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints(GENERATOR_SPRING_SERVICE, { arguments: [this.name] });
+    }
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -64,7 +67,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get initializing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._initializing();
   }
 
@@ -94,7 +97,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get prompting() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._prompting();
   }
 
@@ -108,7 +111,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._loading();
   }
 
@@ -122,7 +125,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get default() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._default();
   }
 
@@ -151,7 +154,7 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    if (useBlueprints) return;
+    if (this.delegateToBlueprint) return {};
     return this._writing();
   }
 };

--- a/generators/workspaces/index.js
+++ b/generators/workspaces/index.js
@@ -42,13 +42,17 @@ module.exports = class extends BaseBlueprintGenerator {
 
     if (this.options.help) return;
 
-    this.useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('workspaces');
-
     // Generate workspaces file only when option passed or regenerating
     this.generateWorkspaces = this.options.workspaces !== false || !!this.packageJson.get('workspaces');
 
     // When generating workspaces, save to .yo-rc.json. Use a dummy config otherwise.
     this.workspacesConfig = this.generateWorkspaces ? this.jhipsterConfig : {};
+  }
+
+  async _postConstruct() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints('workspaces');
+    }
 
     this.loadRuntimeOptions();
   }
@@ -106,7 +110,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get configuring() {
-    return this.useBlueprints ? undefined : this._configuring();
+    if (this.delegateToBlueprint) return {};
+    return this._configuring();
   }
 
   _loading() {
@@ -122,7 +127,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get loading() {
-    return this.useBlueprints ? undefined : this._loading();
+    if (this.delegateToBlueprint) return {};
+    return this._loading();
   }
 
   _writing() {
@@ -146,7 +152,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get writing() {
-    return this.useBlueprints ? undefined : this._writing();
+    if (this.delegateToBlueprint) return {};
+    return this._writing();
   }
 
   _postWriting() {
@@ -179,7 +186,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get postWriting() {
-    return this.useBlueprints ? undefined : this._postWriting();
+    if (this.delegateToBlueprint) return {};
+    return this._postWriting();
   }
 
   // Public API method used by the getter and also by Blueprints
@@ -199,7 +207,8 @@ module.exports = class extends BaseBlueprintGenerator {
   }
 
   get install() {
-    return this.useBlueprints ? undefined : this._install();
+    if (this.delegateToBlueprint) return {};
+    return this._install();
   }
 
   _detectNodePackageManager() {

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -93,7 +93,7 @@ describe('jhipster cli', () => {
     const commands = { mocked: {} };
     const generator = { mocked: {} };
     let oldArgv;
-    let callback;
+    let runArgs;
     before(() => {
       oldArgv = process.argv;
     });
@@ -113,7 +113,7 @@ describe('jhipster cli', () => {
         sourceRoot: () => '',
       };
       sandbox.stub(Environment.prototype, 'run').callsFake((...args) => {
-        callback(...args);
+        runArgs = args;
         return Promise.resolve();
       });
       sandbox.stub(Environment.prototype, 'composeWith');
@@ -121,12 +121,10 @@ describe('jhipster cli', () => {
     });
 
     const commonTests = () => {
-      it('should pass a defined command', done => {
-        callback = (command, _options) => {
-          expect(command).to.not.be.undefined;
-          done();
-        };
-        return mockCli({ commands });
+      it('should pass a defined command', async () => {
+        await mockCli({ commands });
+        const [command] = runArgs;
+        expect(command).to.not.be.undefined;
       });
     };
 
@@ -137,14 +135,12 @@ describe('jhipster cli', () => {
 
       commonTests();
 
-      it('should forward options', done => {
-        callback = (command, options) => {
-          expect(command).to.be.equal('jhipster:mocked');
-          expect(options.foo).to.be.true;
-          expect(options.fooBar).to.be.true;
-          done();
-        };
-        return mockCli({ commands });
+      it('should forward options', async () => {
+        await mockCli({ commands });
+        const [command, options] = runArgs;
+        expect(command).to.be.equal('jhipster:mocked');
+        expect(options.foo).to.be.true;
+        expect(options.fooBar).to.be.true;
       });
     });
 
@@ -156,14 +152,12 @@ describe('jhipster cli', () => {
 
       commonTests();
 
-      it('should forward argument and options', done => {
-        callback = (command, options) => {
-          expect(command).to.be.equal('jhipster:mocked Foo');
-          expect(options.foo).to.be.true;
-          expect(options.fooBar).to.be.true;
-          done();
-        };
-        return mockCli({ commands });
+      it('should forward argument and options', async () => {
+        await mockCli({ commands });
+        const [command, options] = runArgs;
+        expect(command).to.be.equal('jhipster:mocked Foo');
+        expect(options.foo).to.be.true;
+        expect(options.fooBar).to.be.true;
       });
     });
 
@@ -175,13 +169,12 @@ describe('jhipster cli', () => {
 
       commonTests();
 
-      it('should forward argument and options', done => {
-        callback = (command, options) => {
-          expect(command).to.be.equal('jhipster:mocked Foo Bar');
-          expect(options.foo).to.be.true;
-          expect(options.fooBar).to.be.true;
-          done();
-        };
+      it('should forward argument and options', async () => {
+        await mockCli({ commands });
+        const [command, options] = runArgs;
+        expect(command).to.be.equal('jhipster:mocked Foo Bar');
+        expect(options.foo).to.be.true;
+        expect(options.fooBar).to.be.true;
         return mockCli({ commands });
       });
     });
@@ -223,10 +216,9 @@ describe('jhipster cli', () => {
     });
 
     const commonTests = () => {
-      it('should pass a defined environment', done => {
+      it('should pass a defined environment', async () => {
         const cb = (_args, _options, env) => {
           expect(env).to.not.be.undefined;
-          done();
         };
         return mockCli({ commands, './mocked': cb });
       });
@@ -242,14 +234,13 @@ describe('jhipster cli', () => {
 
       commonTests();
 
-      it('should forward argument and options', done => {
+      it('should forward argument and options', async () => {
         const cb = (args, options) => {
           expect(args).to.eql(['Foo']);
           expect(options.foo).to.be.true;
           expect(options.fooBar).to.be.true;
-          done();
         };
-        return mockCli({ commands, './mocked': cb });
+        await mockCli({ commands, './mocked': cb });
       });
     });
 
@@ -263,14 +254,13 @@ describe('jhipster cli', () => {
 
       commonTests();
 
-      it('should forward argument and options', done => {
+      it('should forward argument and options', async () => {
         const cb = (args, options) => {
           expect(args).to.eql(['Foo']);
           expect(options.foo).to.be.false;
           expect(options.fooBar).to.be.false;
-          done();
         };
-        return mockCli({ commands, './mocked': cb });
+        await mockCli({ commands, './mocked': cb });
       });
     });
 
@@ -284,14 +274,13 @@ describe('jhipster cli', () => {
 
       commonTests();
 
-      it('should forward argument and options', done => {
+      it('should forward argument and options', async () => {
         const cb = (args, options, env) => {
           expect(args).to.eql([['Foo', 'Bar']]);
           expect(options.foo).to.be.true;
           expect(options.fooBar).to.be.true;
-          done();
         };
-        return mockCli({ commands, './mocked': cb });
+        await mockCli({ commands, './mocked': cb });
       });
     });
 
@@ -304,12 +293,11 @@ describe('jhipster cli', () => {
 
       commonTests();
 
-      it('should forward argument and options', done => {
+      it('should forward argument and options', async () => {
         const cb = (args, options, env) => {
           expect(args).to.eql([]);
           expect(options.foo).to.be.true;
           expect(options.fooBar).to.be.true;
-          done();
         };
         return mockCli({ commands, './mocked': cb });
       });


### PR DESCRIPTION
Node community is adopting esm and commonjs packages cannot depend on esm packages.
By allowing blueprints to switch to esm, will make easier esm adoption on generator-jhipster probably for v8.

Why this is needed?
`require()` doesn't exist on an esm module. It was replaced by the async `import()`.
So every operation that depend on dynamically loading a module (like a blueprint), need to be converted to async.
A constructor is always sync, as workaround, an async `_postConstruct` needs to be used to wait for the blueprint to be instantiated.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
