### PR TITLE
use caffeine cache for caching user information

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -373,8 +373,10 @@ if (SPRING_BOOT_VERSION.indexOf('M') > -1 || SPRING_BOOT_VERSION.indexOf('RC') >
     implementation "org.hibernate:hibernate-jcache"
   <%_ } _%>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine) { _%>
+<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
     implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
+<%_ } _%>
+<%_ if (cacheProviderCaffeine) { _%>
     implementation "com.github.ben-manes.caffeine:jcache:${caffeineVersion}"
     implementation "com.typesafe:config:${typesafeConfigVersion}"
   <%_ if (enableHibernateCache) { _%>

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -373,7 +373,7 @@ if (SPRING_BOOT_VERSION.indexOf('M') > -1 || SPRING_BOOT_VERSION.indexOf('RC') >
     implementation "org.hibernate:hibernate-jcache"
   <%_ } _%>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
+<%_ if (cacheProviderCaffeine || (authenticationTypeOauth2 && !cacheProviderInfinispan)) { _%>
     implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
 <%_ } _%>
 <%_ if (cacheProviderCaffeine) { _%>

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -32,7 +32,7 @@ archunitJunit5Version=0.22.0
 <%_ if (enableSwaggerCodegen) { _%>
 jacksonDatabindNullableVersion=<%= JACKSON_DATABIND_NULLABLE_VERSION %>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
+<%_ if (cacheProviderCaffeine || (authenticationTypeOauth2 && !cacheProviderInfinispan)) { _%>
 caffeineVersion=3.1.1
 <%_ } _%>
 <%_ if (cacheProviderCaffeine) { _%>

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -32,8 +32,10 @@ archunitJunit5Version=0.22.0
 <%_ if (enableSwaggerCodegen) { _%>
 jacksonDatabindNullableVersion=<%= JACKSON_DATABIND_NULLABLE_VERSION %>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine) { _%>
+<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
 caffeineVersion=3.1.1
+<%_ } _%>
+<%_ if (cacheProviderCaffeine) { _%>
 typesafeConfigVersion=1.4.2
 <%_ } _%>
 <%_ if (databaseTypeSql && !reactive) { _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -130,8 +130,10 @@
 <%_ if (enableSwaggerCodegen) { _%>
         <jackson-databind-nullable.version><%= JACKSON_DATABIND_NULLABLE_VERSION %></jackson-databind-nullable.version>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine) { _%>
+<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
         <caffeine.version>3.1.1</caffeine.version>
+<%_ } _%>
+<%_ if (cacheProviderCaffeine) { _%>
         <typesafe.version>1.4.2</typesafe.version>
 <%_ } _%>
         <!-- Plugin versions -->
@@ -408,12 +410,14 @@
         </dependency>
   <%_ } _%>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine) { _%>
+<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>${caffeine.version}</version>
         </dependency>
+<%_ } _%>
+<%_ if (cacheProviderCaffeine) { _%>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>jcache</artifactId>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -130,7 +130,7 @@
 <%_ if (enableSwaggerCodegen) { _%>
         <jackson-databind-nullable.version><%= JACKSON_DATABIND_NULLABLE_VERSION %></jackson-databind-nullable.version>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
+<%_ if (cacheProviderCaffeine || (authenticationTypeOauth2 && !cacheProviderInfinispan)) { _%>
         <caffeine.version>3.1.1</caffeine.version>
 <%_ } _%>
 <%_ if (cacheProviderCaffeine) { _%>
@@ -410,7 +410,7 @@
         </dependency>
   <%_ } _%>
 <%_ } _%>
-<%_ if (cacheProviderCaffeine || authenticationTypeOauth2) { _%>
+<%_ if (cacheProviderCaffeine || (authenticationTypeOauth2 && !cacheProviderInfinispan)) { _%>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
@@ -134,6 +134,9 @@ import reactor.core.publisher.Mono;
   <%_ if (!applicationTypeMicroservice) { _%>
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 import java.util.Arrays;
 import java.util.Map;
   <%_ } _%>
@@ -141,7 +144,6 @@ import java.util.Map;
 import java.util.HashSet;
 import java.util.Set;
   <%_ if (!applicationTypeMicroservice) { _%>
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
   <%_ } _%>
 <%_ } _%>
@@ -170,8 +172,13 @@ public class SecurityConfiguration {
 
     private final ReactiveClientRegistrationRepository clientRegistrationRepository;
 
-    // todo: optimize for scale https://github.com/jhipster/generator-jhipster/issues/18868
-    private final Map<String, Mono<Jwt>> users = new ConcurrentHashMap<>();
+    // See https://github.com/jhipster/generator-jhipster/issues/18868
+    // We don't use a distributed cache or the user selected cache implementation here on purpose
+    private final Cache<String, Mono<Jwt>> users = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(Duration.ofHours(1))
+        .recordStats()
+        .build();
 
   <%_ } _%>
 <%_ } _%>
@@ -425,7 +432,7 @@ public class SecurityConfiguration {
                     return Mono.just(jwt);
                 }
                 // Retrieve user info from OAuth provider if not already loaded
-                return users.computeIfAbsent(jwt.getSubject(), s -> {
+                return users.get(jwt.getSubject(), s -> {
                     WebClient webClient = WebClient.create();
 
                     return webClient

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
@@ -137,6 +137,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
   <%_ } _%>

--- a/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
@@ -20,6 +20,8 @@ package <%= packageName %>.security.oauth2;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import <%= packageName %>.security.SecurityUtils;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpEntity;
@@ -39,7 +41,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -55,8 +56,13 @@ public class CustomClaimConverter implements Converter<Map<String, Object>, Map<
 
     private final ClientRegistration registration;
 
-    // todo: optimize for scale https://github.com/jhipster/generator-jhipster/issues/18868
-    private final Map<String, ObjectNode> users = new ConcurrentHashMap<>();
+    // See https://github.com/jhipster/generator-jhipster/issues/18868
+    // We don't use a distributed cache or the user selected cache implementation here on purpose
+    private final Cache<String, ObjectNode> users = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(Duration.ofHours(1))
+        .recordStats()
+        .build();
 
     public CustomClaimConverter(ClientRegistration registration, RestTemplate restTemplate) {
         this.registration = registration;
@@ -77,7 +83,7 @@ public class CustomClaimConverter implements Converter<Map<String, Object>, Map<
             headers.set("Authorization", buildBearer(token));
 
             // Retrieve user info from OAuth provider if not already loaded
-            ObjectNode user = users.computeIfAbsent(claims.get("sub").toString(), s -> {
+            ObjectNode user = users.get(claims.get("sub").toString(), s -> {
                 ResponseEntity<ObjectNode> userInfo = restTemplate.exchange(registration.getProviderDetails().getUserInfoEndpoint().getUri(), HttpMethod.GET, new HttpEntity<String>(headers), ObjectNode.class);
                 return userInfo.getBody();
             });

--- a/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
@@ -37,6 +37,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
This PR replaces the unbounded hashmap to cache user information with a simple in memory/node local caffeine cache which seems to be simplest and easiest to use caching solution. 

We could of course use the selected caching type, but it seems to complicated or use some distributed solution for even better scaleability, but I think having each node to do the cache lookup is fine and everything else would be too much.


closes #18868


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
