### PR TITLE
add sort converter to elasticsearch search repository

### DIFF
--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -173,6 +173,16 @@ const serverFiles = {
       ],
     },
     {
+      condition: generator => generator.searchEngine === ELASTICSEARCH && !generator.embedded && !generator.paginationNo,
+      path: SERVER_MAIN_SRC_DIR,
+      templates: [
+        {
+          file: 'package/repository/search/SortToFieldSortBuilderConverter.java',
+          renameTo: generator => `${generator.entityAbsoluteFolder}/repository/search/SortToFieldSortBuilderConverter.java`,
+        },
+      ],
+    },
+    {
       condition: generator => !generator.reactive && !generator.embedded && generator.databaseType !== COUCHBASE,
       path: SERVER_MAIN_SRC_DIR,
       templates: [

--- a/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
@@ -29,6 +29,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
   <%_ } _%>
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+
+
 <%_ } _%>
 <%_ if (reactive) { _%>
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchTemplate;
@@ -72,9 +78,19 @@ class <%= entityClass %>SearchRepositoryInternalImpl implements <%= entityClass 
 
     @Override
     public Flux<<%= entityClass %>> search(String query<% if (!paginationNo) { %>, Pageable pageable<% } %>) {
-        NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(queryStringQuery(query));
   <%_ if (!paginationNo) { _%>
-        nativeSearchQuery.setPageable(pageable);
+        List<FieldSortBuilder> builders = new SortToFieldSortBuilderConverter().convert(pageable.getSort());
+
+        NativeSearchQueryBuilder queryBuilder = new NativeSearchQueryBuilder().withQuery(queryStringQuery(query))
+            .withPageable(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+
+        builders.stream().forEach(builder -> {
+            queryBuilder.withSort(builder);
+        });
+
+        NativeSearchQuery nativeSearchQuery = queryBuilder.build();
+  <%_ } else { _%>
+        NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(queryStringQuery(query));
   <%_ } _%>
         return reactiveElasticsearchTemplate
             .search(nativeSearchQuery, <%= entityClass %>.class)

--- a/generators/entity-server/templates/src/main/java/package/repository/search/SortToFieldSortBuilderConverter.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/search/SortToFieldSortBuilderConverter.java.ejs
@@ -1,0 +1,24 @@
+package <%= entityAbsolutePackage %>.repository.search;
+
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.domain.Sort;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SortToFieldSortBuilderConverter implements Converter<Sort, List<FieldSortBuilder>> {
+
+    @Override
+    public List<FieldSortBuilder> convert(Sort sort) {
+        List<FieldSortBuilder> builders = new ArrayList<>();
+        sort.stream().forEach(order -> {
+            String property = order.getProperty() + ".keyword";
+            SortOrder sortOrder = SortOrder.fromString(order.getDirection().name());
+            builders.add(new FieldSortBuilder(property).order(sortOrder));
+
+        });
+        return builders;
+    }
+}

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -43,6 +43,56 @@ describe('JHipster generator for entity', () => {
           assert.file(expectedFiles.gatling);
         });
       });
+
+      describe('search, no dto, no service, pagination', () => {
+        before(async () => {
+          await helpers
+            .run(require.resolve('../generators/entity'))
+            .doInDir(dir => {
+              fse.copySync(path.join(__dirname, '../test/templates/default-elasticsearch'), dir);
+            })
+            .withArguments(['foo'])
+            .withPrompts({
+              fieldAdd: false,
+              relationshipAdd: false,
+              dto: NO_DTO,
+              service: NO_SERVICE,
+              pagination: PAGINATION,
+            });
+        });
+
+        it('does creates search files', () => {
+          assert.file(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/search/FooSearchRepository.java`);
+          assert.file(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/search/SortToFieldSortBuilderConverter.java`);
+          assert.file(expectedFiles.server);
+          assert.file(expectedFiles.gatling);
+        });
+      });
+
+      describe('search, no dto, no service, infinite-scroll', () => {
+        before(async () => {
+          await helpers
+            .run(require.resolve('../generators/entity'))
+            .doInDir(dir => {
+              fse.copySync(path.join(__dirname, '../test/templates/default-elasticsearch'), dir);
+            })
+            .withArguments(['foo'])
+            .withPrompts({
+              fieldAdd: false,
+              relationshipAdd: false,
+              dto: NO_DTO,
+              service: NO_SERVICE,
+              pagination: INFINITE_SCROLL,
+            });
+        });
+
+        it('does creates search files', () => {
+          assert.file(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/search/FooSearchRepository.java`);
+          assert.file(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/search/SortToFieldSortBuilderConverter.java`);
+          assert.file(expectedFiles.server);
+          assert.file(expectedFiles.gatling);
+        });
+      });
     });
 
     context('monolith with couchbase FTS', () => {


### PR DESCRIPTION
Fix #17018

Add SortToFieldSortBuilderConverter for SearchRepositoryInternal to append ".keyword" suffix to sort property for elasticsearch paginated queries.
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
