### PR TITLE
Add .npmrc to workspaces

### DIFF
--- a/generators/common/templates/package.json
+++ b/generators/common/templates/package.json
@@ -3,7 +3,7 @@
     "concurrently": "7.0.0",
     "husky": "7.0.4",
     "lint-staged": "12.3.5",
-    "npm": "8.4.1",
+    "npm": "8.5.3",
     "wait-on": "6.0.1"
   }
 }

--- a/generators/workspaces/index.js
+++ b/generators/workspaces/index.js
@@ -142,7 +142,7 @@ module.exports = class extends BaseBlueprintGenerator {
           {
             base: [
               {
-                templates: ['.gitignore'],
+                templates: ['.gitignore', '.npmrc'],
               },
             ],
           },

--- a/generators/workspaces/templates/.npmrc.ejs
+++ b/generators/workspaces/templates/.npmrc.ejs
@@ -1,0 +1,1 @@
+workspaces=false


### PR DESCRIPTION
We use npm workspaces for scripts.
Since npm 8.5.0, `npm install` dedupes to the root by default.
Npm https://github.com/npm/cli/issues/4437 behavior can break workspaces on transitive dependency changes at the root package.json.

So this PR tries to disable workspaces behavior by default.
Following https://github.com/npm/cli/issues/4437#issuecomment-1063047791.
Add `.npmrc` with `workspaces=false`.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
