### PR TITLE
Avoid StackoverflowError when updating entity

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.jhi.elastic_search.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.jhi.elastic_search.ejs
@@ -31,3 +31,12 @@
     <%_ } _%>
   <&_ } -&>
 <%_ } -%>
+
+<%_ for (const relationship of relationships) { -%>
+  <&_ if (fragment.relationship<%- relationship.relationshipNameCapitalized %>AnnotationSection) { -&>
+    <% // just break the cycle // in the reactive area, we already have the annotation in place
+      if (!relationship.ownerSide && !reactive) { %>
+        @org.springframework.data.annotation.Transient
+    <% } %>
+  <&_ } -&>
+<%_ } -%>

--- a/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
@@ -157,7 +157,7 @@ class <%= entityClass %>SearchRepositoryInternalImpl implements <%= entityClass 
 
     @Override
     public void index(<%= persistClass %> entity) {
-        repository.find<% if (implementsEagerLoadApis) { %>OneWithEagerRelationships<% } else { %>ById<% } %>(entity.getId()).ifPresent(elasticsearchTemplate::save);
+        repository.find<% if (implementsEagerLoadApis) { %>OneWithEagerRelationships<% } else { %>ById<% } %>(entity.get<%= primaryKey.nameCapitalized %>()).ifPresent(elasticsearchTemplate::save);
     }
 }
 <%_ } _%>

--- a/test-integration/samples/jdl-entities/custom-id.jdl
+++ b/test-integration/samples/jdl-entities/custom-id.jdl
@@ -169,3 +169,38 @@ relationship ManyToMany {
 
 filter UuidIdFiltering, UuidIdFilteringMapsId, UuidIdFilteringRelationship
 service UuidIdFiltering, UuidIdFilteringMapsId, UuidIdFilteringRelationship with serviceClass
+
+/*
+ * Custom named id with required relationships, mapstruct dtos and search
+ */
+@ChangelogDate(20200804035700)
+entity EntityCustomIdRequiredDTO {
+  @Id customId Long
+}
+
+@ChangelogDate(20200804035701)
+entity EntityCustomIdRequiredDTOMapsId {
+}
+
+@ChangelogDate(20200804035702)
+entity EntityCustomIdRequiredDTORel {
+  @Id relatedId Long
+}
+
+relationship OneToOne {
+  EntityCustomIdRequiredDTOMapsId to @Id EntityCustomIdRequiredDTO
+  EntityCustomIdRequiredDTORel{oneToOne required} to EntityCustomIdRequiredDTO{oneToOneBack}
+  EntityCustomIdRequiredDTORel{oneToOneMapsId required} to EntityCustomIdRequiredDTOMapsId{oneToOneMapsIdBack}
+}
+
+relationship ManyToOne {
+  EntityCustomIdRequiredDTORel{manyToOne required} to EntityCustomIdRequiredDTO{manyToOneBack}
+  EntityCustomIdRequiredDTORel{manyToOneMapsId required} to EntityCustomIdRequiredDTOMapsId{manyToOneMapsIdBack}
+}
+
+relationship ManyToMany {
+  EntityCustomIdRequiredDTORel{manyToMany required} to EntityCustomIdRequiredDTO{manyToManyBack}
+  EntityCustomIdRequiredDTORel{manyToManyMapsId required} to EntityCustomIdRequiredDTOMapsId{manyToManyMapsIdBack}
+}
+
+dto EntityCustomIdRequiredDTO, EntityCustomIdRequiredDTOMapsId, EntityCustomIdRequiredDTORel with mapstruct


### PR DESCRIPTION
when elasticsearch is enabled. We do add Spring Data
Transient annotation on the non-owning side
of relationships to break the artificial cycle introduced with the
bidirectional relationship model

Fix #18729
Fix #14840
Fix #16136

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
