### PR TITLE
fix test when nested jpaDerivedIdentifier is used

### DIFF
--- a/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
@@ -24,6 +24,7 @@ const otherEntities = _.uniq(Object.values(differentRelationships).filter(rels =
 const skipCreateTest =
   (
     !cypressBootstrapEntities ||
+    requiredRelationships.some(rel => rel.otherEntity.primaryKey && rel.otherEntity.primaryKey.derived) ||
     requiredRelationships.some(rel => rel.otherEntity.builtInUser || rel.otherEntity === this.entity) ||
     requiredRelationships.map(rel => rel.otherEntity.relationships).flat().some(rel => rel.relationshipRequired) ||
     !entityFakeData

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -517,13 +517,17 @@ if (field.fieldTypeString || field.blobContentTypeText) {
         <%_ } else { _%>
         <%= asEntity(otherEntityNameCapitalized) %> <%= otherEntityName %>;
           <%_ if (databaseTypeSql && !reactive) { _%>
+            <%_ if (!isUsingMapsId || fieldStatus !== "UPDATED_") { _%>
         if (TestUtil.findAll(em, <%= asEntity(otherEntityNameCapitalized) %>.class).isEmpty()) {
+            <%_ } _%>
             <%= otherEntityName %> = <%= createEntityPrefix %><%= otherEntityNameCapitalized %>ResourceIT.create<% if (fieldStatus === 'UPDATED_') { %>Updated<% } %>Entity(em)<%= createEntityPostfix %>;
             em.persist(<%= otherEntityName %>);
             em.flush();
+            <%_ if (!isUsingMapsId || fieldStatus !== "UPDATED_") { _%>
         } else {
             <%= otherEntityName %> = TestUtil.findAll(em, <%= asEntity(otherEntityNameCapitalized) %>.class).get(0);
         }
+            <%_ } _%>
           <%_ } else { _%>
         <%= otherEntityName %> = <%= createEntityPrefix %><%= otherEntityNameCapitalized %>ResourceIT.create<% if (fieldStatus === 'UPDATED_') { %>Updated<% } %>Entity(<% if (databaseType === 'sql') { %>em<% } %>)<%= createEntityPostfix %>;
           <%_ } _%>

--- a/test-integration/samples/.jhipster/MapsIdChildEntityWithDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdChildEntityWithDTO.json
@@ -17,6 +17,13 @@
       "ownerSide": true,
       "relationshipName": "mapsIdParentEntityWithDTO",
       "relationshipType": "one-to-one"
+    },
+    {
+      "otherEntityName": "mapsIdGrandchildEntityWithDTO",
+      "otherEntityRelationshipName": "mapsIdChildEntityWithDTO",
+      "ownerSide": false,
+      "relationshipName": "mapsIdGrandchildEntityWithDTO",
+      "relationshipType": "one-to-one"
     }
   ],
   "searchEngine": false,

--- a/test-integration/samples/.jhipster/MapsIdChildEntityWithDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdChildEntityWithDTO.json
@@ -3,7 +3,7 @@
   "clientRootFolder": "",
   "databaseType": "sql",
   "dto": "mapstruct",
-  "entityTableName": "maps_id_child_entity_withdto",
+  "entityTableName": "maps_id_child_with_dto",
   "fields": [{ "fieldName": "date", "fieldType": "Instant" }],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,

--- a/test-integration/samples/.jhipster/MapsIdChildEntityWithoutDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdChildEntityWithoutDTO.json
@@ -3,7 +3,7 @@
   "clientRootFolder": "",
   "databaseType": "sql",
   "dto": "no",
-  "entityTableName": "child_entity_wo_dto",
+  "entityTableName": "maps_id_child_wo_dto",
   "fields": [{ "fieldName": "date", "fieldType": "Instant" }],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,

--- a/test-integration/samples/.jhipster/MapsIdChildEntityWithoutDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdChildEntityWithoutDTO.json
@@ -17,6 +17,13 @@
       "ownerSide": true,
       "relationshipName": "mapsIdParentEntityWithoutDTO",
       "relationshipType": "one-to-one"
+    },
+    {
+      "otherEntityName": "mapsIdGrandchildEntityWithoutDTO",
+      "otherEntityRelationshipName": "mapsIdChildEntityWithoutDTO",
+      "ownerSide": false,
+      "relationshipName": "mapsIdGrandchildEntityWithoutDTO",
+      "relationshipType": "one-to-one"
     }
   ],
   "searchEngine": false,

--- a/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithDTO.json
@@ -1,0 +1,24 @@
+{
+  "changelogDate": "20220313234025",
+  "clientRootFolder": "",
+  "databaseType": "sql",
+  "dto": "mapstruct",
+  "entityTableName": "maps_id_gc_entity_w_dto",
+  "fields": [{ "fieldName": "date", "fieldType": "Instant" }],
+  "fluentMethods": true,
+  "jpaMetamodelFiltering": false,
+  "pagination": "no",
+  "relationships": [
+    {
+      "id": true,
+      "otherEntityField": "id",
+      "otherEntityName": "mapsIdChildEntityWithDTO",
+      "otherEntityRelationshipName": "mapsIdGrandchildEntityWithDTO",
+      "ownerSide": true,
+      "relationshipName": "mapsIdChildEntityWithDTO",
+      "relationshipType": "one-to-one"
+    }
+  ],
+  "searchEngine": false,
+  "service": "serviceImpl"
+}

--- a/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithDTO.json
@@ -3,7 +3,7 @@
   "clientRootFolder": "",
   "databaseType": "sql",
   "dto": "mapstruct",
