### PR TITLE
fix Croatian translation for global.entity.action.view #18386 

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/hr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hr/global.json.ejs
@@ -118,7 +118,7 @@
             "edit": "Uredi",
             "open": "Otvori",
             "save": "Spremi",
-            "view": "Preged"
+            "view": "Pregled"
         },
         "detail": {
             "field": "Polje",


### PR DESCRIPTION
 The Croatian translation for global.entity.action.view is correct #18386 