### PR TITLE
[React] Bump react-router-dom from 6.4.1 to 6.4.2

### DIFF
--- a/generators/client/templates/react/package.json
+++ b/generators/client/templates/react/package.json
@@ -16,7 +16,7 @@
     "react-loadable": "5.5.0",
     "react-redux": "8.0.4",
     "react-redux-loading-bar": "5.0.4",
-    "react-router-dom": "6.4.1",
+    "react-router-dom": "6.4.2",
     "react-toastify": "9.0.8",
     "react-transition-group": "4.4.5",
     "reactstrap": "9.1.4",

--- a/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
@@ -1,11 +1,11 @@
 import React from 'react';
-import { RouteProps, useLocation, Navigate } from 'react-router-dom';
+import { useLocation, Navigate, PathRouteProps } from 'react-router-dom';
 import { Translate } from 'react-jhipster';
 
 import { useAppSelector } from 'app/config/store';
 import ErrorBoundary from 'app/shared/error/error-boundary';
 
-interface IOwnProps extends RouteProps {
+interface IOwnProps extends PathRouteProps {
   hasAnyAuthorities?: string[];
   children: React.ReactNode;
 }


### PR DESCRIPTION
Fix #19935 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
