### PR TITLE
Prepare for angular 13

### DIFF
--- a/generators/client/templates/angular/jest.conf.js.ejs
+++ b/generators/client/templates/angular/jest.conf.js.ejs
@@ -22,6 +22,7 @@ const { compilerOptions: { paths = {}, baseUrl = './' } } = require('./tsconfig.
 const environment = require('./webpack/environment');
 
 module.exports = {
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$|dayjs/esm)'],
   globals: {
     ...environment,
   },

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.spec.ts.ejs
@@ -16,16 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (enableTranslation) { _%>
-jest.mock('@ngx-translate/core');
-<%_ } _%>
-
 import { ComponentFixture, TestBed, waitForAsync, inject, tick, fakeAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 <%_ if (enableTranslation) { _%>
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 <%_ } _%>
 
 import { EMAIL_ALREADY_USED_TYPE, LOGIN_ALREADY_USED_TYPE } from 'app/config/error.constants';
@@ -40,9 +36,14 @@ describe('RegisterComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
+        imports: [
+<%_ if (enableTranslation) { _%>
+          TranslateModule.forRoot(),
+<%_ } _%>
+          HttpClientTestingModule
+        ],
         declarations: [RegisterComponent],
-        providers: [FormBuilder<% if (enableTranslation) { %>, TranslateService<% } %>],
+        providers: [FormBuilder],
       })
         .overrideTemplate(RegisterComponent, '')
         .compileComponents();
@@ -67,10 +68,10 @@ describe('RegisterComponent', () => {
 
   it('should update success to true after creating an account', inject(
     [RegisterService<% if (enableTranslation) { %>, TranslateService<% } %>],
-    fakeAsync((service: RegisterService<% if (enableTranslation) { %>, mockLanguageService: TranslateService<% } %>) => {
+    fakeAsync((service: RegisterService<% if (enableTranslation) { %>, mockTranslateService: TranslateService<% } %>) => {
       jest.spyOn(service, 'save').mockReturnValue(of({}));
 <%_ if (enableTranslation) { _%>
-      mockLanguageService.currentLang = '<%= nativeLanguage %>';
+      mockTranslateService.currentLang = '<%= nativeLanguage %>';
 <%_ } _%>
       comp.registerForm.patchValue({
         password: 'password',

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.spec.ts.ejs
@@ -16,9 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (enableTranslation) { _%>
-jest.mock('@ngx-translate/core');
-<%_ } _%>
 jest.mock('app/core/auth/account.service');
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
@@ -26,7 +23,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormBuilder } from '@angular/forms';
 import { throwError, of } from 'rxjs';
 <%_ if (enableTranslation) { _%>
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateModule } from '@ngx-translate/core';
 <%_ } _%>
 
 import { AccountService } from 'app/core/auth/account.service';
@@ -52,9 +49,14 @@ describe('SettingsComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
+        imports: [
+<%_ if (enableTranslation) { _%>
+          TranslateModule.forRoot(),
+<%_ } _%>
+          HttpClientTestingModule
+        ],
         declarations: [SettingsComponent],
-        providers: [FormBuilder<% if (enableTranslation) { %>, TranslateService<% } %>, AccountService],
+        providers: [FormBuilder, AccountService],
       })
         .overrideTemplate(SettingsComponent, '')
         .compileComponents();

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.spec.ts.ejs
@@ -19,13 +19,13 @@
 <%_
 const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
-jest.mock('@angular/router');
 jest.mock('app/core/auth/account.service');
 
 import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
 import { UserManagementService } from '../service/user-management.service';
@@ -53,9 +53,9 @@ describe('User Management Component', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
+        imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
         declarations: [UserManagementComponent],
-        providers: [Router, { provide: ActivatedRoute, useValue: { data, queryParamMap } }, AccountService],
+        providers: [{ provide: ActivatedRoute, useValue: { data, queryParamMap } }, AccountService],
       })
         .overrideTemplate(UserManagementComponent, '')
         .compileComponents();

--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -30,7 +30,7 @@ import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { CookieService } from 'ngx-cookie-service';
 <%_ } _%>
 import { NgxWebstorageModule<% if (enableTranslation) { %>, SessionStorageService<% } %> } from 'ngx-webstorage';
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 import { NgbDateAdapter, NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
 
 import { ApplicationConfigService } from 'app/core/config/application-config.service';

--- a/generators/client/templates/angular/src/main/webapp/app/config/datepicker-adapter.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/config/datepicker-adapter.ts.ejs
@@ -21,7 +21,7 @@
  */
 import { Injectable } from '@angular/core';
 import { NgbDateAdapter, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 
 @Injectable()
 export class NgbDateDayjsAdapter extends NgbDateAdapter<dayjs.Dayjs> {

--- a/generators/client/templates/angular/src/main/webapp/app/config/dayjs.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/config/dayjs.ts.ejs
@@ -16,10 +16,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import * as dayjs from 'dayjs';
-import * as customParseFormat from 'dayjs/plugin/customParseFormat';
-import * as duration from 'dayjs/plugin/duration';
-import * as relativeTime from 'dayjs/plugin/relativeTime';
+import dayjs from 'dayjs/esm';
+import customParseFormat from 'dayjs/esm/plugin/customParseFormat';
+import duration from 'dayjs/esm/plugin/duration';
+import relativeTime from 'dayjs/esm/plugin/relativeTime';
 
 // jhipster-needle-i18n-language-dayjs-imports - JHipster will import languages from dayjs here
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
@@ -16,20 +16,18 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-jest.mock('@angular/router');
-<%_ if (enableTranslation) { _%>
-jest.mock('@ngx-translate/core');
-<%_ } _%>
 jest.mock('app/core/auth/state-storage.service');
 <%_ if (communicationSpringWebsocket) { _%>
 jest.mock('app/core/tracker/tracker.service');
 <%_ } _%>
 
 import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
 <%_ } _%>
 import { NgxWebstorageModule<% if (enableTranslation) { %>, SessionStorageService<% } %> } from 'ngx-webstorage';
 
@@ -76,16 +74,19 @@ describe('Account Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, NgxWebstorageModule.forRoot()],
-      providers: [
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule.withRoutes([]),
 <%_ if (enableTranslation) { _%>
-        TranslateService,
+        TranslateModule.forRoot(),
 <%_ } _%>
+        NgxWebstorageModule.forRoot()
+      ],
+      providers: [
 <%_ if (communicationSpringWebsocket) { _%>
         TrackerService,
 <%_ } _%>
         StateStorageService,
-        Router,
       ],
     });
 
@@ -96,11 +97,15 @@ describe('Account Service', () => {
     httpMock = TestBed.inject(HttpTestingController);
     mockStorageService = TestBed.inject(StateStorageService);
     mockRouter = TestBed.inject(Router);
+    jest.spyOn(mockRouter, 'navigateByUrl').mockImplementation(() => Promise.resolve(true));
 <%_ if (communicationSpringWebsocket) { _%>
+
     mockTrackerService = TestBed.inject(TrackerService);
 <%_ } _%>
 <%_ if (enableTranslation) { _%>
+
     mockTranslateService = TestBed.inject(TranslateService);
+    jest.spyOn(mockTranslateService, 'use').mockImplementation(() => of(''));
     sessionStorageService = TestBed.inject(SessionStorageService);
 <%_ } _%>
   });

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -21,8 +21,8 @@ import { Location } from '@angular/common';
 import { Router, NavigationEnd, Event } from '@angular/router';
 import { Subscription, ReplaySubject, Subject } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import * as SockJS from 'sockjs-client';
-import * as Stomp from 'webstomp-client';
+import SockJS from 'sockjs-client';
+import Stomp, { Client, Subscription as StompSubscription, ConnectionHeaders, Message } from 'webstomp-client';
 
 <%_ if (authenticationTypeSession) { _%>
 import { CSRFService } from 'app/core/auth/csrf.service';
@@ -34,11 +34,11 @@ import { TrackerActivity } from './tracker-activity.model';
 
 @Injectable({ providedIn: 'root' })
 export class TrackerService {
-  private stompClient: Stomp.Client | null = null;
+  private stompClient: Client | null = null;
   private routerSubscription: Subscription | null = null;
   private connectionSubject: ReplaySubject<void> = new ReplaySubject(1);
   private connectionSubscription: Subscription | null = null;
-  private stompSubscription: Stomp.Subscription | null = null;
+  private stompSubscription: StompSubscription | null = null;
   private listenerSubject: Subject<TrackerActivity> = new Subject();
 
   constructor(
@@ -67,7 +67,7 @@ export class TrackerService {
 <%_ } _%>
     const socket: WebSocket = new SockJS(url);
     this.stompClient = Stomp.over(socket, { protocols: ['v12.stomp'] });
-    const headers: Stomp.ConnectionHeaders = {};
+    const headers: ConnectionHeaders = {};
 <%_ if (authenticationTypeSession) { _%>
     headers['X-XSRF-TOKEN'] = this.csrfService.getCSRF('XSRF-TOKEN');
 <%_ } _%>
@@ -111,7 +111,7 @@ export class TrackerService {
 
     this.connectionSubscription = this.connectionSubject.subscribe(() => {
       if (this.stompClient) {
-        this.stompSubscription = this.stompClient.subscribe('/topic/tracker', (data: Stomp.Message) => {
+        this.stompSubscription = this.stompClient.subscribe('/topic/tracker', (data: Message) => {
           this.listenerSubject.next(JSON.parse(data.body));
         });
       }

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.spec.ts.ejs
@@ -17,15 +17,14 @@
  limitations under the License.
 -%>
 jest.mock('app/core/auth/account.service');
-<%_ if (!authenticationTypeOauth2) { _%>
-jest.mock('@angular/router');
-<% } else { %>
+<%_ if (authenticationTypeOauth2) { _%>
 jest.mock('app/login/login.service');
 <%_ } _%>
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 <%_ if (!authenticationTypeOauth2) { _%>
 import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 <%_ } _%>
 import { of<% if (!authenticationTypeOauth2) { %>, Subject<% } %> } from 'rxjs';
 
@@ -60,8 +59,16 @@ describe('Home Component', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
+<%_ if (!authenticationTypeOauth2) { _%>
+        imports: [RouterTestingModule.withRoutes([])],
+<%_ } _%>
         declarations: [HomeComponent],
-        providers: [AccountService, <% if (!authenticationTypeOauth2) { %>Router<% } else { %>LoginService<% } %>],
+        providers: [
+          AccountService,
+<%_ if (authenticationTypeOauth2) { _%>
+          LoginService
+<%_ } _%>
+        ],
       })
         .overrideTemplate(HomeComponent, '')
         .compileComponents();
@@ -75,7 +82,10 @@ describe('Home Component', () => {
     mockAccountService.identity = jest.fn(() => of(null));
     mockAccountService.getAuthenticationState = jest.fn(() => of(null));
 <%_ if (!authenticationTypeOauth2) { _%>
+
     mockRouter = TestBed.inject(Router);
+    jest.spyOn(mockRouter, 'navigate').mockImplementation(() => of(true).toPromise());
+
 <%_ } else { _%>
     mockLoginService = TestBed.inject(LoginService);
 <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -21,7 +21,7 @@ import { Title } from '@angular/platform-browser';
 import { Router, ActivatedRouteSnapshot, NavigationEnd } from '@angular/router';
 <%_ if (enableTranslation) { _%>
 import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 <%_ } _%>
 
 import { AccountService } from 'app/core/auth/account.service';

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.spec.ts.ejs
@@ -16,12 +16,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-jest.mock('@angular/router');
 jest.mock('app/login/login.service');
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 import { NgxWebstorageModule } from 'ngx-webstorage';
 <%_ if (enableTranslation) { _%>
@@ -55,9 +54,16 @@ describe('Navbar Component', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, NgxWebstorageModule.forRoot()<% if (enableTranslation) { %>, TranslateModule.forRoot()<% } %>],
+        imports: [
+          HttpClientTestingModule,
+          RouterTestingModule.withRoutes([]),
+<%_ if (enableTranslation) { _%>
+          TranslateModule.forRoot(),
+<%_ } _%>
+          NgxWebstorageModule.forRoot()
+        ],
         declarations: [NavbarComponent],
-        providers: [Router, LoginService],
+        providers: [LoginService],
       })
         .overrideTemplate(NavbarComponent, '')
         .compileComponents();

--- a/generators/client/templates/angular/src/main/webapp/app/login/login.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/login/login.component.spec.ts.ejs
@@ -16,7 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-jest.mock('@angular/router');
 jest.mock('app/core/auth/account.service');
 jest.mock('app/login/login.service');
 
@@ -24,6 +23,7 @@ import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { Router, Navigation } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of, throwError } from 'rxjs';
 
 import { AccountService } from 'app/core/auth/account.service';
@@ -41,11 +41,11 @@ describe('LoginComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
+        imports: [RouterTestingModule.withRoutes([])],
         declarations: [LoginComponent],
         providers: [
           FormBuilder,
           AccountService,
-          Router,
           {
             provide: LoginService,
             useValue: {
@@ -63,6 +63,7 @@ describe('LoginComponent', () => {
     fixture = TestBed.createComponent(LoginComponent);
     comp = fixture.componentInstance;
     mockRouter = TestBed.inject(Router);
+    jest.spyOn(mockRouter, 'navigate').mockImplementation(() => of(true).toPromise());
     mockLoginService = TestBed.inject(LoginService);
     mockAccountService = TestBed.inject(AccountService);
   });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/date/duration.pipe.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/date/duration.pipe.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { Pipe, PipeTransform } from '@angular/core';
 
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 
 @Pipe({
   name: 'duration',

--- a/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-date.pipe.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-date.pipe.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 
 import { FormatMediumDatePipe } from './format-medium-date.pipe';
 

--- a/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-date.pipe.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-date.pipe.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { Pipe, PipeTransform } from '@angular/core';
 
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 
 @Pipe({
   name: 'formatMediumDate',

--- a/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-datetime.pipe.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-datetime.pipe.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 
 import { FormatMediumDatetimePipe } from './format-medium-datetime.pipe';
 

--- a/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-datetime.pipe.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/date/format-medium-datetime.pipe.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { Pipe, PipeTransform } from '@angular/core';
 
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 
 @Pipe({
   name: 'formatMediumDatetime',

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -33,6 +33,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "target": "es2017",
     "module": "es2020",
     "lib": ["es2018", "dom"]

--- a/generators/client/templates/angular/tsconfig.spec.json.ejs
+++ b/generators/client/templates/angular/tsconfig.spec.json.ejs
@@ -19,7 +19,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "emitDecoratorMetadata": true,
     "outDir": "<%= BUILD_DIR %>out-tsc/spec",
     "types": ["jest", "node"]
   },

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -23,7 +23,7 @@ const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields);
 const enumImports = generateEntityClientEnumImports(fields);
 %>
 <%_ if (fieldsContainInstant || fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 <%_ } _%>
 <%_ typeImports.forEach((importedPath, importedType) => { _%>
     <%_ if (importedType !== `I${entityAngularName}`) { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.spec.ts.ejs
@@ -21,17 +21,13 @@ const entityArrayOptionalChainSymbol = paginationInfiniteScroll ? '' : '?.';
 const order = paginationInfiniteScroll ? 'asc' : 'desc';
 const testEntityPrimaryKey = generateTestEntityPrimaryKey(primaryKey, 0);
 _%>
-<%_ if (paginationPagination || searchEngine) { _%>
-jest.mock('@angular/router');
-<%_ } _%>
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-<%_ if (paginationPagination) { _%>
-import { ActivatedRoute, Router } from '@angular/router';
-<%_ } else if (searchEngine) { _%>
+<%_ if (paginationPagination || searchEngine) { _%>
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 <%_ } _%>
 import { of } from 'rxjs';
 
@@ -46,11 +42,15 @@ describe('<%= entityAngularName %> Management Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [
+<%_ if (paginationPagination || searchEngine) { _%>
+              RouterTestingModule.withRoutes([{ path: '<%= entityPage %>', component: <%= entityAngularName %>Component }]),
+<%_ } _%>
+              HttpClientTestingModule
+            ],
             declarations: [<%= entityAngularName %>Component],
 <%_ if (paginationPagination) { _%>
             providers: [
-                Router,
                 {
                     provide: ActivatedRoute,
                     useValue: {

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/route/entity-management-routing-resolve.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/route/entity-management-routing-resolve.service.spec.ts.ejs
@@ -19,12 +19,11 @@
 <%_
 const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
-jest.mock('@angular/router');
-
 import { TestBed } from '@angular/core/testing';
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
 import { I<%= entityAngularName %>, <%= entityAngularName %> } from '../<%= entityFileName %>.model';
@@ -41,11 +40,21 @@ describe('<%= entityAngularName %> routing resolve service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [Router, ActivatedRouteSnapshot],
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: convertToParamMap({})
+            },
+          },
+        },
+      ],
     });
     mockRouter = TestBed.inject(Router);
-    mockActivatedRouteSnapshot = TestBed.inject(ActivatedRouteSnapshot);
+    jest.spyOn(mockRouter, 'navigate').mockImplementation(() => of(true).toPromise());
+    mockActivatedRouteSnapshot = TestBed.inject(ActivatedRoute).snapshot;
     routingResolveService = TestBed.inject(<%= entityAngularName %>RoutingResolveService);
     service = TestBed.inject(<%= entityAngularName %>Service);
     result<%= entityAngularName %> = undefined;

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.spec.ts.ejs
@@ -25,7 +25,7 @@ _%>
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 <%_ if (fieldsContainDate) { _%>
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 <%_ } _%>
 
 <%_ if (fieldsContainDate) { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.ts.ejs
@@ -27,7 +27,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 <%_ if (fieldsContainDate) { _%>
 import { map } from 'rxjs/operators';
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 <%_ } _%>
 
 import { isPresent } from 'app/core/util/operators';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/update/entity-management-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/update/entity-management-update.component.spec.ts.ejs
@@ -25,14 +25,13 @@ const allRelationshipsByEntityNeedingOptions = Object
 const testEntityPrimaryKey0 = generateTestEntityPrimaryKey(primaryKey, 0);
 const testEntityPrimaryKey1 = generateTestEntityPrimaryKey(primaryKey, 1);
 _%>
-jest.mock('@angular/router');
-
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { of, Subject } from 'rxjs';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, Subject, from } from 'rxjs';
 
 import { <%= entityAngularName %>Service } from '../service/<%= entityFileName %>.service';
 import { I<%= entityAngularName %>, <%= entityAngularName %> } from '../<%= entityFileName %>.model';
@@ -62,9 +61,17 @@ describe('<%= entityAngularName %> Management Update Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
             declarations: [<%= entityAngularName %>UpdateComponent],
-            providers: [FormBuilder, ActivatedRoute],
+            providers: [
+              FormBuilder,
+              {
+                provide: ActivatedRoute,
+                useValue: {
+                  params: from([{}]),
+                },
+              },
+            ]
         })
         .overrideTemplate(<%= entityAngularName %>UpdateComponent, '')
         .compileComponents();

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/update/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/update/entity-management-update.component.ts.ejs
@@ -43,7 +43,7 @@ import { Observable } from 'rxjs';
 import { finalize<% if (relationships.some(rel => rel.ownerSide === true)) { %>, map<% } %> } from 'rxjs/operators';
 
 <%_ if (fieldsContainInstant || fieldsContainZonedDateTime) { _%>
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs/esm';
 import { DATE_TIME_FORMAT } from 'app/config/input.constants';
 <%_ } _%>
 

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -42,7 +42,7 @@ import {
     <%_ } _%>
 } from './<%= entityFileName %>.page-object';
 <%_ if (fieldsContainBlobOrImage) { _%>
-import * as path from 'path';
+import path from 'path';
 <%_ } _%>
 
 const expect = chai.expect;

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -355,7 +355,8 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
     }
     try {
       const content = languages.reduce(
-        (content, language) => `${content}import 'dayjs/locale/${this.getDayjsLocaleId(language)}'\n`,
+        (content, language) =>
+          `${content}import 'dayjs/${this.clientFrameworkAngular ? 'esm/' : ''}locale/${this.getDayjsLocaleId(language)}'\n`,
         '// jhipster-needle-i18n-language-dayjs-imports - JHipster will import languages from dayjs here\n'
       );
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2636,7 +2636,11 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
     if (options.language) {
       // workaround double options parsing, remove once generator supports skipping parse options
       const languages = options.language.flat();
-      this.jhipsterConfig.languages = [...this.jhipsterConfig.languages, ...languages];
+      if (languages.length === 1 && languages[0] === 'false') {
+        this.jhipsterConfig.enableTranslation = false;
+      } else {
+        this.jhipsterConfig.languages = [...this.jhipsterConfig.languages, ...languages];
+      }
     }
     if (options.nativeLanguage) {
       if (typeof options.nativeLanguage === 'string') {


### PR DESCRIPTION
Split angular 13 preparation from https://github.com/jhipster/generator-jhipster/pull/16961.

For some reason https://github.com/jhipster/generator-jhipster/pull/16961 breaks angular microfrontend.
Move preparation here to reduce that PR and let that PR to focus on the microfrontend failure.

Angular 13 generated packages are esm now.
- Jest mock cannot mock an esm package, so switch to an alternative.
- Switch dayjs to use esm exports. Requires changes to tsconfig and jest.config.

Related to https://github.com/jhipster/generator-jhipster/issues/16960
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
