### PR TITLE
Replace deprecated Mono.subscriberContext by Mono.contextWrite

### DIFF
--- a/generators/server/templates/src/main/java/package/security/jwt/JWTFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/jwt/JWTFilter.java.ejs
@@ -75,7 +75,7 @@ public class JWTFilter <% if (reactive) { %>implements WebFilter<% } else { %>ex
         if (StringUtils.hasText(jwt) && this.tokenProvider.validateToken(jwt)) {
             Authentication authentication = this.tokenProvider.getAuthentication(jwt);
 <%_ if (reactive) { _%>
-            return chain.filter(exchange).subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication));
+            return chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
         }
         return chain.filter(exchange);
 <%_ } else { _%>

--- a/generators/server/templates/src/main/java/package/security/jwt/TokenProvider.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/jwt/TokenProvider.java.ejs
@@ -106,7 +106,7 @@ public class TokenProvider {
             .signWith(key, SignatureAlgorithm.HS512)
             .setExpiration(validity)
 <%_ if (reactive) { _%>
-            .serializeToJsonWith(new JacksonSerializer())
+            .serializeToJsonWith(new JacksonSerializer<>())
 <%_ } _%>
             .compact();
     }

--- a/generators/server/templates/src/test/java/package/security/jwt/JWTFilterTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/jwt/JWTFilterTest.java.ejs
@@ -93,7 +93,7 @@ class JWTFilterTest {
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
         jwtFilter.filter(
             exchange,
-            it -> Mono.subscriberContext()
+            it -> Mono.deferContextual(Mono::just)
                 .flatMap(c -> ReactiveSecurityContextHolder.getContext())
                 .map(SecurityContext::getAuthentication)
                 .doOnSuccess(auth -> assertThat(auth.getName()).isEqualTo("test-user"))
@@ -123,7 +123,7 @@ class JWTFilterTest {
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
         jwtFilter.filter(
             exchange,
-            it -> Mono.subscriberContext()
+            it -> Mono.deferContextual(Mono::just)
                 .flatMap(c -> ReactiveSecurityContextHolder.getContext())
                 .map(SecurityContext::getAuthentication)
                 .doOnSuccess(auth -> assertThat(auth).isNull())
@@ -149,7 +149,7 @@ class JWTFilterTest {
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
         jwtFilter.filter(
             exchange,
-            it -> Mono.subscriberContext()
+            it -> Mono.deferContextual(Mono::just)
                 .flatMap(c -> ReactiveSecurityContextHolder.getContext())
                 .map(SecurityContext::getAuthentication)
                 .doOnSuccess(auth -> assertThat(auth).isNull())
@@ -175,7 +175,7 @@ class JWTFilterTest {
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
         jwtFilter.filter(
             exchange,
-            it -> Mono.subscriberContext()
+            it -> Mono.deferContextual(Mono::just)
                 .flatMap(c -> ReactiveSecurityContextHolder.getContext())
                 .map(SecurityContext::getAuthentication)
                 .doOnSuccess(auth -> assertThat(auth).isNull())
@@ -208,7 +208,7 @@ class JWTFilterTest {
         MockServerWebExchange exchange = MockServerWebExchange.from(request);
         jwtFilter.filter(
             exchange,
-            it -> Mono.subscriberContext()
+            it -> Mono.deferContextual(Mono::just)
                 .flatMap(c -> ReactiveSecurityContextHolder.getContext())
                 .map(SecurityContext::getAuthentication)
                 .doOnSuccess(auth -> assertThat(auth).isNull())


### PR DESCRIPTION
<!--
PR description.
-->
Related with #17967
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
