### PR TITLE
wrap non long ids with ' to have valid sql where clause

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepositoryInternalImpl_reactive.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepositoryInternalImpl_reactive.java.ejs
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
@@ -148,7 +149,11 @@ _%>
 
     @Override
     public Mono<<%= persistClass %>> findById(<%= primaryKey.type %> id) {
+<%_ if (primaryKey.type != 'Long') {  _%>
+        Comparison whereClause = Conditions.isEqual(entityTable.column("<%= primaryKey.fields[0].columnName %>"), Conditions.just(StringUtils.wrap(id.toString(), "'")));
+<%_ } else { _%>
         Comparison whereClause = Conditions.isEqual(entityTable.column("<%= primaryKey.fields[0].columnName %>"), Conditions.just(id.toString()));
+<%_ }_%>
         return createQuery(null, whereClause).one();
     }
 


### PR DESCRIPTION
This PR ensures non long ids are correctly wrapper with `'`. Used following entities to test it out:

```
entity Example {
    id String
    name String
}

entity Example2 {
    name String
}

entity Example3 {
    id UUID
    name String
}
```

Both `Example` and `Example3` need the wrapping.

closes #18804

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
