### PR TITLE
Improve jhipster cli global/local messages.

### DIFF
--- a/cli/program.js
+++ b/cli/program.js
@@ -65,8 +65,9 @@ const createProgram = ({ executableName = CLI_NAME, executableVersion = JHIPSTER
       .option('--skip-regenerate', "Don't regenerate identical files", false)
       .option('--skip-yo-resolve', 'Ignore .yo-resolve files', false)
       .addOption(new Option('--from-jdl', 'Allow every option jdl forwards').default(false).hideHelp())
-      .addOption(new Option('--prefer-global', 'Run jhipster installed globally').hideHelp())
-      .addOption(new Option('--prefer-local', 'Run jhipster installed locally').hideHelp())
+      .addOption(new Option('--bundled', 'Use JHipster generators bundled with current cli'))
+      .addOption(new Option('--prefer-global', 'Alias for --blundled').hideHelp())
+      .addOption(new Option('--prefer-local', 'Prefer JHipster generators installed in current folder node repository.').hideHelp())
   );
 };
 


### PR DESCRIPTION
- cli:
  - change message from `Using JHipster version installed globally` to `Using bundled JHipster`
  - change message from `Using JHipster version installed locally in current project's node_modules` to `Switching to JHipster installed locally in current project's node repository (node_modules)`
  - print `Using bundled JHipster` if the current jhipster is already in current project's repository. Ex: `npx jhipster`
  - allow commands to set a custom `useOptions` to force some options.

Or current cli switching to current project repository jhipster is not node/npm default, so we need to improve our messages.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
