### PR TITLE
Fix issue: Replace any occurrences of 'ts-jest/utils' with just 'ts-jest`

### DIFF
--- a/generators/client/templates/angular/jest.conf.js.ejs
+++ b/generators/client/templates/angular/jest.conf.js.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-const { pathsToModuleNameMapper } = require('ts-jest/utils')
+const { pathsToModuleNameMapper } = require('ts-jest')
 
 const { compilerOptions: { paths = {}, baseUrl = './' } } = require('./tsconfig.json');
 const environment = require('./webpack/environment');

--- a/generators/client/templates/vue/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/vue/src/test/javascript/jest.conf.js.ejs
@@ -1,4 +1,4 @@
-const { pathsToModuleNameMapper } = require('ts-jest/utils');
+const { pathsToModuleNameMapper } = require('ts-jest');
 const config = require('../../../webpack/config');
 const { compilerOptions: { paths = {}, baseUrl = './' } } = require('../../../tsconfig.json');
 


### PR DESCRIPTION
Other linting warnings that we might want to fix:

```
/Users/mraible/dev/21-points/src/test/javascript/cypress/integration/entity/blood-pressure.spec.ts
    1:10  warning  'entityItemSelector' is defined but never used  @typescript-eslint/no-unused-vars
   21:22  warning  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
   48:11  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
   72:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  113:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  124:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  134:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  137:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  163:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  164:25  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  167:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion

/Users/mraible/dev/21-points/src/test/javascript/cypress/integration/entity/points.spec.ts
    1:10  warning  'entityItemSelector' is defined but never used  @typescript-eslint/no-unused-vars
   21:15  warning  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
   48:11  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
   72:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  113:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  124:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  134:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  137:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  167:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  168:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  171:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion

/Users/mraible/dev/21-points/src/test/javascript/cypress/integration/entity/preferences.spec.ts
    1:10  warning  'entityItemSelector' is defined but never used  @typescript-eslint/no-unused-vars
   21:20  warning  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
   48:11  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
   72:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  110:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  121:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  131:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  134:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  158:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  159:23  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  162:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion

/Users/mraible/dev/21-points/src/test/javascript/cypress/integration/entity/weight.spec.ts
    1:10  warning  'entityItemSelector' is defined but never used  @typescript-eslint/no-unused-vars
   21:15  warning  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
   48:11  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
   72:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  113:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  124:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  134:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  137:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  161:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  162:18  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion
  165:16  warning  Forbidden non-null assertion                    @typescript-eslint/no-non-null-assertion

/Users/mraible/dev/21-points/src/test/javascript/cypress/support/commands.ts
   81:53  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  120:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```