### PR TITLE
Bump node to 16.13.1 and adjust @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
       # https://github.com/ng-bootstrap/ng-bootstrap/issues/3899
       - dependency-name: 'bootstrap'
         versions: ['>=5']
+      # Should match generated project node major version.
+      - dependency-name: '@types/node'
+        versions: ['>=17']
 
   - package-ecosystem: 'npm'
     directory: '/generators/common/templates/'
@@ -57,6 +60,10 @@ updates:
     labels:
       - 'theme: react'
       - 'theme: dependencies'
+    ignore:
+      # Should match generated project node major version.
+      - dependency-name: '@types/node'
+        versions: ['>=17']
 
   - package-ecosystem: 'npm'
     directory: '/generators/client/templates/vue/'
@@ -74,6 +81,9 @@ updates:
       # https://github.com/bootstrap-vue/bootstrap-vue/issues/5507
       - dependency-name: 'bootstrap'
         versions: ['>=5']
+      # Should match generated project node major version.
+      - dependency-name: '@types/node'
+        versions: ['>=17']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [16.13.0]
+        node_version: [16.13.1]
         os: [ubuntu-20.04]
         cache: [other]
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN \
        exit 1; \
        ;; \
   esac; \
-  wget https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-$ARCH.tar.gz -O /tmp/node.tar.gz && \
+  wget https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-$ARCH.tar.gz -O /tmp/node.tar.gz && \
   tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
   # upgrade npm
   npm install -g npm@7 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1
 FROM eclipse-temurin:11-focal
+
+# copy sources
+COPY . /home/jhipster/generator-jhipster
+
 RUN \
   # configure the "jhipster" user
   groupadd jhipster && \
@@ -34,7 +38,8 @@ RUN \
        exit 1; \
        ;; \
   esac; \
-  wget https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-$ARCH.tar.gz -O /tmp/node.tar.gz && \
+  JHI_NODE_VERSION="$(/home/jhipster/generator-jhipster/test-integration/scripts/99-print-node-version.sh)"; \
+  wget https://nodejs.org/dist/v$JHI_NODE_VERSION/node-v$JHI_NODE_VERSION-linux-$ARCH.tar.gz -O /tmp/node.tar.gz && \
   tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
   # upgrade npm
   npm install -g npm@7 && \
