### PR TITLE
Adjusts to upgrade on files conflicts.

### DIFF
--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -158,6 +158,7 @@ function runGenerator(command, { cwd, fork, env }, generatorOptions = {}) {
     forceNoFiltering: undefined,
     unidirectionalRelationships: undefined,
     localConfigOnly: undefined,
+    commandName: undefined,
     fromJdl: true,
   };
 

--- a/cli/program.js
+++ b/cli/program.js
@@ -168,6 +168,7 @@ const buildCommands = ({ program, commands = {}, envBuilder, env, loadCommand })
         const options = {
           ...program.opts(),
           ...cmdOptions,
+          commandName: cmdName,
         };
         if (options.installPath) {
           // eslint-disable-next-line no-console

--- a/generators/bootstrap/index.js
+++ b/generators/bootstrap/index.js
@@ -188,7 +188,8 @@ module.exports = class extends BaseGenerator {
     if (!skipPrettier) {
       const prettierOptions = { packageJson: true, java: !this.skipServer && !this.jhipsterConfig.skipServer };
       // Prettier is clever, it uses correct rules and correct parser according to file extension.
-      transformStreams.push(prettierTransform(prettierOptions, this, this.options.ignoreErrors));
+      const ignoreErrors = this.options.commandName === 'upgrade' || this.options.ignoreErrors;
+      transformStreams.push(prettierTransform(prettierOptions, this, ignoreErrors));
     }
 
     transformStreams.push(createConflicterCheckTransform(this.env.conflicter, conflicterStatus), createConflicterStatusTransform());

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -36,6 +36,9 @@ const prettierTransform = function (options, generator, transformOptions = {}) {
       if (isFileStateDeleted(file)) {
         return file;
       }
+      if (!file.contents) {
+        throw new Error(`File content doesn't exit for ${file.relative}`);
+      }
       /* resolve from the projects config */
       let fileContent;
       try {
@@ -58,12 +61,17 @@ const prettierTransform = function (options, generator, transformOptions = {}) {
         file.contents = Buffer.from(data);
         return file;
       } catch (error) {
-        const errorMessage = `Error parsing file ${file.relative}: ${error}
+        let errorMessage;
+        if (fileContent) {
+          errorMessage = `Error parsing file ${file.relative}: ${error}
 
 At: ${fileContent
-          .split('\n')
-          .map((value, idx) => `${idx + 1}: ${value}`)
-          .join('\n')}`;
+            .split('\n')
+            .map((value, idx) => `${idx + 1}: ${value}`)
+            .join('\n')}`;
+        } else {
+          errorMessage = `Unknown prettier error: ${error}`;
+        }
         if (ignoreErrors) {
           generator.warning(errorMessage);
           return file;

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -37,7 +37,7 @@ const prettierTransform = function (options, generator, transformOptions = {}) {
         return file;
       }
       if (!file.contents) {
-        throw new Error(`File content doesn't exit for ${file.relative}`);
+        throw new Error(`File content doesn't exist for ${file.relative}`);
       }
       /* resolve from the projects config */
       let fileContent;

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -164,7 +164,7 @@ module.exports = class extends BaseGenerator {
       generatorCommand = `"${generatorDir.replace('\n', '')}/jhipster"`;
     }
     const skipChecksOption = this.skipChecks ? '--skip-checks' : '';
-    const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install --skip-git --no-insight ${skipChecksOption}`;
+    const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install --skip-git --ignore-errors --no-insight ${skipChecksOption}`;
     this.info(regenerateCmd);
     try {
       childProcess.execSync(regenerateCmd, { stdio: 'inherit' });


### PR DESCRIPTION
When file conflicts, it becomes invalid.
So prettier fails to parse its configuration (package.json, .prettierrc) or to parse the file.
Upgrade must ignore prettier errors.

Related to https://github.com/jhipster/generator-jhipster/issues/17072.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
