### PR TITLE
define boot dev tools only in main gradle

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -16,12 +16,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-dependencies {
-    developmentOnly "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
 <%_ if (devDatabaseTypeH2Disk || devDatabaseTypeH2Memory) { _%>
+dependencies {
     implementation "com.h2database:h2"
-<%_ } _%>
 }
+<%_ } _%>
 
 def profiles = "dev"
 if (project.hasProperty("no-liquibase")) {


### PR DESCRIPTION
We define it already in main build file, no need to have it dev profile again.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
