### PR TITLE
Clear sort if unsortable

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.html.ejs
@@ -61,7 +61,7 @@
 <%_ } _%>
 
 <%_ if (jpaMetamodelFiltering && paginationPagination) { _%>
-    <<%= jhiPrefixDashed %>-filter [filters]="filters" (filterChange)="load()"></<%= jhiPrefixDashed %>-filter>
+    <<%= jhiPrefixDashed %>-filter [filters]="filters" (filterChange)="navigateToWithComponentValues()"></<%= jhiPrefixDashed %>-filter>
 <%_ } _%>
 
     <div class="alert alert-warning" id="no-result" *ngIf="<%= entityInstancePlural %>?.length === 0">

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.ts.ejs
@@ -18,10 +18,10 @@
 -%>
 <%_
   const notSortableFieldsAfterSearchArray = !searchEngine ? [] : fields
-      .filter(field => !field.hidden && !field.fieldTypeBoolean && !field.fieldTypeNumeric && !field.fieldTypeTemporal)
+      .filter(field => !field.hidden && !field.fieldTypeBoolean && !field.fieldTypeNumeric && !field.fieldTypeTemporal);
 
   const notSortableFieldsAfterSearchFieldNames = notSortableFieldsAfterSearchArray
-      .map(field => field.fieldName)
+      .map(field => field.fieldName);
 
   const notSortableFieldsAfterSearch = notSortableFieldsAfterSearchArray
       .map(field => `'${field.fieldName}'`)
