### PR TITLE
implement getTypescriptType

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -34,6 +34,7 @@ const { languageToJavaLanguage } = require('./utils');
 const JSONToJDLEntityConverter = require('../jdl/converters/json-to-jdl-entity-converter');
 const JSONToJDLOptionConverter = require('../jdl/converters/json-to-jdl-option-converter');
 const { stringify } = require('../utils');
+const { fieldIsEnum } = require('../utils/field');
 const { databaseData } = require('./sql-constants');
 
 const { ANGULAR, REACT, VUE } = SUPPORTED_CLIENT_FRAMEWORKS;
@@ -865,7 +866,7 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
   /**
    * Find key type for Typescript
    *
-   * @param {string} primaryKey - primary key definition
+   * @param {string | object} primaryKey - primary key definition
    * @returns {string} primary key type in Typescript
    */
   getTypescriptKeyType(primaryKey) {
@@ -874,6 +875,28 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
     }
     if ([TYPE_INTEGER, TYPE_LONG, TYPE_FLOAT, TYPE_DOUBLE, TYPE_BIG_DECIMAL].includes(primaryKey)) {
       return 'number';
+    }
+    return 'string';
+  }
+
+  /**
+   * Find type for Typescript
+   *
+   * @param {string} fieldType - field type
+   * @returns {string} field type in Typescript
+   */
+  getTypescriptType(fieldType) {
+    if ([TYPE_INTEGER, TYPE_LONG, TYPE_FLOAT, TYPE_DOUBLE, TYPE_BIG_DECIMAL].includes(fieldType)) {
+      return 'number';
+    }
+    if ([TYPE_LOCAL_DATE, TYPE_ZONED_DATE_TIME, TYPE_INSTANT].includes(fieldType)) {
+      return 'dayjs.Dayjs';
+    }
+    if ([TYPE_BOOLEAN].includes(fieldType)) {
+      return 'boolean';
+    }
+    if (fieldIsEnum(fieldType)) {
+      return fieldType;
     }
     return 'string';
   }

--- a/test/generator-base-private.spec.js
+++ b/test/generator-base-private.spec.js
@@ -1,10 +1,12 @@
 const path = require('path');
 const expect = require('chai').expect;
+const { expect: jestExpect } = require('expect');
 // using base generator which extends the private base
 const BaseGeneratorPrivate = require('../generators/generator-base-private').prototype;
 const BaseGenerator = require('../generators/generator-base').prototype; // TODO remove in favor of a cleaner architecture
 const { CASSANDRA, MONGODB, MYSQL, SQL } = require('../jdl/jhipster/database-types');
 const { MapperTypes } = require('../jdl/jhipster/entity-options');
+const { CommonDBTypes } = require('../jdl/jhipster/field-types');
 
 const NO_DTO = MapperTypes.NO;
 
@@ -282,6 +284,35 @@ export * from './entityFolderName/entityFileName.state';`;
     describe('when passing ../../foo', () => {
       it('throw an error', () => {
         expect(() => BaseGeneratorPrivate.getEntityParentPathAddition('../../foo')).to.throw();
+      });
+    });
+  });
+
+  describe('getTypescriptType', () => {
+    describe('when called with sql DB name', () => {
+      it('return SQL', () => {
+        jestExpect(Object.fromEntries(Object.values(CommonDBTypes).map(dbType => [dbType, BaseGeneratorPrivate.getTypescriptType(dbType)])))
+          .toMatchInlineSnapshot(`
+Object {
+  "AnyBlob": "string",
+  "BigDecimal": "number",
+  "Blob": "string",
+  "Boolean": "boolean",
+  "Double": "number",
+  "Duration": "string",
+  "Enum": "Enum",
+  "Float": "number",
+  "ImageBlob": "string",
+  "Instant": "dayjs.Dayjs",
+  "Integer": "number",
+  "LocalDate": "dayjs.Dayjs",
+  "Long": "number",
+  "String": "string",
+  "TextBlob": "string",
+  "UUID": "string",
+  "ZonedDateTime": "dayjs.Dayjs",
+}
+`);
       });
     });
   });

--- a/utils/field.js
+++ b/utils/field.js
@@ -245,7 +245,7 @@ function prepareFieldForTemplates(entityWithConfig, field, generator) {
     fieldNameUnderscored: _.snakeCase(field.fieldName),
     fieldNameHumanized: _.startCase(field.fieldName),
     fieldTranslationKey: `${entityWithConfig.i18nKeyPrefix}.${field.fieldName}`,
-    tsType: generator.getTypescriptKeyType(field.fieldType),
+    tsType: generator.getTypescriptType(field.fieldType),
     entity: entityWithConfig,
   });
   const fieldType = field.fieldType;
@@ -389,6 +389,10 @@ function fieldIsEnum(fieldType) {
     BOOLEAN,
     BYTES,
     BYTE_BUFFER,
+    ANY_BLOB,
+    BLOB,
+    IMAGE_BLOB,
+    TEXT_BLOB,
   ].includes(fieldType);
 }
 


### PR DESCRIPTION
`getTypescriptKeyType` only maps ids types, create `getTypescriptType` for all field types.

Related to https://github.com/jhipster/generator-jhipster/issues/18817 and https://github.com/jhipster/generator-jhipster/pull/18586.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
