### PR TITLE
Expose properties from the Environment whose name starts with info

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -113,6 +113,8 @@ management:
   info:
     git:
       mode: full
+    env:
+      enabled: true
   health:
     mail:
       enabled: false # When using the MailService, configure an SMTP server and set this to true


### PR DESCRIPTION
This PR Fix #17777
<!--
PR description.
-->
Exposes any property from the Environment whose name starts with `info.`.
Docs: https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#:~:text=info.properties%20resource.-,env,None.,-git

Fix the missing `display-ribbon-on-profiles` in the `/management/info` call (I just upgraded from JHipster v7.4.0 to v7.6.0 and noticed its missing) 

Before:
![image](https://user-images.githubusercontent.com/3299903/152112198-924393f6-8d96-4778-910b-522f3d8869ae.png)

After:
![image](https://user-images.githubusercontent.com/3299903/152112126-a914f488-afbf-4daa-9c5e-246b7bbd6f3f.png)

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
