### PR TITLE
updates k8s ingress resource to generate the current non-deprecated format

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -117,7 +117,7 @@ const KUBERNETES_CORE_API_VERSION = 'v1';
 const KUBERNETES_BATCH_API_VERSION = 'batch/v1';
 const KUBERNETES_DEPLOYMENT_API_VERSION = 'apps/v1';
 const KUBERNETES_STATEFULSET_API_VERSION = 'apps/v1';
-const KUBERNETES_INGRESS_API_VERSION = 'networking.k8s.io/v1beta1';
+const KUBERNETES_INGRESS_API_VERSION = 'networking.k8s.io/v1';
 const KUBERNETES_ISTIO_NETWORKING_API_VERSION = 'networking.istio.io/v1beta1';
 const KUBERNETES_RBAC_API_VERSION = 'rbac.authorization.k8s.io/v1';
 

--- a/generators/kubernetes/templates/ingress.yml.ejs
+++ b/generators/kubernetes/templates/ingress.yml.ejs
@@ -22,6 +22,7 @@ metadata:
   name: <%= app.baseName.toLowerCase() %>
   namespace: <%= kubernetesNamespace %>
 spec:
+  ingressClassName: <%= ingressTypeNginx || "nginx" %>
   rules:
   <%_ if (ingressDomain) { _%>
   - host: <%= app.baseName.toLowerCase() %>.<%= kubernetesNamespace %>.<%= ingressDomain %>
@@ -31,14 +32,20 @@ spec:
   <%_ } _%>
       paths:
       - path: /<%= ingressTypeNginx ? "" : "*" %>
+        pathType: Prefix
         backend:
-          serviceName: <%= app.baseName.toLowerCase() %>
-          servicePort: <%= app.serverPort %>
+          service:
+            name: <%= app.baseName.toLowerCase() %>
+            port:
+              name: http
       <%_ if (!app.serviceDiscoveryType) { _%>
         <%_ appConfigs.filter(config => config.baseName !== app.baseName).forEach(config => { _%>
       - path: /services/<%= config.baseName.toLowerCase() %>/<%= ingressTypeNginx ? "" : "*" %>
+        pathType: Prefix
         backend:
-          serviceName: <%= config.baseName.toLowerCase() %>
-          servicePort: <%= config.serverPort %>
+          service:
+            name: <%= config.baseName.toLowerCase() %>
+            port:
+              name: http
         <%_ }); _%>
       <%_ } _%>

--- a/generators/kubernetes/templates/ingress.yml.ejs
+++ b/generators/kubernetes/templates/ingress.yml.ejs
@@ -22,7 +22,7 @@ metadata:
   name: <%= app.baseName.toLowerCase() %>
   namespace: <%= kubernetesNamespace %>
 spec:
-  ingressClassName: <%= ingressTypeNginx || "nginx" %>
+  ingressClassName: <%= ingressType || "nginx" %>
   rules:
   <%_ if (ingressDomain) { _%>
   - host: <%= app.baseName.toLowerCase() %>.<%= kubernetesNamespace %>.<%= ingressDomain %>

--- a/generators/kubernetes/templates/monitoring/jhipster-grafana.yml.ejs
+++ b/generators/kubernetes/templates/monitoring/jhipster-grafana.yml.ejs
@@ -106,12 +106,16 @@ metadata:
   name: jhipster-grafana
   namespace: <%= kubernetesNamespace %>
 spec:
+  ingressClassName: nginx
   rules:
   - host: jhipster-grafana.<%= kubernetesNamespace %>.<%= ingressDomain %>
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: jhipster-grafana
-          servicePort: 3000
+          service:
+            name: jhipster-grafana
+            port: 
+              number: 3000
 <%_ } _%>

--- a/test/__snapshots__/kubernetes.helm.spec.js.snap
+++ b/test/__snapshots__/kubernetes.helm.spec.js.snap
@@ -1615,7 +1615,7 @@ metadata:
   name: jhgate
   namespace: default
 spec:
-  ingressClassName: nginx
+  ingressClassName: gke
   rules:
     - host: jhgate.default.example.com
       http:

--- a/test/__snapshots__/kubernetes.helm.spec.js.snap
+++ b/test/__snapshots__/kubernetes.helm.spec.js.snap
@@ -1615,7 +1615,7 @@ metadata:
   name: jhgate
   namespace: default
 spec:
-  ingressClassName: nginc
+  ingressClassName: nginx
   rules:
     - host: jhgate.default.example.com
       http:

--- a/test/__snapshots__/kubernetes.helm.spec.js.snap
+++ b/test/__snapshots__/kubernetes.helm.spec.js.snap
@@ -1609,20 +1609,24 @@ spec:
     "stateCleared": "modified",
   },
   "jhgate-helm/templates/jhgate-ingress.yml": Object {
-    "contents": "apiVersion: networking.k8s.io/v1beta1
+    "contents": "apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jhgate
   namespace: default
 spec:
+  ingressClassName: nginc
   rules:
     - host: jhgate.default.example.com
       http:
         paths:
           - path: /*
+            pathType: Prefix
             backend:
-              serviceName: jhgate
-              servicePort: 8080
+              service:
+                name: jhgate
+                port:
+                  name: http
 ",
     "stateCleared": "modified",
   },

--- a/test/__snapshots__/kubernetes.spec.js.snap
+++ b/test/__snapshots__/kubernetes.spec.js.snap
@@ -1553,20 +1553,24 @@ spec:
     "stateCleared": "modified",
   },
   "jhgate-k8s/jhgate-ingress.yml": Object {
-    "contents": "apiVersion: networking.k8s.io/v1beta1
+    "contents": "apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jhgate
   namespace: default
 spec:
+  ingressClassName: nginx
   rules:
     - host: jhgate.default.example.com
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: jhgate
-              servicePort: 8080
+              service:
+                name: jhgate
+                port:
+                  name: http
 ",
     "stateCleared": "modified",
   },


### PR DESCRIPTION
Since Kubernetes version 1.22 the `Ingress` resource version `v1beta1` is deprecated and no longer supported.

Using the old version prevents users of k8s version 1.22+ to deploy our generated k8s manifests

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
