### PR TITLE
Remove constraint for login function

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/support/commands.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/support/commands.ts.ejs
@@ -173,10 +173,8 @@ Cypress.Commands.add('login', (username: string, password: string) => {
 declare global {
   namespace Cypress {
     interface Chainable {
-<%_ if (!authenticationTypeOauth2) { _%>
-      login(username: string, password: string): Cypress.Chainable;
-<%_ } _%>
       authenticatedRequest(data: any): Cypress.Chainable;
+      login(username: string, password: string): Cypress.Chainable;
     }
   }
 }


### PR DESCRIPTION
Since the login function is defined here:

https://github.com/jhipster/generator-jhipster/blob/b474b1ea960d604da6fa19fc06cac43acbec434c/generators/cypress/templates/src/test/javascript/cypress/support/commands.ts.ejs#L133-L136

and used here without constraints:

https://github.com/jhipster/generator-jhipster/blob/61a47dbe197873286f815b5fc37e55445842e477/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs#L61-L63

the constraints around the declaration should be removed.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
