### PR TITLE
Restored cache invalidation for Vue client

### DIFF
--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -30,6 +30,10 @@ module.exports = (env, options) => {
     },
     // cheap-module-eval-source-map is faster for development
     devtool: config.dev.devtool,
+    output: {
+      filename: 'app/[contenthash].bundle.js',
+      chunkFilename: 'app/[id].chunk.js'
+    },
     optimization: {
       moduleIds: 'named',
     },

--- a/generators/client/templates/vue/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.prod.js.ejs
@@ -36,6 +36,10 @@ const webpackConfig = {
     })
   },
   devtool: config.build.productionSourceMap ? config.build.devtool : false,
+  output: {
+    filename: 'app/[name].[contenthash].bundle.js',
+    chunkFilename: 'app/[id].[chunkhash].chunk.js'
+  },
   optimization: {
     moduleIds: 'deterministic',
     minimizer: [
@@ -90,7 +94,10 @@ const webpackConfig = {
       extractComments: false,
     }),
     // extract css into its own file
-    new MiniCssExtractPlugin(),
+    new MiniCssExtractPlugin({
+      filename: 'content/[name].[contenthash].css',
+      chunkFilename: 'content/[id].css'
+    }),
     // keep module.id stable when vendor modules does not change
     new ForkTsCheckerWebpackPlugin(
       {


### PR DESCRIPTION
Fix #17573 

> basically, cache invalidation was removed with [this commit](https://github.com/jhipster/generator-jhipster/commit/89364a74735f19bab0f54d437b4d08fe0f216a54)

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
