### PR TITLE
skip applications install when generating workspaces.

### DIFF
--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -391,13 +391,10 @@ class JDLProcessor {
     statistics.sendSubGenEvent('generator', 'import-jdl');
   }
 
-  generateWorkspaces(options) {
-    if (!options.workspaces || !multiplesApplications(this)) {
-      return Promise.resolve();
-    }
+  generateWorkspaces(options, generateJdl) {
     return EnvironmentBuilder.createDefaultBuilder()
       .getEnvironment()
-      .run('jhipster:workspaces', { workspaces: false, ...options, importState: this.importState, skipInstall: true });
+      .run('jhipster:workspaces', { workspaces: false, ...options, importState: this.importState, generateJdl });
   }
 
   generateApplications() {
@@ -532,18 +529,25 @@ module.exports = (jdlFiles, options = {}, env) => {
     jdlImporter.sendInsight();
     jdlImporter.config();
 
-    return jdlImporter
-      .generateWorkspaces(options)
-      .then(() => jdlImporter.generateApplications())
-      .then(() => jdlImporter.generateEntities(env))
-      .then(() => jdlImporter.generateDeployments())
-      .then(() => {
-        if (options.workspaces) {
-          logger.log(`${chalk.green.bold("'npm install'")} was skipped due to workspaces. Run it by yourself.`);
-        }
-        printSuccess();
-        return jdlFiles;
-      });
+    const generateJdl = () =>
+      jdlImporter
+        .generateApplications()
+        .then(() => jdlImporter.generateEntities(env))
+        .then(() => jdlImporter.generateDeployments());
+
+    let generation;
+    if (!options.workspaces || !multiplesApplications(jdlImporter)) {
+      generation = generateJdl();
+    } else {
+      // Wrap generation inside workspaces root generation.
+      // generate applications after git initialization and before root npm install
+      generation = jdlImporter.generateWorkspaces(options, generateJdl);
+    }
+
+    return generation.then(() => {
+      printSuccess();
+      return jdlFiles;
+    });
   } catch (e) {
     logger.error(`Error during import-jdl: ${e}`, e);
     return Promise.reject(new Error(`Error during import-jdl: ${e.message}`));

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -144,6 +144,7 @@ function writeApplicationConfig(applicationWithEntities, basePath) {
  * @param {Promise}
  */
 function runGenerator(command, { cwd, fork, env }, generatorOptions = {}) {
+  const { workspaces } = generatorOptions;
   generatorOptions = {
     ...generatorOptions,
     // Remove jdl command exclusive options
@@ -161,6 +162,9 @@ function runGenerator(command, { cwd, fork, env }, generatorOptions = {}) {
     commandName: undefined,
     fromJdl: true,
   };
+  if (workspaces) {
+    generatorOptions.skipInstall = true;
+  }
   if (!generatorOptions.blueprints) {
     delete generatorOptions.blueprints;
   }
@@ -393,7 +397,7 @@ class JDLProcessor {
     }
     return EnvironmentBuilder.createDefaultBuilder()
       .getEnvironment()
-      .run('jhipster:workspaces', { workspaces: false, ...options, importState: this.importState });
+      .run('jhipster:workspaces', { workspaces: false, ...options, importState: this.importState, skipInstall: true });
   }
 
   generateApplications() {
@@ -534,6 +538,9 @@ module.exports = (jdlFiles, options = {}, env) => {
       .then(() => jdlImporter.generateEntities(env))
       .then(() => jdlImporter.generateDeployments())
       .then(() => {
+        if (options.workspaces) {
+          logger.log(`${chalk.green.bold("'npm install'")} was skipped due to workspaces. Run it by yourself.`);
+        }
         printSuccess();
         return jdlFiles;
       });


### PR DESCRIPTION
Current jdl generation makes npm workspaces unsuitable for auto install.
So disable it by default.

npm 8.<something> changed the workspaces behavior by deduping dependencies to the root.
We generate applications in parallel, so `install` will be executed 3 times in same npm tree causing lots of problems.
We need to execute `npm install` only once.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
