### PR TITLE
Move ColumnConverter from service to repository

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/repository/rowmapper/EntityRowMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/rowmapper/EntityRowMapper.java.ejs
@@ -39,7 +39,7 @@ import <%= entityAbsolutePackage %>.domain.<%= persistClass %>;
 <%_ Object.keys(uniqueEnums).forEach(function(element) { _%>
 import <%= entityAbsolutePackage %>.domain.enumeration.<%= element %>;
 <%_ }); _%>
-import <%= packageName %>.service.ColumnConverter;
+import <%= packageName %>.repository.ColumnConverter;
 
 import io.r2dbc.spi.Row;
 

--- a/generators/server/__snapshots__/generator.spec.mjs.snap
+++ b/generators/server/__snapshots__/generator.spec.mjs.snap
@@ -679,7 +679,7 @@ Object {
       "path": "src/main/java/",
       "templates": Array [
         Object {
-          "file": "package/service/ColumnConverter.java",
+          "file": "package/repository/ColumnConverter.java",
           "renameTo": [Function],
         },
         Object {

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -933,8 +933,8 @@ const baseServerFiles = {
       path: SERVER_MAIN_SRC_DIR,
       templates: [
         {
-          file: 'package/service/ColumnConverter.java',
-          renameTo: generator => `${generator.javaDir}service/ColumnConverter.java`,
+          file: 'package/repository/ColumnConverter.java',
+          renameTo: generator => `${generator.javaDir}repository/ColumnConverter.java`,
         },
         {
           file: 'package/service/EntityManager.java',

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -460,6 +460,12 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
           this.removeFile(`${this.srcTestDir}features/user/user.feature`);
         }
       },
+      cleanupSql() {
+        if (!this.databaseTypeSql) return undefined;
+        if (this.reactive && this.isJhipsterVersionLessThan('7.5.1')) {
+          this.removeFile(`${this.mainJavaPackageDir}repository/ColumnConverter.java`);
+        }
+      },
       cleanupServer() {
         if (this.isJhipsterVersionLessThan('7.4.2')) {
           this.removeFile(`${this.mainJavaPackageDir}config/apidocs/GatewaySwaggerResourcesProvider.java`);

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -463,7 +463,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
       cleanupSql() {
         if (!this.databaseTypeSql) return undefined;
         if (this.reactive && this.isJhipsterVersionLessThan('7.5.1')) {
-          this.removeFile(`${this.mainJavaPackageDir}repository/ColumnConverter.java`);
+          this.removeFile(`${this.mainJavaPackageDir}service/ColumnConverter.java`);
         }
       },
       cleanupServer() {

--- a/generators/server/templates/src/main/java/package/repository/ColumnConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/ColumnConverter.java.ejs
@@ -16,13 +16,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service;
+package <%= packageName %>.repository;
 
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.r2dbc.convert.R2dbcConverter;
 import org.springframework.data.r2dbc.convert.R2dbcCustomConversions;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
 
 import io.r2dbc.spi.Row;
@@ -30,7 +30,7 @@ import io.r2dbc.spi.Row;
 /**
  * This service provides helper function dealing with the low level {@link Row} and Spring's {@link R2dbcCustomConversions}, so type conversions can be applied.
  */
-@Service
+@Component
 public class ColumnConverter {
 
     private final ConversionService conversionService;

--- a/generators/server/templates/src/main/java/package/repository/rowmapper/UserRowMapper.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/rowmapper/UserRowMapper.java.ejs
@@ -25,7 +25,7 @@ import java.util.function.BiFunction;
 import org.springframework.stereotype.Service;
 
 import <%= packageName %>.domain.<%= asEntity('User') %>;
-import <%= packageName %>.service.ColumnConverter;
+import <%= packageName %>.repository.ColumnConverter;
 
 import io.r2dbc.spi.Row;
 


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/17520 and https://github.com/jhipster/generator-jhipster/pull/17521

ColumnConverter is only used at repository layer, move there.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
