### PR TITLE
Align MySQL image in TestContainer with the docker compose

### DIFF
--- a/generators/server/templates/sql/common/src/test/java/package/config/MysqlTestContainer.java.ejs
+++ b/generators/server/templates/sql/common/src/test/java/package/config/MysqlTestContainer.java.ejs
@@ -43,7 +43,7 @@ public class MysqlTestContainer implements SqlTestContainer {
     @Override
     public void afterPropertiesSet() {
         if (null == mysqlContainer) {
-            mysqlContainer = new MySQLContainer<>("<%= DOCKER_MYSQL %>-debian")
+            mysqlContainer = new MySQLContainer<>("<%= DOCKER_MYSQL %>")
                 .withDatabaseName("<%= baseName %>")
                 .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"))
                 .withLogConsumer(new Slf4jLogConsumer(log))


### PR DESCRIPTION
<!--
PR description.
-->
Fix issue that MySQL is not starting (Macbook M1). this error message:
```
c.i.b.config.MysqlTestContainer  : STDERR: 2022-10-02T06:53:50.787055Z 1 [ERROR] [MY-012585] [InnoDB] Linux Native AIO interface is not supported on this platform. Please check your OS documentation and install appropriate binary of InnoDB.
```

<img width="1725" alt="image" src="https://user-images.githubusercontent.com/3299903/193446670-3b845cad-2856-421e-9170-f8f25cd84446.png">

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
Related: https://github.com/jhipster/generator-jhipster/pull/19126
