### PR TITLE
Fix error for expired oauth2 token in unit test

### DIFF
--- a/generators/server/templates/src/test/java/package/security/oauth2/AuthorizationHeaderUtilTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/oauth2/AuthorizationHeaderUtilTest.java.ejs
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -179,6 +180,20 @@ class AuthorizationHeaderUtilTest {
     }
 
     private OAuth2AuthorizedClient getTestOAuth2AuthorizedClient(boolean accessTokenExpired) {
+        Instant issuedAt = Instant.now();
+        Instant expiresAt;
+        if (accessTokenExpired) {
+            expiresAt = issuedAt.plus(Duration.ofNanos(1));
+            try {
+                Thread.sleep(1);
+            } catch (Exception e) {
+                fail("Error in Thread.sleep(1) : " + e.getMessage());
+            }
+        } else {
+            expiresAt = issuedAt.plus(Duration.ofMinutes(3));
+        }
+        OAuth2AccessToken token = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "tokenVal", issuedAt, expiresAt);
+
         return new OAuth2AuthorizedClient(
             ClientRegistration.withRegistrationId(VALID_REGISTRATION_ID)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
@@ -189,8 +204,7 @@ class AuthorizationHeaderUtilTest {
                 .tokenUri("https://localhost:8080/auth/realms/master/protocol/openid-connect/token")
                 .build(),
             "sub",
-            new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "tokenVal", Instant.now(),
-                accessTokenExpired ? Instant.now() : Instant.now().plus(Duration.ofMinutes(3))),
+            token,
             new OAuth2RefreshToken("refreshVal", Instant.now()));
     }
 


### PR DESCRIPTION
OAuth2AccessToken require expiryTime to be after issuedTime.

Fix #16570

<!--
PR description.
-->
I've redone this PR reverting the change of the enforcer plugin back to 3.0.0-M3,
The enforcer plugin now remains at version 3.0.0

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
