### PR TITLE
adapt release drafter config to have smaller github release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,6 +3,10 @@ template: |
 
   $CHANGES
 
+exclude-labels:
+  - 'theme: dependencies'
+include-labels:
+  - 'release-notes'
 exclude-contributors:
   - 'dependabot'
 categories:


### PR DESCRIPTION
With this configuration dependabot PRs are excluded and only PRs with label "release-notes" (must be added manually to a PR) are added to release notes. Hope this works now, at least thats what the documentation says.

Relates too #18319 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
