### PR TITLE
Fix MSSQL Server testcontainer issues

### DIFF
--- a/generators/server/templates/sql/common/src/test/java/package/config/MsSqlTestContainer.java.ejs
+++ b/generators/server/templates/sql/common/src/test/java/package/config/MsSqlTestContainer.java.ejs
@@ -42,8 +42,6 @@ public class MsSqlTestContainer implements SqlTestContainer {
     public void afterPropertiesSet() {
         if (null == mSSQLServerContainer) {
             mSSQLServerContainer = new MSSQLServerContainer<>("<%= DOCKER_MSSQL %>")
-                // MSSQLServerContainer does not support withDatabaseName. Using default database "master" for tests.
-                //.withDatabaseName("<%= baseName %>")
                 .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"))
                 .withLogConsumer(new Slf4jLogConsumer(log))
                 .withReuse(true);

--- a/generators/server/templates/sql/common/src/test/java/package/config/MsSqlTestContainer.java.ejs
+++ b/generators/server/templates/sql/common/src/test/java/package/config/MsSqlTestContainer.java.ejs
@@ -26,9 +26,9 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 import java.util.Collections;
 
-public class MsSqlServerContainer implements SqlTestContainer {
+public class MsSqlTestContainer implements SqlTestContainer {
 
-    private static final Logger log = LoggerFactory.getLogger(MsSqlServerContainer.class);
+    private static final Logger log = LoggerFactory.getLogger(MsSqlTestContainer.class);
 
     private MSSQLServerContainer<?> mSSQLServerContainer;
 

--- a/generators/server/templates/sql/common/src/test/java/package/config/MsSqlTestContainer.java.ejs
+++ b/generators/server/templates/sql/common/src/test/java/package/config/MsSqlTestContainer.java.ejs
@@ -42,7 +42,8 @@ public class MsSqlTestContainer implements SqlTestContainer {
     public void afterPropertiesSet() {
         if (null == mSSQLServerContainer) {
             mSSQLServerContainer = new MSSQLServerContainer<>("<%= DOCKER_MSSQL %>")
-                .withDatabaseName("<%= baseName %>")
+                // MSSQLServerContainer does not support withDatabaseName. Using default database "master" for tests.
+                //.withDatabaseName("<%= baseName %>")
                 .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"))
                 .withLogConsumer(new Slf4jLogConsumer(log))
                 .withReuse(true);


### PR DESCRIPTION
This PR fixes 2 issues present when generating an application with MS SqlServer as test database.

1.  public class defined inside MsSqlTestContainer.java differs from its filename (resulting in compile errors)
2.  MSSQLServerContainer provided by org.testcontainers does not support withDatabaseName() method (resulting in a UnsupportedOperationException during tests runtime)

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
