### PR TITLE
Add translation keys for two translation-not-found errors on the admi…

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/al/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/al/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ar-ly/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ar-ly/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "البريد الإلكتروني",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "قاعدة البيانات"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/bg/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/bg/health.json.ejs
@@ -50,6 +50,8 @@
             "mail": "Имейл",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Приложение"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "База данни"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/bn/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/by/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/by/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "База дадзеных"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ca/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Compte de correu electrònic",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Base de dades"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/cs/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Databáze"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/da/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/da/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/de/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/de/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Datenbank"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/en/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/en/health.json.ejs
@@ -49,6 +49,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/es/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/es/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Correo Electrónico",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Aplicación"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Base de Datos"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/et/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/et/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "E-post",
             "livenessState": "Elusolek",
             "readinessState": "Valmisolek",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Rakendus"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Andmebaas"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/fa/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "پایگاه داده"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/fi/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fi/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Sähköposti",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/fr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Base de données"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/gl/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/health.json.ejs
@@ -47,6 +47,8 @@
             "diskSpace": "Espazo en disco",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "mail": "Email"<% if (databaseTypeSql) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/hi/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "ई-मेल",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/hr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hr/health.json.ejs
@@ -46,6 +46,8 @@
             "mail": "E-pošta",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Aplikacija"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/hu/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Adatbázis"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/hy/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hy/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/in/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/in/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/it/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/it/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ja/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ja/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "メール",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "データベース"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ko/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "이메일",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "데이터베이스"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/mr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "ईमेल ",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/my/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/my/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/nl/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Databank"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/pa/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pa/health.json.ejs
@@ -49,6 +49,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/pl/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pl/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Baza danych"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "E-mail",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Banco de dados"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Base de dados"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ro/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Bază de date"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ru/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Эл. почта",
             "livenessState": "Живой",
             "readinessState": "Готово",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Приложение"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "База данных"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/si/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/si/health.json.ejs
@@ -49,6 +49,8 @@
             "mail": "විද්යුත් තැපෑල",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "අයදුම්පත"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "දත්ත සමුදාය"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/sk/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sk/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Databáza"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/sr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sr/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elastična pretraga"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "SQL baza podataka"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/sv/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "E-post",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Databas"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ta/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "மின்னஞ்சல்",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/te/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/te/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Database"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/tr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "E-posta",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Veritabanı"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/ua/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ua/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Електронна пошта",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "База даних"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Маълумотлар базаси"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Ma`lumotlar bazasi"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/vi/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/vi/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "Email",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "Application"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "Cơ sở dữ liệu"<% } %><% if (databaseTypeSql && reactive) { %>,

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/health.json.ejs
@@ -48,6 +48,8 @@
             "mail": "電子郵件",
             "livenessState": "Liveness state",
             "readinessState": "Readiness state",
+            "discoveryComposite": "Discovery Composite",
+            "refreshScope": "Refresh Scope",
             "ping": "應用程式"<% if (searchEngineElasticsearch) { %>,
             "elasticsearch": "Elasticsearch"<% } %><% if (databaseTypeSql && !reactive) { %>,
             "db": "資料庫"<% } %><% if (databaseTypeSql && reactive) { %>,


### PR DESCRIPTION
Two translation keys were missing on the admin health panel across all i18n-related `health.json` files. The two keys with their values were added. It appears that no conditional logic is needed for these keys since they seem related to Spring itself.

In the contribution guidelines, I didn't see whether it is customary to first open and issue before opening a PR; it appears that opening a PR not linked to an issue is acceptable. If this is incorrect, please let me know so I can fix.

- [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X] Tests are added where necessary
- [X] The JDL part is updated if necessary
- [X] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

Prior to fix:
![i18n-bug-screenshot](https://user-images.githubusercontent.com/6279541/185813182-d9825a50-29d2-4f1d-b84e-ec5904b3dff0.jpg)

After fix on this branch:
![Fixed-i18n-bug-screenshot](https://user-images.githubusercontent.com/6279541/185813186-5c17ee31-f5f3-48c6-af12-aaeeaa3cf45e.jpg)


