### PR TITLE
fix the reversed version problem for maven-enforcer-plugin rule config

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -808,8 +808,7 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
       } else {
         const javaVersion = stderr.match(/(?:java|openjdk) version "(.*)"/)[1];
         if (!javaVersion.match(new RegExp(`(${JAVA_COMPATIBLE_VERSIONS.map(ver => `^${ver}`).join('|')})`))) {
-          const [latest, ...others] = JAVA_COMPATIBLE_VERSIONS.reverse();
-          JAVA_COMPATIBLE_VERSIONS.reverse();
+          const [latest, ...others] = JAVA_COMPATIBLE_VERSIONS.concat().reverse();
           this.warning(
             `Java ${others.reverse().join(', ')} or ${latest} are not found on your computer. Your Java version is: ${chalk.yellow(
               javaVersion

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -809,6 +809,7 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
         const javaVersion = stderr.match(/(?:java|openjdk) version "(.*)"/)[1];
         if (!javaVersion.match(new RegExp(`(${JAVA_COMPATIBLE_VERSIONS.map(ver => `^${ver}`).join('|')})`))) {
           const [latest, ...others] = JAVA_COMPATIBLE_VERSIONS.reverse();
+          JAVA_COMPATIBLE_VERSIONS.reverse();
           this.warning(
             `Java ${others.reverse().join(', ')} or ${latest} are not found on your computer. Your Java version is: ${chalk.yellow(
               javaVersion


### PR DESCRIPTION
fix the reversed version problem for maven-enforcer-plugin rule config
when generating jhipster with a low version of java

Fix #18038

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
