### PR TITLE
Use correct env variable for Java options

### DIFF
--- a/generators/kubernetes-knative/templates/service.yml.ejs
+++ b/generators/kubernetes-knative/templates/service.yml.ejs
@@ -147,7 +147,7 @@ spec:
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: "x-request-id,x-ot-span-context"
 <%_ } _%>
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: " -Xmx256m -Xms256m"
             - name: SERVER_SHUTDOWN
               value: graceful

--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -216,7 +216,7 @@ spec:
         - name: SPRING_SLEUTH_PROPAGATION_KEYS
           value: "x-request-id,x-ot-span-context"
 <%_ } _%>
-        - name: JAVA_OPTS
+        - name: JAVA_TOOL_OPTIONS
           value: " -Xmx256m -Xms256m"
         - name: SERVER_SHUTDOWN
           value: graceful

--- a/test/__snapshots__/knative.spec.js.snap
+++ b/test/__snapshots__/knative.spec.js.snap
@@ -580,7 +580,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -864,7 +864,7 @@ spec:
                   value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -1559,7 +1559,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -2268,7 +2268,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -2469,7 +2469,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -3163,7 +3163,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -3923,7 +3923,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -4133,7 +4133,7 @@ spec:
                       key: mariadb-root-password
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -4343,7 +4343,7 @@ spec:
                   value: \\"mongodb://msmongodb-mongodb-0.msmongodb-mongodb.default:27017\\"
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -4541,7 +4541,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -4825,7 +4825,7 @@ spec:
                   value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -7865,7 +7865,7 @@ spec:
                   value: \\"true\\"
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -8515,7 +8515,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.mynamespace.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -9218,7 +9218,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.jhipsternamespace.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -9658,7 +9658,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -9949,7 +9949,7 @@ spec:
                   value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -10545,7 +10545,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -11170,7 +11170,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -11396,7 +11396,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -11992,7 +11992,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -12632,7 +12632,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -12886,7 +12886,7 @@ spec:
                       key: mariadb-root-password
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -13352,7 +13352,7 @@ spec:
                   value: \\"mongodb://msmongodb-mongodb-0.msmongodb-mongodb.default:27017\\"
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -13571,7 +13571,7 @@ spec:
                       key: secret
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -13769,7 +13769,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -14060,7 +14060,7 @@ spec:
                   value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -17322,7 +17322,7 @@ spec:
                   value: \\"true\\"
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -17900,7 +17900,7 @@ spec:
                   value: jdbc:mysql://msmysql-mysql.mynamespace.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful
@@ -18504,7 +18504,7 @@ spec:
                   value: jdbc:mysql://jhgate-mysql.jhipsternamespace.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
                 - name: SPRING_SLEUTH_PROPAGATION_KEYS
                   value: \\"x-request-id,x-ot-span-context\\"
-                - name: JAVA_OPTS
+                - name: JAVA_TOOL_OPTIONS
                   value: \\" -Xmx256m -Xms256m\\"
                 - name: SERVER_SHUTDOWN
                   value: graceful

--- a/test/__snapshots__/kubernetes.helm.spec.js.snap
+++ b/test/__snapshots__/kubernetes.helm.spec.js.snap
@@ -324,7 +324,7 @@ spec:
               value: \\"org.apache.kafka.common.serialization.StringDeserializer\\"
             - name: KAFKA_PRODUCER_VALUE_DESERIALIZER
               value: \\"org.apache.kafka.common.serialization.StringDeserializer\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -833,7 +833,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -1017,7 +1017,7 @@ spec:
               value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -1579,7 +1579,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -2105,7 +2105,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -2281,7 +2281,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -2919,7 +2919,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -3580,7 +3580,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -3769,7 +3769,7 @@ spec:
                   key: mariadb-root-password
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -3952,7 +3952,7 @@ spec:
               value: \\"mongodb://msmongodb-mongodb-0.msmongodb-mongodb.default:27017\\"
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -4125,7 +4125,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -4309,7 +4309,7 @@ spec:
               value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -4675,7 +4675,7 @@ spec:
               value: jdbc:mysql://samplemysql-mysql.default.svc.cluster.local:3306/samplemysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_ELASTICSEARCH_REST_URIS
               value: http://samplemysql-elasticsearch.default.svc.cluster.local:9200
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -7589,7 +7589,7 @@ spec:
               value: \\"true\\"
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -8090,7 +8090,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.mynamespace.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -8591,7 +8591,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.jhipsternamespace.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful

--- a/test/__snapshots__/kubernetes.spec.js.snap
+++ b/test/__snapshots__/kubernetes.spec.js.snap
@@ -343,7 +343,7 @@ spec:
               value: \\"org.apache.kafka.common.serialization.StringDeserializer\\"
             - name: KAFKA_PRODUCER_VALUE_DESERIALIZER
               value: \\"org.apache.kafka.common.serialization.StringDeserializer\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -758,7 +758,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -952,7 +952,7 @@ spec:
               value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -1523,7 +1523,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -2095,7 +2095,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -2359,7 +2359,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -2975,7 +2975,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -3697,7 +3697,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -3994,7 +3994,7 @@ spec:
                   key: mariadb-root-password
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -4203,7 +4203,7 @@ spec:
               value: \\"mongodb://msmongodb-mongodb-0.msmongodb-mongodb.default:27017\\"
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -4647,7 +4647,7 @@ spec:
                   key: secret
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -4852,7 +4852,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -5046,7 +5046,7 @@ spec:
               value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -5671,7 +5671,7 @@ spec:
               value: jdbc:mysql://samplemysql-mysql.default.svc.cluster.local:3306/samplemysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_ELASTICSEARCH_REST_URIS
               value: http://samplemysql-elasticsearch.default.svc.cluster.local:9200
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -8826,7 +8826,7 @@ spec:
               value: \\"true\\"
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -9411,7 +9411,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.mynamespace.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -9888,7 +9888,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.default.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -10185,7 +10185,7 @@ spec:
                   key: mariadb-root-password
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -10394,7 +10394,7 @@ spec:
               value: \\"mongodb://msmongodb-mongodb-0.msmongodb-mongodb.default:27017\\"
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -10838,7 +10838,7 @@ spec:
                   key: secret
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -11043,7 +11043,7 @@ spec:
               value: jdbc:mysql://msmysql-mysql.default.svc.cluster.local:3306/msmysql?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -11237,7 +11237,7 @@ spec:
               value: http://mspsql-elasticsearch.default.svc.cluster.local:9200
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful
@@ -11819,7 +11819,7 @@ spec:
               value: jdbc:mysql://jhgate-mysql.jhipsternamespace.svc.cluster.local:3306/jhgate?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
             - name: SPRING_SLEUTH_PROPAGATION_KEYS
               value: \\"x-request-id,x-ot-span-context\\"
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: \\" -Xmx256m -Xms256m\\"
             - name: SERVER_SHUTDOWN
               value: graceful


### PR DESCRIPTION
The `JAVA_OPTS` environment variable is not picked up by the JVM.

Using `JAVA_TOOL_OPTIONS` instead.

Maybe this could also be changed for the Docker Compose files, so these options can be overridden by command line if necessary.

See [here](https://stackoverflow.com/questions/28327620/difference-between-java-options-java-tool-options-and-java-opts) for more details.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
