### PR TITLE
switch cassandra sample to cassandra db

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -184,11 +184,6 @@ module.exports = class extends BaseDockerGenerator {
             delete databaseYamlConfig.ports;
 
             if (database === CASSANDRA) {
-              // node config
-              // const cassandraClusterYaml = jsyaml.load(this.fs.read(`${path}/src/main/docker/cassandra-cluster.yml`));
-              // const cassandraNodeConfig = cassandraClusterYaml.services[`${databaseServiceName}-node`];
-              // parentConfiguration[`${databaseServiceName}-node`] = cassandraNodeConfig;
-
               // migration service config
               const cassandraMigrationConfig = databaseYaml.services[`${databaseServiceName}-migration`];
 

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -185,18 +185,19 @@ module.exports = class extends BaseDockerGenerator {
 
             if (database === CASSANDRA) {
               // node config
-              const cassandraClusterYaml = jsyaml.load(this.fs.read(`${path}/src/main/docker/cassandra-cluster.yml`));
-              const cassandraNodeConfig = cassandraClusterYaml.services[`${databaseServiceName}-node`];
-              parentConfiguration[`${databaseServiceName}-node`] = cassandraNodeConfig;
+              // const cassandraClusterYaml = jsyaml.load(this.fs.read(`${path}/src/main/docker/cassandra-cluster.yml`));
+              // const cassandraNodeConfig = cassandraClusterYaml.services[`${databaseServiceName}-node`];
+              // parentConfiguration[`${databaseServiceName}-node`] = cassandraNodeConfig;
 
               // migration service config
-              const cassandraMigrationYaml = jsyaml.load(this.fs.read(`${path}/src/main/docker/cassandra-migration.yml`));
-              const cassandraMigrationConfig = cassandraMigrationYaml.services[`${databaseServiceName}-migration`];
+              const cassandraMigrationConfig = databaseYaml.services[`${databaseServiceName}-migration`];
+
+              // replace script with prod
+              cassandraMigrationConfig.environment = [
+                ...cassandraMigrationConfig.environment.filter(envVariable => !envVariable.includes('CREATE_KEYSPACE_SCRIPT=')),
+                'CREATE_KEYSPACE_SCRIPT=create-keyspace-prod.cql',
+              ];
               cassandraMigrationConfig.build.context = relativePath;
-              const createKeyspaceScript = cassandraClusterYaml.services[`${databaseServiceName}-migration`].environment.find(envVariable =>
-                envVariable.includes('CREATE_KEYSPACE_SCRIPT')
-              );
-              cassandraMigrationConfig.environment.push(createKeyspaceScript);
               const cqlFilesRelativePath = normalize(pathjs.relative(this.destinationRoot(), `${path}/src/main/resources/config/cql`));
               cassandraMigrationConfig.volumes[0] = `${cqlFilesRelativePath}:/cql:ro`;
 

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -215,10 +215,6 @@ _%>
       - 127.0.0.1:7199:7199
       - 127.0.0.1:9042:9042
       - 127.0.0.1:9160:9160
-  <%= baseName.toLowerCase() %>-cassandra-node:
-    image: <%= DOCKER_CASSANDRA %>
-    environment:
-      - CASSANDRA_SEEDS=<%= baseName.toLowerCase() %>-cassandra
   <%= baseName.toLowerCase() %>-cassandra-migration:
     environment:
       - CASSANDRA_CONTACT_POINT=<%= baseName.toLowerCase() %>-cassandra

--- a/generators/server/templates/src/main/docker/cassandra-migration.yml.ejs
+++ b/generators/server/templates/src/main/docker/cassandra-migration.yml.ejs
@@ -23,6 +23,7 @@ services:
       - CASSANDRA_CONTACT_POINT=<%= baseName.toLowerCase() %>-cassandra
       - USER=docker-cassandra-migration
       # - DEBUG_LOG=1 # uncomment to show debug logs during the migration process
+      - CREATE_KEYSPACE_SCRIPT=create-keyspace.cql
     build:
       context: .
       dockerfile: cassandra/Cassandra-Migration.Dockerfile

--- a/test-integration/jdl-samples/ms-react-consul-jwt-cassandra-redis/blog-store.jdl
+++ b/test-integration/jdl-samples/ms-react-consul-jwt-cassandra-redis/blog-store.jdl
@@ -45,9 +45,7 @@ application {
     buildTool gradle
     cacheProvider redis
     creationTimestamp 1617901618887
-    // TODO switch to cassandra
-    // databaseType cassandra
-    prodDatabaseType postgresql
+    databaseType cassandra
     jwtSecretKey "ZjY4MTM4YjI5YzMwZjhjYjI2OTNkNTRjMWQ5Y2Q0Y2YwOWNmZTE2NzRmYzU3NTMwM2NjOTE3MTllOTM3MWRkMzcyYTljMjVmNmQ0Y2MxOTUzODc0MDhhMTlkMDIxMzI2YzQzZDM2ZDE3MmQ3NjVkODk3OTVmYzljYTQyZDNmMTQ="
     packageName com.okta.developer.blog
     serverPort 8081
@@ -86,14 +84,13 @@ application {
     baseName notification,
     buildTool maven
     creationTimestamp 1617901618889
-    // TODO switch to cassandra
-    // databaseType cassandra
-    prodDatabaseType postgresql
-    // dtoSuffix Rest
-    // entitySuffix Entity
+    databaseType cassandra
+    dtoSuffix Rest
+    entitySuffix Entity
     jwtSecretKey "ZjY4MTM4YjI5YzMwZjhjYjI2OTNkNTRjMWQ5Y2Q0Y2YwOWNmZTE2NzRmYzU3NTMwM2NjOTE3MTllOTM3MWRkMzcyYTljMjVmNmQ0Y2MxOTUzODc0MDhhMTlkMDIxMzI2YzQzZDM2ZDE3MmQ3NjVkODk3OTVmYzljYTQyZDNmMTQ="
     packageName com.okta.developer.notification
-    reactive true
+    // TODO switch to reactive
+    // reactive true
     serverPort 8083
     serviceDiscoveryType consul
     testFrameworks [cucumber, gatling]
@@ -101,10 +98,12 @@ application {
   entities Notification
 }
 
+/* TODO enable when gateway+cassandra is fixed
 @ChangelogDate(20210408164809)
 entity UserData {
   address String
 }
+*/
 
 @ChangelogDate(20210408164810)
 entity Blog {

--- a/test/__snapshots__/docker-compose.spec.js.snap
+++ b/test/__snapshots__/docker-compose.spec.js.snap
@@ -216,10 +216,6 @@ eureka:
       - SPRING_DATA_CASSANDRA_CONTACTPOINTS=cassandra
       - JHIPSTER_SLEEP=30
       - JHIPSTER_REGISTRY_PASSWORD=admin
-  mscassandra-cassandra-node:
-    image: cassandra:3.11.13
-    environment:
-      - CASSANDRA_SEEDS=mscassandra-cassandra
   mscassandra-cassandra-migration:
     environment:
       - CASSANDRA_CONTACT_POINT=mscassandra-cassandra

--- a/test/templates/compose/05-cassandra/src/main/docker/cassandra.yml
+++ b/test/templates/compose/05-cassandra/src/main/docker/cassandra.yml
@@ -13,9 +13,10 @@ services:
     mscassandra-cassandra-migration:
         environment:
             - CASSANDRA_CONTACT_POINT=mscassandra-cassandra
+            - USER=docker-cassandra-migration
             - CREATE_KEYSPACE_SCRIPT=create-keyspace.cql
         build:
             context: .
-            dockerfile: cassandra/Cassandra.Dockerfile
+            dockerfile: cassandra/Cassandra-Migration.Dockerfile
         volumes:
             - ../resources/config/cql:/cql:ro


### PR DESCRIPTION
- don't generate cassandra-node at app.yml and docker compose, it's not required.
- adjust cassandra template
- cassandra+reactive is not supported, use imperative instead and add TODO
- cassandra+gateway(reactive) is not supported, nodb + jwt is not supported, use gateway with postgresql.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
