### PR TITLE
update gradle git properties to get rid of slf4j warnings

### DIFF
--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -61,7 +61,7 @@ cassandraDriverVersion=4.13.0
 
 # gradle plugin version
 jibPluginVersion=<%= JIB_VERSION %>
-gitPropertiesPluginVersion=2.4.0
+gitPropertiesPluginVersion=2.4.1
 <%_ if (!skipClient) { _%>
 gradleNodePluginVersion=3.2.1
 <%_ } _%>


### PR DESCRIPTION
This fixes the annoying slf4 logger binding warning when using e.g. bootRun. See https://github.com/n0mer/gradle-git-properties/issues/203 for details.

CC @mraible 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
