### PR TITLE
Update spring-boot-thin-layout to version 1.0.28.RELEASE

### DIFF
--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -789,7 +789,7 @@ module.exports = class extends BaseBlueprintGenerator {
       addDependencies() {
         if (this.abort) return;
         if (this.buildTool === MAVEN) {
-          this.addMavenDependency('org.springframework.boot.experimental', 'spring-boot-thin-layout', '1.0.23.RELEASE');
+          this.addMavenDependency('org.springframework.boot.experimental', 'spring-boot-thin-layout', '1.0.28.RELEASE');
         }
         if (this.gaeCloudSQLInstanceNeeded === 'N') return;
         if (this.prodDatabaseType === MYSQL || this.prodDatabaseType === MARIADB) {


### PR DESCRIPTION
Update spring-boot-thin-layout to version 1.0.28.RELEASE
fix #17639

Error: An API incompatibility was encountered while executing org.springframework.boot:spring-boot-maven-plugin:2.5.8:repackage: java.lang.AbstractMethodError: Receiver class org.springframework.boot.loader.thin.ThinLayout does not define or inherit an implementation of the resolved method 'abstract java.lang.String getLibraryLocation(java.lang.String, org.springframework.boot.loader.tools.LibraryScope)' of interface org.springframework.boot.loader.tools.Layout.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
