### PR TITLE
Revert "adapt release drafter config to have smaller github release notes"

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,10 +3,6 @@ template: |
 
   $CHANGES
 
-exclude-labels:
-  - 'theme: dependencies'
-include-labels:
-  - 'release-notes'
 exclude-contributors:
   - 'dependabot'
 categories:


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#18320