@@ -79,6 +79,10 @@ import { SortService } from 'app/shared/sort/sort.service';
 })
 export class <%= componentName %> implements OnInit {
 
+<%_ if (notSortableFieldsAfterSearch) { _%>
+    private static readonly NOT_SORTABLE_FIELDS_AFTER_SEARCH = [<%- notSortableFieldsAfterSearch %>];
+
+<%_ } _%>
     <%= entityInstancePlural %>?: I<%= entityAngularName %>[];
     isLoading = false;
 
@@ -96,9 +100,7 @@ export class <%= componentName %> implements OnInit {
 <%_ } else if (paginationInfiniteScroll) { _%>
 <%- include('infinite-scroll-template'); -%>
 <%_ } _%>
-<%_ if (notSortableFieldsAfterSearch) { _%>
-    private static readonly NOT_SEARCHABLE_FIELDS_AFTER_SEARCH = [<%- notSortableFieldsAfterSearch %>];
-<%_ } _%>
+
     constructor(
       protected <%= entityInstance %>Service: <%= entityAngularName %>Service,
       protected activatedRoute: ActivatedRoute,
@@ -136,7 +138,7 @@ export class <%= componentName %> implements OnInit {
 <%_ if (searchEngine) { _%>
     search(query: string): void {
   <%_ if (notSortableFieldsAfterSearch) { _%>
-      if (query && <%= componentName %>.NOT_SEARCHABLE_FIELDS_AFTER_SEARCH.includes(this.predicate)) {
+      if (query && <%= componentName %>.NOT_SORTABLE_FIELDS_AFTER_SEARCH.includes(this.predicate)) {
     <%_ if (notSortableFieldsAfterSearchFieldNames.includes(primaryKey.name)) { _%>
         this.predicate = '';
     <%_ } else { _%>
@@ -228,7 +230,7 @@ export class <%= componentName %> implements OnInit {
       if (params.has('search') && params.get('search') !== '') {
         this.currentSearch = params.get('search') as string;
   <%_ if (notSortableFieldsAfterSearch) { _%>
-          if (<%= componentName %>.NOT_SEARCHABLE_FIELDS_AFTER_SEARCH.includes(this.predicate)) {
+          if (<%= componentName %>.NOT_SORTABLE_FIELDS_AFTER_SEARCH.includes(this.predicate)) {
             this.predicate = '';
           }
   <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.ts.ejs
@@ -17,10 +17,17 @@
  limitations under the License.
 -%>
 <%_
-  const notSortableFieldsAfterSearch = !searchEngine ? '' : fields
+  const notSortableFieldsAfterSearchArray = !searchEngine ? [] : fields
       .filter(field => !field.hidden && !field.fieldTypeBoolean && !field.fieldTypeNumeric && !field.fieldTypeTemporal)
+
+  const notSortableFieldsAfterSearchFieldNames = notSortableFieldsAfterSearchArray
+      .map(field => field.fieldName)
+
+  const notSortableFieldsAfterSearch = notSortableFieldsAfterSearchArray
       .map(field => `'${field.fieldName}'`)
       .join(', ');
+  
+  const componentName = entityAngularName + 'Component';
 _%>
 import { Component, OnInit } from '@angular/core';
 <%_ if (!paginationNo) { _%>
@@ -70,7 +77,7 @@ import { SortService } from 'app/shared/sort/sort.service';
     selector: '<%= jhiPrefixDashed %>-<%= entityFileName %>',
     templateUrl: './<%= entityFileName %>.component.html'
 })
-export class <%= entityAngularName %>Component implements OnInit {
+export class <%= componentName %> implements OnInit {
 
     <%= entityInstancePlural %>?: I<%= entityAngularName %>[];
     isLoading = false;
@@ -85,11 +92,13 @@ export class <%= entityAngularName %>Component implements OnInit {
 <%_ } _%>
 
 <%_ if (paginationPagination) { _%>
-<%- include('pagination-template', { notSortableFieldsAfterSearch: notSortableFieldsAfterSearch }); -%>
+<%- include('pagination-template'); -%>
 <%_ } else if (paginationInfiniteScroll) { _%>
-<%- include('infinite-scroll-template', { notSortableFieldsAfterSearch: notSortableFieldsAfterSearch }); -%>
+<%- include('infinite-scroll-template'); -%>
 <%_ } _%>
-
+<%_ if (notSortableFieldsAfterSearch) { _%>
+    private static readonly NOT_SEARCHABLE_FIELDS_AFTER_SEARCH = [<%- notSortableFieldsAfterSearch %>];
+<%_ } _%>
     constructor(
       protected <%= entityInstance %>Service: <%= entityAngularName %>Service,
       protected activatedRoute: ActivatedRoute,
@@ -127,9 +136,13 @@ export class <%= entityAngularName %>Component implements OnInit {
 <%_ if (searchEngine) { _%>
     search(query: string): void {
   <%_ if (notSortableFieldsAfterSearch) { _%>
-      if (query && [<%- notSortableFieldsAfterSearch %>].includes(this.predicate)) {
+      if (query && <%= componentName %>.NOT_SEARCHABLE_FIELDS_AFTER_SEARCH.includes(this.predicate)) {
+    <%_ if (notSortableFieldsAfterSearchFieldNames.includes(primaryKey.name)) { _%>
+        this.predicate = '';
+    <%_ } else { _%>
         this.predicate = '<%- primaryKey.name %>';
         this.ascending = true;
+    <%_ } _%>
       }
   <%_ } _%>
   <%_ if (!paginationNo) { _%>
@@ -214,6 +227,11 @@ export class <%= entityAngularName %>Component implements OnInit {
 <%_ if (searchEngine) { _%>
       if (params.has('search') && params.get('search') !== '') {
         this.currentSearch = params.get('search') as string;
+  <%_ if (notSortableFieldsAfterSearch) { _%>
+          if (<%= componentName %>.NOT_SEARCHABLE_FIELDS_AFTER_SEARCH.includes(this.predicate)) {
+            this.predicate = '';
+          }
+  <%_ } _%>
       }
 <%_ } _%>
     }
@@ -342,6 +360,10 @@ export class <%= entityAngularName %>Component implements OnInit {
 
     protected getSortQueryParam(predicate = this.predicate, ascending = this.ascending): string[] {
       const ascendingQueryParam = ascending ? ASC : DESC;
-      return [predicate + ',' + ascendingQueryParam];
+      if (predicate === '') {
+        return [];
+      } else {
+        return [predicate + ',' + ascendingQueryParam];
+      }
     }
 }


### PR DESCRIPTION
<!--
PR description.
-->
Leave list unsorted if non-sortable field is used

Especially corrects broken search for non-sortable primary keys

Fixes https://github.com/jhipster/generator-jhipster/issues/18720

Also corrects the issue of non-clearable filters that had been implemented by me in #18621 but was missed to be changed in #18884 (there, the sort change event handler was updated, same is now also done for the filtering)

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
