### PR TITLE
Fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN \
 
 RUN \
   # install jhipster
-  cd /home/jhipster/generator-jhipster && npm ci --production && \
+  cd /home/jhipster/generator-jhipster && \
   npm install -g /home/jhipster/generator-jhipster && \
   # fix jhipster user permissions
   chown -R jhipster:jhipster \


### PR DESCRIPTION
We can't use the production install since we need typescript and typescript is a devDependency.

Related to #19559 

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
