### PR TITLE
Use specific RXJS version at workspace root.

### DIFF
--- a/generators/workspaces/index.js
+++ b/generators/workspaces/index.js
@@ -190,7 +190,7 @@ module.exports = class extends BaseBlueprintGenerator {
         if (!this.generateWorkspaces) return;
 
         const {
-          devDependencies: { rxjs },
+          dependencies: { rxjs },
         } = this.fs.readJSON(this.fetchFromInstalledJHipster('client', 'templates', 'angular', 'package.json'));
 
         this.packageJson.merge({

--- a/generators/workspaces/index.js
+++ b/generators/workspaces/index.js
@@ -189,12 +189,16 @@ module.exports = class extends BaseBlueprintGenerator {
       generatePackageJson() {
         if (!this.generateWorkspaces) return;
 
+        const {
+          devDependencies: { rxjs },
+        } = this.fs.readJSON(this.fetchFromInstalledJHipster('client', 'templates', 'angular', 'package.json'));
+
         this.packageJson.merge({
           workspaces: {
             packages: this.packages,
           },
           devDependencies: {
-            rxjs: '^7', // Not required, workaround https://github.com/npm/cli/issues/4437
+            rxjs, // Set version to workaround https://github.com/npm/cli/issues/4437
             concurrently: this.dependabotPackageJson.devDependencies.concurrently,
           },
           scripts: {


### PR DESCRIPTION
There is a new RXJS version.
When installing workspaces, concurrently is installing v7.5.6, while inside workspaces the required version is v7.5.5.
This is causing conflict between RXJS imported directly and RXJS imported by angular.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
