### PR TITLE
[Angular] Warnings: tilde imports is deprecated

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.component.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.component.scss.ejs
@@ -16,11 +16,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-@import '~bootstrap/scss/functions';
+@import 'bootstrap/scss/functions';
 <%_ if (!clientThemeNone) { _%>
 @import "~bootswatch/dist/<%= clientTheme %>/variables";
 <%_ } _%>
-@import '~bootstrap/scss/variables';
+@import 'bootstrap/scss/variables';
 
 iframe {
   background: white;

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.scss.ejs
@@ -16,11 +16,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-@import '~bootstrap/scss/functions';
+@import 'bootstrap/scss/functions';
 <%_ if (!clientThemeNone) { _%>
 @import "~bootswatch/dist/<%= clientTheme %>/variables";
 <%_ } _%>
-@import '~bootstrap/scss/variables';
+@import 'bootstrap/scss/variables';
 
 /* ==========================================================================
 Navbar

--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -17,11 +17,11 @@
  limitations under the License.
 -%>
 @import 'bootstrap-variables';
-@import '~bootstrap/scss/functions';
+@import 'bootstrap/scss/functions';
 <%_ if (!clientThemeNone) { _%>
 @import "~bootswatch/dist/<%= clientTheme %>/variables";
 <%_ } _%>
-@import '~bootstrap/scss/variables';
+@import 'bootstrap/scss/variables';
 
 /* ==============================================================
 Bootstrap tweaks

--- a/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
@@ -28,7 +28,7 @@ eg $input-color: red;
 // Override Bootstrap variables
 @import 'bootstrap-variables';
 // Import Bootstrap source files from node_modules
-@import '~bootstrap/scss/bootstrap';
+@import 'bootstrap/scss/bootstrap';
 <%_ if (!clientThemeNone) { _%>
 @import '~bootswatch/dist/<%= clientTheme %>/bootswatch';
 <%_ } _%>


### PR DESCRIPTION
Fix warnings:

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/9989211/192110834-6bf8bbc6-0820-4241-8946-0a7ac706f6d2.png">


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
