### PR TITLE
Add support for Java 18

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -24,7 +24,7 @@ const commonPackageJson = require('./common/templates/package.json');
 
 // Version of Java
 const JAVA_VERSION = '11';
-const JAVA_COMPATIBLE_VERSIONS = ['11', '12', '13', '14', '15', '16', '17'];
+const JAVA_COMPATIBLE_VERSIONS = ['11', '12', '13', '14', '15', '16', '17', '18'];
 
 // Version of Node, NPM
 const NODE_VERSION = '16.14.0';


### PR DESCRIPTION
Solves this error on Java 18:

```
[INFO] --- maven-enforcer-plugin:3.0.0:enforce (enforce-versions) @ flickr-2 ---
[WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
You are running an incompatible version of Java. JHipster supports JDK 11 to 17.
```

<img width="1330" alt="Screen Shot 2022-03-23 at 09 25 44" src="https://user-images.githubusercontent.com/17892/159735988-70532a57-4184-4bd3-8df8-503ccb8a11b9.png">


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
