### PR TITLE
Switch to @faker-js/faker

### DIFF
--- a/generators/cypress/files.js
+++ b/generators/cypress/files.js
@@ -22,7 +22,7 @@
  * For any other config an object { file:.., method:.., template:.. } can be used
  */
 
-const faker = require('faker');
+const faker = require('@faker-js/faker');
 
 const constants = require('../generator-constants');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.6.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@faker-js/faker": "5.5.3",
         "aws-sdk": "2.1062.0",
         "axios": "0.25.0",
         "chalk": "4.1.2",
@@ -18,7 +19,6 @@
         "debug": "4.3.3",
         "didyoumean": "1.2.2",
         "ejs": "3.1.6",
-        "faker": "5.5.3",
         "glob": "7.2.0",
         "insight": "0.11.1",
         "js-yaml": "4.1.0",
@@ -720,6 +720,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.2",
@@ -3515,11 +3520,6 @@
       "engines": [
         "node >=0.6.0"
       ]
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10270,6 +10270,11 @@
         }
       }
     },
+    "@faker-js/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw=="
+    },
     "@gar/promisify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
@@ -12495,11 +12500,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "update-snapshots": "npm run update-snapshot -- test generators"
   },
   "dependencies": {
+    "@faker-js/faker": "5.5.3",
     "aws-sdk": "2.1062.0",
     "axios": "0.25.0",
     "chalk": "4.1.2",
@@ -92,7 +93,6 @@
     "debug": "4.3.3",
     "didyoumean": "1.2.2",
     "ejs": "3.1.6",
-    "faker": "5.5.3",
     "glob": "7.2.0",
     "insight": "0.11.1",
     "js-yaml": "4.1.0",

--- a/utils/faker.js
+++ b/utils/faker.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const Faker = require('faker/lib');
+const Faker = require('@faker-js/faker/lib');
 const Randexp = require('randexp');
 
 const { languageToJavaLanguage } = require('../generators/utils');
@@ -46,11 +46,11 @@ function createFaker(nativeLanguage = 'en') {
   nativeLanguage = languageToJavaLanguage(nativeLanguage);
   // Fallback language
   // eslint-disable-next-line global-require
-  const locales = { en: require('faker/lib/locales/en') };
+  const locales = { en: require('@faker-js/faker/lib/locales/en') };
   if (nativeLanguage !== 'en') {
     try {
       // eslint-disable-next-line global-require, import/no-dynamic-require
-      const nativeLanguageLocale = require(`faker/lib/locales/${nativeLanguage}`);
+      const nativeLanguageLocale = require(`@faker-js/faker/lib/locales/${nativeLanguage}`);
       locales[nativeLanguage] = nativeLanguageLocale;
     } catch (error) {
       // Faker not implemented for the native language, fallback to en.


### PR DESCRIPTION
Since original faker was abruptly discontinued, the community got involved and there is an 'official' fork maintained at https://github.com/faker-js/faker.
Is this fork 'official'?
Yes, at least for opencollective https://opencollective.com/fakerjs.
The fakerjs collective has been transferred to the new maintainers. The new maintainers transferred the old funds to fakers-legacy collective.
More info https://fakerjs.dev/update.html#funding-yml.

IMO it's safe to move on.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
