### PR TITLE
allow editFile to cascade callbacks.

### DIFF
--- a/generators/server/needles.cjs
+++ b/generators/server/needles.cjs
@@ -56,7 +56,7 @@ const { createBaseNeedle } = require('../../lib/support/needles.cjs');
  * );
  * @param {import('../generator-base.js')} [generator]
  * @param {ApplicationPropertiesNeedles} needles
- * @returns {string | import('../../generators/generator-base.js').EditFileCallback}
+ * @returns {import('../../generators/generator-base.js').CascatedEditFileCallback | import('../../generators/generator-base.js').EditFileCallback}
  */
 const insertContentIntoApplicationProperties = (generator, needles) => {
   if (!needles) {

--- a/lib/support/base.cjs
+++ b/lib/support/base.cjs
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2013-2022 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const { platform } = require('os');
+
+const isWin32 = platform() === 'win32';
+
+/**
+ * Converts multiples EditFileCallback callbacks into one.
+ *
+ * @param {...import('../../generators/generator-base.js').EditFileCallback} callbacks
+ * @returns {import('../../generators/generator-base.js').EditFileCallback}
+ */
+const joinCallbacks = (...callbacks) => {
+  return function (content, filePath) {
+    if (isWin32 && content.match(/\r\n/)) {
+      callbacks = [ct => ct.replace(/\r\n/g, '\n')].concat(callbacks).concat(ct => ct.replace(/\n/g, '\r\n'));
+    }
+    for (const callback of callbacks) {
+      content = callback.call(this, content, filePath);
+    }
+    return content;
+  };
+};
+
+module.exports = {
+  joinCallbacks,
+};

--- a/lib/support/base.spec.mjs
+++ b/lib/support/base.spec.mjs
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2013-2022 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'expect';
+import jest from 'jest-mock';
+
+import { joinCallbacks } from './base.cjs';
+
+describe('base support', () => {
+  describe('joinCallbacks', () => {
+    it('should return a function', () => {
+      expect(typeof joinCallbacks()).toBe('function');
+    });
+
+    it('without callbacks, should return the original content', () => {
+      expect(joinCallbacks()('original')).toBe('original');
+    });
+
+    it('with a callback, should return the callback return', () => {
+      const mock = jest.fn().mockReturnValue('return1');
+      const callback = joinCallbacks(mock);
+
+      expect(callback('original', 'file')).toBe('return1');
+
+      expect(mock.mock.calls[0][0]).toBe('original');
+      expect(mock.mock.calls[0][1]).toBe('file');
+    });
+
+    it('with two callbacks, should forward last callback and return the last callback return', () => {
+      const mock1 = jest.fn().mockReturnValue('return1');
+      const mock2 = jest.fn().mockReturnValue('return2');
+      const callback = joinCallbacks(mock1, mock2);
+
+      expect(callback('original', 'file')).toBe('return2');
+
+      expect(mock2.mock.calls[0][0]).toBe('return1');
+      expect(mock2.mock.calls[0][1]).toBe('file');
+    });
+  });
+});

--- a/lib/support/needles.cjs
+++ b/lib/support/needles.cjs
@@ -172,7 +172,7 @@ const createNeedleCallback = ({ needle, contentToAdd, optional = false, ignoreWh
  * @param {string} [options.filePath] path to file
  * @param {string} [options.needlesPrefix] common needle prefix
  * @param {boolean} [options.optional=false] throw error if needle was not found
- * @returns {string | import('../../generators/generator-base.js').EditFileCallback}
+ * @returns {import('../../generators/generator-base.js').CascatedEditFileCallback | import('../../generators/generator-base.js').EditFileCallback}
  */
 const createBaseNeedle = (options, needles) => {
   if (!needles) {


### PR DESCRIPTION
Allows needles to cascade with file defined by the needle:
```js
insertFooInSpecificFile(generator)(
  insertBar(),
  insertBar2()
)
```

Old notation needs the file:
```js
generator.editFile(
  'specificFile',
  insertFooInSpecificFile(),
  insertBar(),
  insertBar2()
)
```

`editFile` is new so it’s not a breaking change.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
