### PR TITLE
Fix build-matrix common detection.

### DIFF
--- a/test-integration/scripts/99-build-changes.sh
+++ b/test-integration/scripts/99-build-changes.sh
@@ -103,7 +103,6 @@ echo "::group::Check Common"
 git -c color.ui=always diff --exit-code @~1 -- \
   '.github/actions' \
   '.github/workflows' \
-  'generators/*.*' \
   'generators/app' \
   'generators/bootstrap' \
   'generators/common' \
@@ -114,6 +113,11 @@ git -c color.ui=always diff --exit-code @~1 -- \
   'lib' \
   'test-integration' \
   'utils' \
+  || CLIENT=true SERVER=true COMMON=true ANY=true
+echo "::endgroup::"
+
+echo "::group::Check Base"
+git -c color.ui=always diff --exit-code @~1 -- $(ls generators/*.*) \
   || CLIENT=true SERVER=true COMMON=true ANY=true
 echo "::endgroup::"
 


### PR DESCRIPTION
`git diff` is always recursive.
Fix condition by splitting the non recursive condition.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
