### PR TITLE
Sonar rule key 'squid:S4502' has been changed to 'java:S4502'

### DIFF
--- a/generators/common/templates/sonar-project.properties.ejs
+++ b/generators/common/templates/sonar-project.properties.ejs
@@ -45,7 +45,7 @@ sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey=squid:UndocumentedApi
 <%_ if (authenticationTypeJwt) { _%>
 # Rule https://rules.sonarsource.com/java/RSPEC-4502 is ignored, as for JWT tokens we are not subject to CSRF attack
 sonar.issue.ignore.multicriteria.S4502.resourceKey=<%= MAIN_DIR %>java/**/*
-sonar.issue.ignore.multicriteria.S4502.ruleKey=squid:S4502
+sonar.issue.ignore.multicriteria.S4502.ruleKey=java:S4502
 <%_ } _%>
 # Rule https://rules.sonarsource.com/java/RSPEC-4684
 sonar.issue.ignore.multicriteria.S4684.resourceKey=<%= MAIN_DIR %>java/**/*


### PR DESCRIPTION
<!--
PR description.
-->
A multicriteria issue exclusion uses the rule key 'squid:S4502' that has been changed. The pattern should be updated to 'java:S4502'

From SonarCloud:
![image](https://user-images.githubusercontent.com/3299903/152384304-bdb30696-bea0-42c7-abfa-d11d99a9d474.png)

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
