### PR TITLE
Sonar: Remove this unused import 'org.springframework.http.HttpStatus'

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -74,7 +74,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
   <%_ } _%>
 <%_ } _%>
-<%_ if (reactive || !paginationNo && (!(databaseTypeSql && reactive) || viaService)) { _%>
+<%_ if (reactive || !paginationNo) { _%>
 import org.springframework.http.HttpStatus;
 <%_ } _%>
 <%_ if (reactive) { _%>

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -74,7 +74,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
   <%_ } _%>
 <%_ } _%>
-<%_ if (reactive || !paginationNo) { _%>
+<%_ if (reactive || (!jpaMetamodelFiltering && !paginationNo)) { _%>
 import org.springframework.http.HttpStatus;
 <%_ } _%>
 <%_ if (reactive) { _%>

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -65,7 +65,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageImpl;
   <%_ } _%>
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
   <%_ if (reactive) { _%>
 import org.springframework.http.server.reactive.ServerHttpRequest;
   <%_ } _%>
@@ -74,7 +73,8 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
   <%_ } else { _%>
 import org.springframework.web.util.UriComponentsBuilder;
   <%_ } _%>
-<%_ } else if (reactive) { _%>
+<%_ } _%>
+<%_ if (reactive || !paginationNo && (!(databaseTypeSql && reactive) || viaService)) { _%>
 import org.springframework.http.HttpStatus;
 <%_ } _%>
 <%_ if (reactive) { _%>


### PR DESCRIPTION
Fix some sonar issues:
- https://sonarcloud.io/project/issues?id=jhipster-sample-application&open=AW7IFzYozz0zKTgJXRom&resolved=false&types=CODE_SMELL
- https://sonarcloud.io/project/issues?id=jhipster-sample-application&open=AW7IFzYWzz0zKTgJXRoi&resolved=false&types=CODE_SMELL
- ...

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
