### PR TITLE
Revert "workaround intrusive warning due to deprecated bootstrap property"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,10 +70,6 @@ updates:
       # Should match generated project node major version.
       - dependency-name: '@types/node'
         versions: ['>=17']
-      # Force autoprefixer@10.4.5 to workaround https://github.com/twbs/bootstrap/issues/36259
-      # Drop when bootstrap@5.2.0 or 5.1.4 is released
-      - dependency-name: 'autoprefixer'
-        versions: ['>=10.4.6']
 
   - package-ecosystem: 'npm'
     directory: '/generators/client/templates/vue/'
@@ -95,10 +91,6 @@ updates:
       # Should match generated project node major version.
       - dependency-name: '@types/node'
         versions: ['>=17']
-      # Force autoprefixer@10.4.5 to workaround https://github.com/twbs/bootstrap/issues/36259
-      # Drop when bootstrap@5.2.0 or 5.1.4 is released
-      - dependency-name: 'autoprefixer'
-        versions: ['>=10.4.6']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -134,11 +134,6 @@
     "webpack-notifier": "<%= dependabotPackageJson.devDependencies['webpack-notifier'] %>"
   },
   "overrides": {
-<%#
-  Force autoprefixer@10.4.5 to workaround https://github.com/twbs/bootstrap/issues/36259
-  Drop when bootstrap@5.2.0 or 5.1.4 is released
-_%>
-    "autoprefixer": "10.4.5",
     "webpack": "<%= dependabotPackageJson.devDependencies['webpack'] %>"
   },
   "engines": {

--- a/generators/client/templates/react/package.json
+++ b/generators/client/templates/react/package.json
@@ -38,7 +38,7 @@
     "@types/webpack-env": "1.17.0",
     "@typescript-eslint/eslint-plugin": "5.30.7",
     "@typescript-eslint/parser": "5.30.7",
-    "autoprefixer": "10.4.5",
+    "autoprefixer": "10.4.7",
     "browser-sync": "2.27.10",
     "browser-sync-webpack-plugin": "2.3.0",
     "copy-webpack-plugin": "11.0.0",

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -222,13 +222,6 @@
     "webapp:test": "<%= clientPackageManager %> run test --",
     "webpack-dev-server": "webpack serve"
   },
-<%#
-  Force autoprefixer@10.4.5 to workaround https://github.com/twbs/bootstrap/issues/36259
-  Drop when bootstrap@5.2.0 or 5.1.4 is released
-_%>
-  "overrides": {
-    "autoprefixer": "10.4.5"
-  },
   "jestSonar": {
     "reportPath": "<%= BUILD_DIR %>test-results/jest",
     "reportFile": "TESTS-results-sonar.xml"

--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -29,7 +29,7 @@
     "@vue/vue2-jest": "28.0.1",
     "@vue/test-utils": "1.3.0",
     "axios-mock-adapter": "1.21.1",
-    "autoprefixer": "10.4.5",
+    "autoprefixer": "10.4.7",
     "browser-sync-webpack-plugin": "2.3.0",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.7.1",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -191,13 +191,6 @@
     "webpack-dev-server": "webpack serve --config webpack/webpack.common.js",
     "webpack": "webpack --config webpack/webpack.common.js"
   },
-<%#
-  Force autoprefixer@10.4.5 to workaround https://github.com/twbs/bootstrap/issues/36259
-  Drop when bootstrap@5.2.0 or 5.1.4 is released
-_%>
-  "overrides": {
-    "autoprefixer": "10.4.5"
-  },
   "jestSonar": {
     "reportPath": "<%= BUILD_DIR %>test-results/jest",
     "reportFile": "TESTS-results-sonar.xml"


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#19159

bootstrap@5.2.0 has been released.