### PR TITLE
disable sonar at ci if frontend or backend were skiped.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -219,7 +219,14 @@ jobs:
         if: always()
         uses: jwalton/gh-docker-logs@v2
       - name: 'ANALYSIS: Sonar analysis'
-        if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 'false' && matrix.workspaces != 'true'
+        if: >-
+          steps.compare.outputs.equals != 'true' &&
+          matrix.sonar-analyse != 'false' &&
+          matrix.workspaces != 'true' &&
+          matrix.skip-frontend-tests != 1 &&
+          needs.build-matrix.outputs.client != 'false' &&
+          matrix.skip-backend-tests != 1 &&
+          needs.build-matrix.outputs.server != 'false'
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -219,7 +219,14 @@ jobs:
         if: always()
         uses: jwalton/gh-docker-logs@v2
       - name: 'ANALYSIS: Sonar analysis'
-        if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 'false' && matrix.workspaces != 'true'
+        if: >-
+          steps.compare.outputs.equals != 'true' &&
+          matrix.sonar-analyse != 'false' &&
+          matrix.workspaces != 'true' &&
+          matrix.skip-frontend-tests != 1 &&
+          needs.build-matrix.outputs.client != 'false' &&
+          matrix.skip-backend-tests != 1 &&
+          needs.build-matrix.outputs.server != 'false'
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -219,7 +219,14 @@ jobs:
         if: always()
         uses: jwalton/gh-docker-logs@v2
       - name: 'ANALYSIS: Sonar analysis'
-        if: steps.compare.outputs.equals != 'true' && matrix.sonar-analyse != 'false' && matrix.workspaces != 'true'
+        if: >-
+          steps.compare.outputs.equals != 'true' &&
+          matrix.sonar-analyse != 'false' &&
+          matrix.workspaces != 'true' &&
+          matrix.skip-frontend-tests != 1 &&
+          needs.build-matrix.outputs.client != 'false' &&
+          matrix.skip-backend-tests != 1 &&
+          needs.build-matrix.outputs.server != 'false'
         run: $JHI_SCRIPTS/25-sonar-analyze.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The build fails otherwise with the missing results.
Example: https://github.com/jhipster/generator-jhipster/runs/6917256799?check_suite_focus=true
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
