### PR TITLE
Override angular webpack version.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,6 @@ updates:
       - 'theme: angular'
       - 'theme: dependencies'
     ignore:
-      # Must match @angular-devkit/build-webpack dependency https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/build_webpack/package.json#L16
-      - dependency-name: 'webpack'
       # https://github.com/ng-bootstrap/ng-bootstrap/issues/3899
       - dependency-name: 'bootstrap'
         versions: ['>=5']

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -125,10 +125,12 @@
     "rimraf": "<%= dependabotPackageJson.devDependencies['rimraf'] %>",
     "ts-jest": "<%= dependabotPackageJson.devDependencies['ts-jest'] %>",
     "typescript": "<%= dependabotPackageJson.devDependencies['typescript'] %>",
-    "webpack": "<%= dependabotPackageJson.devDependencies['webpack'] %>",
     "webpack-bundle-analyzer": "<%= dependabotPackageJson.devDependencies['webpack-bundle-analyzer'] %>",
     "webpack-merge": "<%= dependabotPackageJson.devDependencies['webpack-merge'] %>",
     "webpack-notifier": "<%= dependabotPackageJson.devDependencies['webpack-notifier'] %>"
+  },
+  "overrides": {
+    "webpack": "<%= dependabotPackageJson.devDependencies['webpack'] %>"
   },
   "engines": {
     "node": ">=<%= NODE_VERSION %>"


### PR DESCRIPTION
Use new npm overrides to force webpack version.

angular-cli force a specific version and requires it to be the same.
By forcing our version we will not need to manually since webpack version.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
