### PR TITLE
Downgrade swagger-ui to 4.2.1

### DIFF
--- a/generators/client/templates/angular/package.json
+++ b/generators/client/templates/angular/package.json
@@ -12,7 +12,7 @@
     "ngx-infinite-scroll": "10.0.1",
     "ngx-webstorage": "9.0.0",
     "rxjs": "7.5.2",
-    "swagger-ui-dist": "4.4.1",
+    "swagger-ui-dist": "4.2.1",
     "tslib": "2.3.1",
     "zone.js": "0.11.4"
   },

--- a/generators/client/templates/react/package.json
+++ b/generators/client/templates/react/package.json
@@ -73,7 +73,7 @@
     "source-map-loader": "3.0.1",
     "sourcemap-istanbul-instrumenter-loader": "0.2.0",
     "style-loader": "3.3.1",
-    "swagger-ui-dist": "4.4.1",
+    "swagger-ui-dist": "4.2.1",
     "terser-webpack-plugin": "5.3.1",
     "thread-loader": "3.0.4",
     "ts-jest": "27.1.3",

--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -7,7 +7,7 @@
     "bootstrap": "4.6.1",
     "bootstrap-vue": "2.21.2",
     "bootswatch": "5.1.3",
-    "swagger-ui-dist": "4.4.1",
+    "swagger-ui-dist": "4.2.1",
     "vue": "2.6.14",
     "vue-class-component": "7.2.6",
     "vue-cookie": "1.1.4",


### PR DESCRIPTION
Our swagger plugins are broken at >=4.3.0
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
