### PR TITLE
Update open-api version

### DIFF
--- a/generators/common/templates/README.md.jhi.ejs
+++ b/generators/common/templates/README.md.jhi.ejs
@@ -233,7 +233,7 @@ See Cypress' documentation for setting OS [environment variables](https://docs.c
 <%_ } _%>
 
 <%_ if (enableSwaggerCodegen) { _%>
-### Doing API-First development using openapi-generator
+### Doing API-First development using openapi-generator-cli
 
 [OpenAPI-Generator]() is configured for this application. You can generate API code from the `src/main/resources/swagger/api.yml` definition file by running:
     <%_ if (buildToolMaven) { _%>

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -29,7 +29,7 @@ const JAVA_COMPATIBLE_VERSIONS = ['11', '12', '13', '14', '15', '16', '17', '18'
 // Version of Node, NPM
 const NODE_VERSION = '16.14.0';
 const NPM_VERSION = commonPackageJson.devDependencies.npm;
-const OPENAPI_GENERATOR_CLI_VERSION = '1.0.13-4.3.1';
+const OPENAPI_GENERATOR_CLI_VERSION = '2.4.26';
 
 const GRADLE_VERSION = gradleOptions.GRADLE_VERSION;
 const JIB_VERSION = '3.2.1';

--- a/generators/openapi-client/files.js
+++ b/generators/openapi-client/files.js
@@ -26,7 +26,7 @@ const { GRADLE, MAVEN } = require('../../jdl/jhipster/build-tool-types');
 const { GATEWAY, MICROSERVICE } = require('../../jdl/jhipster/application-types');
 const { JWT, SESSION } = require('../../jdl/jhipster/authentication-types');
 
-const { AUTHENTICATION_TYPE, BASE_NAME, BUILD_TOOL, PACKAGE_FOLDER, PACKAGE_NAME, REACTIVE } = OptionNames;
+const { REACTIVE } = OptionNames;
 
 module.exports = {
   writeFiles,

--- a/generators/openapi-client/files.js
+++ b/generators/openapi-client/files.js
@@ -45,12 +45,6 @@ function writeFiles() {
 function customizeFiles() {
   return {
     callOpenApiGenerator() {
-      this.baseName = this.config.get(BASE_NAME);
-      this.authenticationType = this.config.get(AUTHENTICATION_TYPE);
-      this.packageName = this.config.get(PACKAGE_NAME);
-      this.packageFolder = this.config.get(PACKAGE_FOLDER);
-      this.buildTool = this.config.get(BUILD_TOOL);
-
       if (Object.keys(this.clientsToGenerate).length === 0) {
         this.log('No openapi client configured. Please run "jhipster openapi-client" to generate your first OpenAPI client.');
         return;
@@ -66,7 +60,7 @@ function customizeFiles() {
         const inputSpec = this.clientsToGenerate[cliName].spec;
         const generatorName = this.clientsToGenerate[cliName].generatorName;
 
-        const openApiCmd = ['openapi-generator generate'];
+        const openApiCmd = ['openapi-generator-cli generate'];
         let openApiGeneratorName;
         let openApiGeneratorLibrary;
         const additionalParameters = [];

--- a/generators/openapi-client/index.js
+++ b/generators/openapi-client/index.js
@@ -64,6 +64,8 @@ module.exports = class extends BaseBlueprintGenerator {
       },
       getConfig() {
         this.openApiClients = this.config.get('openApiClients') || {};
+        this.loadAppConfig();
+        this.loadServerConfig();
       },
     };
   }

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1001,7 +1001,7 @@
 <%_ if (enableSwaggerCodegen) { _%>
             <plugin>
                 <!--
-                    Plugin that provides API-first development using openapi-generator to
+                    Plugin that provides API-first development using openapi-generator-cli to
                     generate Spring-MVC endpoint stubs at compile time from an OpenAPI definition file
                 -->
                 <groupId>org.openapitools</groupId>
@@ -1464,7 +1464,7 @@
 <%_ if (enableSwaggerCodegen) { _%>
                 <plugin>
                     <!--
-                        Plugin that provides API-first development using openapi-generator to
+                        Plugin that provides API-first development using openapi-generator-cli to
                         generate Spring-MVC endpoint stubs at compile time from an OpenAPI definition file
                     -->
                     <groupId>org.openapitools</groupId>


### PR DESCRIPTION
Fix #14287

This PR update the openapi-cli to the latest version (not sure if people use the `openapi-client` generator).

The command was renamed to `openapi-generator-cli` instead of `openapi-generator` with the new version.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
