### PR TITLE
Make husky script executable

### DIFF
--- a/generators/common/files.js
+++ b/generators/common/files.js
@@ -41,12 +41,10 @@ const commonFiles = {
         {
           file: 'gitattributes',
           renameTo: () => '.gitattributes',
-          method: 'copy',
         },
         {
           file: 'editorconfig',
           renameTo: () => '.editorconfig',
-          method: 'copy',
         },
         {
           file: 'sonar-project.properties',
@@ -58,12 +56,7 @@ const commonFiles = {
   commitHooks: [
     {
       condition: generator => !generator.skipCommitHook,
-      templates: [
-        '.lintstagedrc.js',
-        {
-          file: '.husky/pre-commit',
-        },
-      ],
+      templates: ['.lintstagedrc.js', '.husky/pre-commit'],
     },
   ],
 };
@@ -71,7 +64,7 @@ const commonFiles = {
 function writeFiles() {
   return {
     writeFiles() {
-      return this.writeFilesToDisk(commonFiles);
+      return this.writeFiles({ sections: commonFiles });
     },
   };
 }

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -18,6 +18,8 @@
  */
 /* eslint-disable consistent-return */
 const _ = require('lodash');
+const chalk = require('chalk');
+const fs = require('fs');
 
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const {
@@ -28,6 +30,7 @@ const {
   DEFAULT_PRIORITY,
   WRITING_PRIORITY,
   POST_WRITING_PRIORITY,
+  INSTALL_PRIORITY,
 } = require('../../lib/constants/priorities.cjs').compat;
 
 const writeFiles = require('./files').writeFiles;
@@ -215,5 +218,26 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   get [POST_WRITING_PRIORITY]() {
     if (this.delegateToBlueprint) return {};
     return this._postWriting();
+  }
+
+  _install() {
+    return {
+      makeHuskyScriptExecutable() {
+        try {
+          fs.chmodSync('.husky/pre-commit', '755');
+        } catch (err) {
+          this.log(
+            `${chalk.yellow.bold(
+              'WARNING!'
+            )} Failed to make '.husky/pre-commit' executable, you may need to run 'chmod +x .husky/pre-commit'`
+          );
+        }
+      },
+    };
+  }
+
+  get [INSTALL_PRIORITY]() {
+    if (this.delegateToBlueprint) return;
+    return this._install();
   }
 };

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -18,8 +18,6 @@
  */
 /* eslint-disable consistent-return */
 const _ = require('lodash');
-const chalk = require('chalk');
-const fs = require('fs');
 
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const {
@@ -30,7 +28,6 @@ const {
   DEFAULT_PRIORITY,
   WRITING_PRIORITY,
   POST_WRITING_PRIORITY,
-  INSTALL_PRIORITY,
 } = require('../../lib/constants/priorities.cjs').compat;
 
 const writeFiles = require('./files').writeFiles;
@@ -218,26 +215,5 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
   get [POST_WRITING_PRIORITY]() {
     if (this.delegateToBlueprint) return {};
     return this._postWriting();
-  }
-
-  _install() {
-    return {
-      makeHuskyScriptExecutable() {
-        try {
-          fs.chmodSync('.husky/pre-commit', '755');
-        } catch (err) {
-          this.log(
-            `${chalk.yellow.bold(
-              'WARNING!'
-            )} Failed to make '.husky/pre-commit' executable, you may need to run 'chmod +x .husky/pre-commit'`
-          );
-        }
-      },
-    };
-  }
-
-  get [INSTALL_PRIORITY]() {
-    if (this.delegateToBlueprint) return;
-    return this._install();
   }
 };


### PR DESCRIPTION
This fixes a error you get from husky after trying to commit for the first time after starting a new project:
```
hint: The '.husky/pre-commit' hook was ignored because it's not set as executable.
hint: You can disable this warning with `git config advice.ignoredHook false`.
```

I think `_install()` is the right function to put this in. Tried putting it in `_postWriting()`, but the chmod was running too early it seems. Also tried `_end()`, but it was getting run after the git repo and initial commit were already made. But please let me know if there's a better place to put this.

And I formatted the log message similar to how I had seen it elsewhere:
https://github.com/jhipster/generator-jhipster/blob/v7.8.1/generators/kubernetes-helm/index.js#L177-L186

Fix #18537

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
