### PR TITLE
Add permissions to GitHub actions

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -229,6 +229,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   check-angular:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     needs: [applications]
     if: >-

--- a/.github/workflows/devserver.yml
+++ b/.github/workflows/devserver.yml
@@ -156,6 +156,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   check-dev-server:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     needs: [applications]
     if: >-

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -30,6 +30,9 @@ on:
     types: [closed, opened, synchronize, reopened]
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   check-npm-test:
     if: >-

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -31,12 +31,21 @@ on:
     types: [closed, opened, synchronize, reopened]
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   generate-blueprint:
+    permissions:
+      contents: none
     uses: ./.github/workflows/generator-generate-blueprint.yml
   database-changelog-liquibase:
+    permissions:
+      contents: none
     uses: ./.github/workflows/generator-database-changelog-liquibase.yml
   check-generators:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     needs: [generate-blueprint, database-changelog-liquibase]
     if: >-

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -31,6 +31,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: 'Validation'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,14 @@ on:
     branches-ignore:
       - 'dependabot/**'
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,8 +10,8 @@ permissions:
 jobs:
   triage:
     permissions:
-      contents: read  # for actions/labeler to determine modified files
-      pull-requests: write  # for actions/labeler to add labels to PRs
+      contents: read # for actions/labeler to determine modified files
+      pull-requests: write # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/lock-maintenance.yml
+++ b/.github/workflows/lock-maintenance.yml
@@ -4,8 +4,14 @@ on:
     - cron: 0 0 * * 6
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: Bump transitional dependencies
     if: github.repository == 'jhipster/generator-jhipster'
     runs-on: ubuntu-latest

--- a/.github/workflows/lock-maintenance.yml
+++ b/.github/workflows/lock-maintenance.yml
@@ -10,8 +10,8 @@ permissions:
 jobs:
   build:
     permissions:
-      contents: write  # for peter-evans/create-pull-request to create branch
-      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+      contents: write # for peter-evans/create-pull-request to create branch
+      pull-requests: write # for peter-evans/create-pull-request to create a PR
     name: Bump transitional dependencies
     if: github.repository == 'jhipster/generator-jhipster'
     runs-on: ubuntu-latest

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -229,6 +229,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   check-react:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     needs: [applications]
     if: >-

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -31,8 +31,8 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      contents: write  # for release-drafter/release-drafter to create a github release
-      pull-requests: write  # for release-drafter/release-drafter to add label to PR
+      contents: write # for release-drafter/release-drafter to create a github release
+      pull-requests: write # for release-drafter/release-drafter to add label to PR
     if: github.repository == 'jhipster/generator-jhipster'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,8 +25,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
     if: github.repository == 'jhipster/generator-jhipster'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -229,6 +229,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   check-vue:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     needs: [applications]
     if: >-


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