-  "entityTableName": "maps_id_gc_entity_w_dto",
+  "entityTableName": "maps_id_grandchild_with_dto",
   "fields": [{ "fieldName": "date", "fieldType": "Instant" }],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,

--- a/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithoutDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithoutDTO.json
@@ -1,0 +1,24 @@
+{
+  "changelogDate": "20220313234416",
+  "clientRootFolder": "",
+  "databaseType": "sql",
+  "dto": "no",
+  "entityTableName": "maps_id_gc_entity_wo_dto",
+  "fields": [{ "fieldName": "date", "fieldType": "Instant" }],
+  "fluentMethods": true,
+  "jpaMetamodelFiltering": false,
+  "pagination": "no",
+  "relationships": [
+    {
+      "id": true,
+      "otherEntityField": "id",
+      "otherEntityName": "mapsIdChildEntityWithoutDTO",
+      "otherEntityRelationshipName": "mapsIdGrandchildEntityWithoutDTO",
+      "ownerSide": true,
+      "relationshipName": "mapsIdChildEntityWithoutDTO",
+      "relationshipType": "one-to-one"
+    }
+  ],
+  "searchEngine": false,
+  "service": "no"
+}

--- a/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithoutDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdGrandchildEntityWithoutDTO.json
@@ -3,7 +3,7 @@
   "clientRootFolder": "",
   "databaseType": "sql",
   "dto": "no",
-  "entityTableName": "maps_id_gc_entity_wo_dto",
+  "entityTableName": "maps_id_grandchild_wo_dto",
   "fields": [{ "fieldName": "date", "fieldType": "Instant" }],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,

--- a/test-integration/samples/.jhipster/MapsIdParentEntityWithDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdParentEntityWithDTO.json
@@ -3,7 +3,7 @@
   "clientRootFolder": "",
   "databaseType": "sql",
   "dto": "mapstruct",
-  "entityTableName": "maps_id_parent_entity_withdto",
+  "entityTableName": "maps_id_parent_with_dto",
   "fields": [{ "fieldName": "name", "fieldType": "String" }],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,

--- a/test-integration/samples/.jhipster/MapsIdParentEntityWithoutDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdParentEntityWithoutDTO.json
@@ -3,7 +3,7 @@
   "clientRootFolder": "",
   "databaseType": "sql",
   "dto": "no",
-  "entityTableName": "parent_entity_wo_dto",
+  "entityTableName": "maps_id_parent_wo_dto",
   "fields": [{ "fieldName": "name", "fieldType": "String" }],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,

--- a/test-integration/samples/.jhipster/MapsIdUserProfileWithDTO.json
+++ b/test-integration/samples/.jhipster/MapsIdUserProfileWithDTO.json
@@ -3,7 +3,7 @@
   "clientRootFolder": "",
   "databaseType": "sql",
   "dto": "mapstruct",
-  "entityTableName": "maps_id_user_profile_withdto",
+  "entityTableName": "maps_id_user_profile_with_dto",
   "fields": [{ "fieldName": "dateOfBirth", "fieldType": "Instant" }],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -150,8 +150,10 @@ elif [[ "$JHI_ENTITY" == "sqlfull" ]]; then
 
     moveEntity MapsIdParentEntityWithoutDTO
     moveEntity MapsIdChildEntityWithoutDTO
+    moveEntity MapsIdGrandchildEntityWithoutDTO
     moveEntity MapsIdParentEntityWithDTO
     moveEntity MapsIdChildEntityWithDTO
+    moveEntity MapsIdGrandchildEntityWithDTO
     moveEntity MapsIdUserProfileWithDTO
 
     moveEntity JpaFilteringRelationship

--- a/test-integration/scripts/11-generate-entities.sh
+++ b/test-integration/scripts/11-generate-entities.sh
@@ -125,8 +125,10 @@ elif [[ "$JHI_ENTITY" == "sqlfull" ]]; then
 
     moveEntity MapsIdParentEntityWithoutDTO
     moveEntity MapsIdChildEntityWithoutDTO
+    moveEntity MapsIdGrandchildEntityWithoutDTO
     moveEntity MapsIdParentEntityWithDTO
     moveEntity MapsIdChildEntityWithDTO
+    moveEntity MapsIdGrandchildEntityWithDTO
     moveEntity MapsIdUserProfileWithDTO
 
     moveEntity JpaFilteringRelationship

--- a/utils/relationship.js
+++ b/utils/relationship.js
@@ -71,7 +71,12 @@ function prepareRelationshipForTemplates(entityWithConfig, relationship, generat
         }
         return otherSideRelationship.relationshipName === relationship.otherEntityRelationshipName;
       });
-      if (
+      if (!otherRelationship) {
+        // TODO throw error at v8.
+        generator.warning(
+          `Error at '${entityName}' definitions: 'otherEntityRelationshipName' is set with value '${relationship.otherEntityRelationshipName}' at relationship '${relationship.relationshipName}' but no back-reference was found at '${otherEntityName}'`
+        );
+      } else if (
         otherRelationship &&
         otherRelationship.otherEntityRelationshipName &&
         otherRelationship.otherEntityRelationshipName !== relationship.relationshipName


### PR DESCRIPTION
when a relationship is used with the jpaDerivedIdentifier option and the
related entity also has a relationship with that option set the
`updateEntityMapsIdAssociationWithNewId` test fails. This
is caused by the `createUpdatedEntity` reusing the needed parent
entity. This can't work because a parent entity, which already has a child,
can't be used as the parent for a new entity. The reason being
jpaDerivedIdentifier enforces that parent and child share the same id,
which can't be fulfilled with a reused parent entity.
Remove the reuse of the parent entity in `createUpdatedEntity` when the
entity uses jpaDerivedIdentifier to fix the test.

Fixes #17906

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