@@ -47,9 +52,6 @@ RUN \
     /var/lib/apt/lists/* \
     /tmp/* \
     /var/tmp/*
-
-# copy sources
-COPY . /home/jhipster/generator-jhipster
 
 RUN \
   # install jhipster

--- a/generators/client/templates/angular/package.json
+++ b/generators/client/templates/angular/package.json
@@ -21,7 +21,7 @@
     "@angular-builders/custom-webpack": "13.0.0",
     "@angular-builders/jest": "13.0.2",
     "@angular-eslint/eslint-plugin": "13.0.1",
-    "@types/node": "17.0.4",
+    "@types/node": "16.11.17",
     "@types/jest": "27.0.3",
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "browser-sync": "2.27.7",

--- a/generators/client/templates/react/package.json
+++ b/generators/client/templates/react/package.json
@@ -30,7 +30,7 @@
     "@testing-library/react": "12.1.2",
     "@types/jest": "27.0.3",
     "@types/lodash": "4.14.178",
-    "@types/node": "17.0.5",
+    "@types/node": "16.11.17",
     "@types/react": "17.0.38",
     "@types/react-dom": "17.0.11",
     "@types/react-redux": "7.1.21",

--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.0.3",
-    "@types/node": "17.0.5",
+    "@types/node": "16.11.17",
     "@types/sinon": "10.0.6",
     "@types/vuelidate": "0.7.15",
     "@typescript-eslint/eslint-plugin": "5.8.0",

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -26,7 +26,7 @@ const JAVA_VERSION = '11';
 const JAVA_COMPATIBLE_VERSIONS = ['11', '12', '13', '14', '15', '16', '17'];
 
 // Version of Node, NPM
-const NODE_VERSION = '16.13.0';
+const NODE_VERSION = '16.13.1';
 const NPM_VERSION = commonPackageJson.devDependencies.npm;
 const OPENAPI_GENERATOR_CLI_VERSION = '1.0.13-4.3.1';
 

--- a/test-integration/scripts/99-print-node-version.sh
+++ b/test-integration/scripts/99-print-node-version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+source $(dirname $0)/00-init-env.sh
+
+echo $JHI_NODE_VERSION

--- a/test/__snapshots__/ci-cd.spec.js.snap
+++ b/test/__snapshots__/ci-cd.spec.js.snap
@@ -35,7 +35,7 @@ Object {
     pool:
       vmImage: \\"ubuntu-20.04\\"
     variables:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: NEVER
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -164,7 +164,7 @@ Object {
     pool:
       vmImage: \\"ubuntu-20.04\\"
     variables:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: NEVER
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -305,7 +305,7 @@ Object {
     pool:
       vmImage: \\"ubuntu-20.04\\"
     variables:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: NEVER
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -434,7 +434,7 @@ Object {
     pool:
       vmImage: \\"ubuntu-20.04\\"
     variables:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: NEVER
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -575,7 +575,7 @@ Object {
     pool:
       vmImage: \\"ubuntu-20.04\\"
     variables:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: NEVER
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -1117,7 +1117,7 @@ jobs:
     if: \\"!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]')\\"
     timeout-minutes: 40
     env:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: DETECT
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -1126,7 +1126,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.13.0
+          node-version: 16.13.1
       - uses: actions/setup-java@v2
         with:
           distribution: \\"temurin\\"
@@ -1204,7 +1204,7 @@ jobs:
     if: \\"!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]')\\"
     timeout-minutes: 40
     env:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: DETECT
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -1213,7 +1213,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.13.0
+          node-version: 16.13.1
       - uses: actions/setup-java@v2
         with:
           distribution: \\"temurin\\"
@@ -1368,7 +1368,7 @@ jobs:
     if: \\"!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]')\\"
     timeout-minutes: 40
     env:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: DETECT
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -1377,7 +1377,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.13.0
+          node-version: 16.13.1
       - uses: actions/setup-java@v2
         with:
           distribution: \\"temurin\\"
@@ -1449,7 +1449,7 @@ jobs:
     if: \\"!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]')\\"
     timeout-minutes: 40
     env:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: DETECT
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -1458,7 +1458,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.13.0
+          node-version: 16.13.1
       - uses: actions/setup-java@v2
         with:
           distribution: \\"temurin\\"
@@ -1635,7 +1635,7 @@ jobs:
     if: \\"!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]')\\"
     timeout-minutes: 40
     env:
-      NODE_VERSION: 16.13.0
+      NODE_VERSION: 16.13.1
       SPRING_OUTPUT_ANSI_ENABLED: DETECT
       SPRING_JPA_SHOW_SQL: false
       JHI_DISABLE_WEBPACK_LOGS: true
@@ -1644,7 +1644,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.13.0
+          node-version: 16.13.1
       - uses: actions/setup-java@v2
         with:
           distribution: \\"temurin\\"
@@ -3551,7 +3551,7 @@ services:
   - docker
 language: node_js
 node_js:
-  - \\"16.13.0\\"
+  - \\"16.13.1\\"
 cache:
   directories:
     - node
@@ -3559,7 +3559,7 @@ cache:
     - $HOME/.gradle
 env:
   global:
-    - NODE_VERSION=16.13.0
+    - NODE_VERSION=16.13.1
     - JHI_JDK=11
     - SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
     - SPRING_JPA_SHOW_SQL=false
@@ -3648,7 +3648,7 @@ services:
   - docker
 language: node_js
 node_js:
-  - \\"16.13.0\\"
+  - \\"16.13.1\\"
 cache:
   directories:
     - node
@@ -3656,7 +3656,7 @@ cache:
     - $HOME/.m2
 env:
   global:
-    - NODE_VERSION=16.13.0
+    - NODE_VERSION=16.13.1
     - JHI_JDK=11
     - SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
     - SPRING_JPA_SHOW_SQL=false
@@ -3746,7 +3746,7 @@ services:
   - docker
 language: node_js
 node_js:
-  - \\"16.13.0\\"
+  - \\"16.13.1\\"
 cache:
   directories:
     - node
@@ -3754,7 +3754,7 @@ cache:
     - $HOME/.m2
 env:
   global:
-    - NODE_VERSION=16.13.0
+    - NODE_VERSION=16.13.1
     - JHI_JDK=11
     - SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
     - SPRING_JPA_SHOW_SQL=false


### PR DESCRIPTION
`@types/node` should match supported node major version.
We support node 16 at generated projects. So adjust `@types/node` to version 16.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
