### PR TITLE
Sonar: Use concise character class syntax '\d' instead of '[0-9]'

### DIFF
--- a/test-integration/samples/.jhipster/FieldTestEntity.json
+++ b/test-integration/samples/.jhipster/FieldTestEntity.json
@@ -17,15 +17,15 @@
       "fieldName": "numberPatternTom",
       "fieldType": "String",
       "fieldValidateRules": ["pattern"],
-      "fieldValidateRulesPattern": "^[0-9]+$",
-      "fieldValidateRulesPatternJava": "^[0-9]+$"
+      "fieldValidateRulesPattern": "^\\\\d+$",
+      "fieldValidateRulesPatternJava": "^\\\\d+$"
     },
     {
       "fieldName": "numberPatternRequiredTom",
       "fieldType": "String",
       "fieldValidateRules": ["pattern", "required"],
-      "fieldValidateRulesPattern": "^[0-9]+$",
-      "fieldValidateRulesPatternJava": "^[0-9]+$"
+      "fieldValidateRulesPattern": "^\\\\d+$",
+      "fieldValidateRulesPatternJava": "^\\\\d+$"
     },
     { "fieldName": "integerTom", "fieldType": "Integer" },
     { "fieldName": "integerRequiredTom", "fieldType": "Integer", "fieldValidateRules": ["required"] },

--- a/test/templates/reproducible/.jhipster/Foo.json
+++ b/test/templates/reproducible/.jhipster/Foo.json
@@ -16,8 +16,8 @@
                 "pattern",
                 "required"
             ],
-            "fieldValidateRulesPattern": "^[0-9]+$",
-            "fieldValidateRulesPatternJava": "^[0-9]+$"
+            "fieldValidateRulesPattern": "^\\d+$",
+            "fieldValidateRulesPatternJava": "^\\d+$"
         }
     ],
     "relationships": [],


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?resolved=false&severities=MINOR&types=CODE_SMELL&id=jhipster-sample-application&open=AYEG0QoT0HaWLliKRoX_

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
