### PR TITLE
Issue 19649 Fix

### DIFF
--- a/generators/server/templates/src/test/java/package/config/JHipsterBlockHoundIntegration.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/JHipsterBlockHoundIntegration.java.ejs
@@ -45,6 +45,9 @@ public class JHipsterBlockHoundIntegration implements BlockHoundIntegration {
 <%_ if (searchEngineElasticsearch) { _%>
         builder.allowBlockingCallsInside("org.elasticsearch.client.indices.CreateIndexRequest", "settings");
 <%_} _%>
+<%_ if (databaseTypeCassandra) { _%>
+        builder.allowBlockingCallsInside("io.netty.util.NetUtil", "<clinit>");
+<%_} _%>
     }
 
 }


### PR DESCRIPTION
…ialize class io.netty.channel.DefaultChannelId on the Cassandra integration tests

Fixes https://github.com/jhipster/generator-jhipster/issues/19649.
<!--
PR description.
-->
A blocking call caused java.lang.NoClassDefFoundError: Could not initialize class io.netty.channel.DefaultChannelId on the Cassandra integration tests
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
