### PR TITLE
reuse enviroment builder factory method and improve blueprint check

### DIFF
--- a/cli/jdl.js
+++ b/cli/jdl.js
@@ -41,13 +41,14 @@ const toJdlFile = file => {
  * @param {string[]} args[0] jdl files
  * @param {any} options options passed from CLI
  * @param {any} env the yeoman environment
- * @param {function} forkProcess the method to use for process forking
+ * @param {EnvironmentBuilder} envBuilder
+ * @param {(string[], object) => EnvironmentBuilder} createEnvBuilder
  */
-module.exports = ([jdlFiles = []], options = {}, env, forkProcess) => {
+module.exports = ([jdlFiles = []], options = {}, env, envBuilder, createEnvBuilder) => {
   logger.debug('cmd: import-jdl from ./import-jdl');
   logger.debug(`jdlFiles: ${toString(jdlFiles)}`);
   if (options.inline) {
-    return importJdl(jdlFiles, options, env, forkProcess);
+    return importJdl(jdlFiles, options, env, envBuilder, createEnvBuilder);
   }
   if (!jdlFiles || jdlFiles.length === 0) {
     logger.fatal(chalk.red('\nAt least one jdl file is required.\n'));
@@ -59,5 +60,5 @@ module.exports = ([jdlFiles = []], options = {}, env, forkProcess) => {
     }
     return Promise.resolve(filename);
   });
-  return Promise.all(promises).then(jdlFiles => importJdl(jdlFiles.flat(), options, env, forkProcess));
+  return Promise.all(promises).then(jdlFiles => importJdl(jdlFiles.flat(), options, env, envBuilder, createEnvBuilder));
 };

--- a/cli/program.js
+++ b/cli/program.js
@@ -101,6 +101,7 @@ const buildCommands = ({
   defaultCommand = 'app',
   printLogo = printJHipsterLogo,
   printBlueprintLogo = () => {},
+  createEnvBuilder,
 }) => {
   /* create commands */
   Object.entries(commands).forEach(([cmdName, opts]) => {
@@ -224,7 +225,7 @@ const buildCommands = ({
 
         if (cliOnly) {
           logger.debug('Executing CLI only script');
-          return loadCommand(cmdName)(args, options, env, envBuilder);
+          return loadCommand(cmdName)(args, options, env, envBuilder, createEnvBuilder);
         }
         await env.composeWith('jhipster:bootstrap', options);
 
@@ -247,7 +248,8 @@ const buildJHipster = ({
   program = createProgram({ executableName, executableVersion }),
   blueprints,
   lookups,
-  envBuilder = EnvironmentBuilder.create().prepare({ blueprints, lookups }),
+  createEnvBuilder = (args, options) => EnvironmentBuilder.create(args, options).prepare({ blueprints, lookups }),
+  envBuilder = createEnvBuilder(),
   commands = { ...SUB_GENERATORS, ...envBuilder.getBlueprintCommands() },
   printLogo,
   printBlueprintLogo,
@@ -259,7 +261,7 @@ const buildJHipster = ({
   /* setup debugging */
   logger.init(program);
 
-  buildCommands({ program, commands, envBuilder, env, loadCommand, defaultCommand, printLogo, printBlueprintLogo });
+  buildCommands({ program, commands, envBuilder, env, loadCommand, defaultCommand, printLogo, printBlueprintLogo, createEnvBuilder });
 
   return program;
 };

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -204,9 +204,8 @@ class JHipsterBaseGenerator extends PrivateBase {
     try {
       this._jhipsterGenerator = this._jhipsterGenerator || this.env.requireNamespace(this.options.namespace).generator;
     } catch (error) {
-      throw new Error(
-        `The Namespace ${this.options.namespace} may not be correct. Please check your configuration and ensure your blueprint folder start with "generator-". Detail: ${error}`
-      );
+      const split = this.options.namespace.split(':', 2);
+      this._jhipsterGenerator = split.length === 1 ? split[0] : split[1];
     }
     return this.fetchFromInstalledJHipster(this._jhipsterGenerator, 'templates', ...args);
   }


### PR DESCRIPTION
Current cli allows blueprints to create an environment for generators, but not for jdl command.
Implement a factory for EnvironmentBuilder and use it at jdl command.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
