### PR TITLE
fix incorrect eureka status message

### DIFF
--- a/generators/server/__snapshots__/generator.spec.mjs.snap
+++ b/generators/server/__snapshots__/generator.spec.mjs.snap
@@ -297,6 +297,16 @@ Object {
       "path": "src/main/java/",
       "templates": Array [
         Object {
+          "file": "package/config/EurekaWorkaroundConfiguration.java",
+          "renameTo": [Function],
+        },
+      ],
+    },
+    Object {
+      "condition": [Function],
+      "path": "src/main/java/",
+      "templates": Array [
+        Object {
           "file": "package/ApplicationWebXml.java",
           "renameTo": [Function],
         },

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -784,6 +784,16 @@ const baseServerFiles = {
       templates: [{ file: 'package/Application.java', renameTo: generator => `${generator.javaDir}${generator.mainClass}.java` }],
     },
     {
+      condition: generator => generator.serviceDiscoveryType && generator.serviceDiscoveryEureka,
+      path: SERVER_MAIN_SRC_DIR,
+      templates: [
+        {
+          file: 'package/config/EurekaWorkaroundConfiguration.java',
+          renameTo: generator => `${generator.javaDir}/config/EurekaWorkaroundConfiguration.java`,
+        },
+      ],
+    },
+    {
       condition: generator => !generator.reactive,
       path: SERVER_MAIN_SRC_DIR,
       templates: [{ file: 'package/ApplicationWebXml.java', renameTo: generator => `${generator.javaDir}ApplicationWebXml.java` }],

--- a/generators/server/templates/src/main/java/package/config/EurekaWorkaroundConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/EurekaWorkaroundConfiguration.java.ejs
@@ -1,0 +1,49 @@
+<%#
+ Copyright 2013-2022 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+// This is a workaround for
+// https://github.com/jhipster/jhipster-registry/issues/537
+// https://github.com/jhipster/generator-jhipster/issues/18533
+// The original issue will be fixed with spring cloud 2021.0.4
+// https://github.com/spring-cloud/spring-cloud-netflix/issues/3941
+package <%= packageName %>.config;
+
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EurekaWorkaroundConfiguration implements HealthIndicator {
+
+    private boolean applicationIsUp = false;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onStartup() {
+        this.applicationIsUp = true;
+    }
+
+    @Override
+    public Health health() {
+        if (!applicationIsUp) {
+            return Health.down().build();
+        }
+        return Health.up().build();
+    }
+}

--- a/test/__snapshots__/server.spec.js.snap
+++ b/test/__snapshots__/server.spec.js.snap
@@ -1314,6 +1314,9 @@ Object {
   "src/main/java/com/mycompany/myapp/config/DateTimeFormatConfiguration.java": Object {
     "stateCleared": "modified",
   },
+  "src/main/java/com/mycompany/myapp/config/EurekaWorkaroundConfiguration.java": Object {
+    "stateCleared": "modified",
+  },
   "src/main/java/com/mycompany/myapp/config/FeignConfiguration.java": Object {
     "stateCleared": "modified",
   },


### PR DESCRIPTION
The upstream issue seems to be fixed and will be in the next spring cloud release 2021.0.4 which is due for end of august. In any case this works now and we are not depending on release of spring cloud such we could do a next minor release.

closes https://github.com/jhipster/jhipster-registry/issues/537

Further discussion here, but other issue https://github.com/jhipster/generator-jhipster/issues/18533

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
