### PR TITLE
fix: jwt claims should always be converted.

### DIFF
--- a/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/CustomClaimConverter.java.ejs
@@ -71,11 +71,11 @@ public class CustomClaimConverter implements Converter<Map<String, Object>, Map<
     }
 
     public Map<String, Object> convert(Map<String, Object> claims) {
+        Map<String, Object> convertedClaims = this.delegate.convert(claims);
         // Only look up user information if identity claims are missing
         if (claims.containsKey("given_name") && claims.containsKey("family_name")) {
-            return claims;
+            return convertedClaims;
         }
-        Map<String, Object> convertedClaims = this.delegate.convert(claims);
         RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
         if (attributes instanceof ServletRequestAttributes) {
             // Retrieve and set the token


### PR DESCRIPTION
Alternative fix for https://github.com/jhipster/generator-jhipster/issues/19309.

The following is new at v7.9.0
```
       // Only look up user information if identity claims are missing
       if (claims.containsKey("given_name") && claims.containsKey("family_name")) {
           return claims;
       }
```

it removes the default claim converter from the next line.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
