### PR TITLE
fix npmw.cmd failing to set the local node.js up

### DIFF
--- a/generators/server/templates/npmw.cmd
+++ b/generators/server/templates/npmw.cmd
@@ -1,29 +1,31 @@
 @echo off
 
-@setlocal
+setlocal
 
 set NPMW_DIR=%~dp0
 
-if exist "%NPMW_DIR%\mvnw.cmd" (
-  set NODE_EXE=""
-  set NPM_EXE=%NPMW_DIR%\target\node\npm.cmd
-  set INSTALL_NPM_COMMAND=%NPMW_DIR%\mvnw.cmd -Pwebapp frontend:install-node-and-npm@install-node-and-npm
+if exist "%NPMW_DIR%mvnw.cmd" (
+  set NODE_EXE=^"^"
+  set NODE_PATH=%NPMW_DIR%target\node\
+  set NPM_EXE=^"%NPMW_DIR%target\node\npm.cmd^"
+  set INSTALL_NPM_COMMAND=^"%NPMW_DIR%mvnw.cmd^" -Pwebapp frontend:install-node-and-npm@install-node-and-npm
 ) else (
-  set NODE_EXE=%NPMW_DIR%\build\node\bin\node.exe
-  set NPM_EXE=%NPMW_DIR%\build\node\lib\node_modules\npm\bin\npm-cli.js
-  set INSTALL_NPM_COMMAND=%NPMW_DIR%\gradlew.bat npmSetup
+  set NODE_EXE=^"%NPMW_DIR%build\node\bin\node.exe^"
+  set NODE_PATH=%NPMW_DIR%build\node\bin\
+  set NPM_EXE=^"%NPMW_DIR%build\node\lib\node_modules\npm\bin\npm-cli.js^"
+  set INSTALL_NPM_COMMAND=^"%NPMW_DIR%gradlew.bat^" npmSetup
 )
 
 if not exist %NPM_EXE% (
-  call %INSTALL_NPM_COMMAND%
+  call %INSTALL_NPM_COMMAND% 
 )
 
 if exist %NODE_EXE% (
-  Rem Executing local npm with local node
-  call %NODE_EXE% %NPM_EXE% %*
+  Rem execute local npm with local node, whilst adding local node location to the PATH for this CMD session
+  endlocal & echo "%PATH%"|find /i "%NODE_PATH%;">nul || set "PATH=%NODE_PATH%;%PATH%" & call %NODE_EXE% %NPM_EXE% %*
 ) else if exist %NPM_EXE% (
-  Rem Executing local npm
-  call %NPM_EXE% %*
+  Rem execute local npm, whilst adding local npm location to the PATH for this CMD session
+  endlocal & echo "%PATH%"|find /i "%NODE_PATH%;">nul || set "PATH=%NODE_PATH%;%PATH%" & call %NPM_EXE% %*
 ) else (
   call npm %*
 )


### PR DESCRIPTION
When Node.js is not already pre-installed globally on the system Windows building a generated project that relies on Node.js tooling for frontend fails. This is caused by NPM scripts not being able to locate Node.js, because the local installation is not added to the PATH by npmw.cmd. As the result NPM scripts that rely on Node.js fail to run.

The fix makes sure that the local Node.js installation, when present, is added to the PATH for all downstream scripts to see. The local Node.js is added temporarely,  for the duration of CMD session, leaving the global installation still accessible elsewhere.

**To recreate the issue, before applying this fix:**
  1. Make sure there is no Node.js installed on a Windows machine or global PATH variable does NOT contain path to a Node.js installation.
  2.  Take a simple generated project with an Angular frontend.
  3.  Attempt building the project using mvnw.cmd

**Expected result:**
  The project is built.

**Actual result:**
  npmw.cmd fails.

Following the fix, the same scenario should work as expected.

  

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
