### PR TITLE
configure mysql docker image to run with m1 macs

### DIFF
--- a/generators/server/templates/src/main/docker/mysql.yml.ejs
+++ b/generators/server/templates/src/main/docker/mysql.yml.ejs
@@ -21,6 +21,7 @@ version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
   <%= baseName.toLowerCase() %>-mysql:
     image: <%= DOCKER_MYSQL %>
+    platform: linux/x86_64
     # volumes:
     #   - ~/volumes/jhipster/<%= baseName %>/mysql/:/var/lib/mysql/
     environment:


### PR DESCRIPTION
Just adding the mentioned configuration to support running mysql under m1 architecture

closes #18085

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
