### PR TITLE
Fix JdbcSQLIntegrityConstraintViolationException  when running Gradle integration tests

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -39,6 +39,7 @@ const SPRING_BOOT_VERSION = '2.7.3';
 const LIQUIBASE_VERSION = '4.15.0';
 // TODO v8: Remove this constant
 const LIQUIBASE_DTD_VERSION = 'latest';
+const H2_VERSION = '1.4.200';
 const HIBERNATE_VERSION = '5.6.10.Final';
 const JACOCO_VERSION = '0.8.8';
 const JACKSON_DATABIND_NULLABLE_VERSION = '0.2.3';
@@ -408,6 +409,7 @@ const constants = {
   LIQUIBASE_VERSION,
   // TODO v8: Remove this constant
   LIQUIBASE_DTD_VERSION,
+  H2_VERSION,
   HIBERNATE_VERSION,
   JIB_VERSION,
   JACOCO_VERSION,

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -250,6 +250,7 @@ configurations {
             // Inherited version from Spring Boot can't be used because of regressions:
             // To be removed as soon as spring-boot use the same version
             force 'org.liquibase:liquibase-core:<%= LIQUIBASE_VERSION %>'
+            force 'com.h2database:h2:<%= H2_VERSION %>'
         }
     }
 }


### PR DESCRIPTION
Fix `JdbcSQLIntegrityConstraintViolationException` when running Gradle integration tests by forcing h2database dependency version

See the build scan for details:
https://scans.gradle.com/s/7s6fydvpkazyo/tests/overview?outcome=failed

