### PR TITLE
Drop registerComposedGenerator and compose once

### DIFF
--- a/generators/app/generator.cjs
+++ b/generators/app/generator.cjs
@@ -431,22 +431,18 @@ module.exports = class JHipsterAppGenerator extends BaseGenerator {
        * - composeCommon (app) -> initializing (common) -> prompting (common) -> ... -> composeServer (app) -> initializing (server) -> ...
        */
       async compose() {
-        await this.composeWithJHipster(GENERATOR_COMMON, true);
+        await this.composeWithJHipster(GENERATOR_COMMON);
         if (!this.jhipsterConfig.skipServer) {
-          await this.composeWithJHipster(GENERATOR_SERVER, true);
+          await this.composeWithJHipster(GENERATOR_SERVER);
         }
         if (this.jhipsterConfig.clientFramework !== CLIENT_FRAMEWORK_NO) {
-          await this.composeWithJHipster(GENERATOR_CLIENT, true);
+          await this.composeWithJHipster(GENERATOR_CLIENT);
         }
         if (!this.configOptions.skipI18n) {
-          await this.composeWithJHipster(
-            GENERATOR_LANGUAGES,
-            {
-              regenerate: true,
-              skipPrompts: this.options.withEntities || this.existingProject || this.options.defaults,
-            },
-            true
-          );
+          await this.composeWithJHipster(GENERATOR_LANGUAGES, {
+            regenerate: true,
+            skipPrompts: this.options.withEntities || this.existingProject || this.options.defaults,
+          });
         }
       },
       askForTestOpts: prompts.askForTestOpts,

--- a/generators/base/generator-base.cjs
+++ b/generators/base/generator-base.cjs
@@ -157,9 +157,6 @@ class JHipsterBaseGenerator extends PrivateBase {
     // TODO v8 rename to existingProject.
     this.existingModularProject = this.configOptions.existingProject;
 
-    /* Register generator for compose once */
-    this.registerComposedGenerator(this.options.namespace);
-
     this.loadRuntimeOptions();
     this.loadStoredAppOptions();
 
@@ -173,7 +170,7 @@ class JHipsterBaseGenerator extends PrivateBase {
         this.env.queueGenerator(generator, true);
       }
       */
-      this.composeWithJHipster(GENERATOR_BOOTSTRAP, { ...this.options, configOptions: this.configOptions }, true);
+      this.composeWithJHipster(GENERATOR_BOOTSTRAP, { ...this.options, configOptions: this.configOptions });
     }
   }
 
@@ -1414,52 +1411,19 @@ class JHipsterBaseGenerator extends PrivateBase {
   }
 
   /**
-   * @deprecated
-   * Register the composed generator for compose once.
-   * @param {string} namespace - jhipster generator.
-   * @return {boolean} false if already composed
-   */
-  registerComposedGenerator(namespace) {
-    this.configOptions.composedWith = this.configOptions.composedWith || [];
-    if (this.configOptions.composedWith.includes(namespace)) {
-      return false;
-    }
-    this.configOptions.composedWith.push(namespace);
-    return true;
-  }
-
-  /**
    * Compose with a jhipster generator using default jhipster config.
    * @param {string} generator - jhipster generator.
    * @param {object} args - args to pass
    * @param {object} [options] - options to pass
-   * @param {boolean} [once] - compose once with the generator
+   * @param {object} [composeOptions] - compose options
    * @return {object} the composed generator
    */
-  composeWithJHipster(generator, args, options, once = false) {
+  composeWithJHipster(generator, args, options, { immediately = false } = {}) {
     assert(typeof generator === 'string', 'generator should to be a string');
     const namespace = generator.includes(':') ? generator : `jhipster:${generator}`;
-    let immediately = false;
-    if (typeof once === 'object') {
-      immediately = once.immediately;
-      once = false;
-    }
-    if (typeof args === 'boolean') {
-      once = args;
-      args = [];
-      options = {};
-    } else if (!Array.isArray(args)) {
-      once = options;
+    if (!Array.isArray(args)) {
       options = args;
       args = [];
-    } else if (typeof options === 'boolean') {
-      once = options;
-      options = {};
-    }
-    if (once) {
-      if (!this.registerComposedGenerator(namespace)) {
-        return undefined;
-      }
     }
 
     if (this.env.get(namespace)) {

--- a/generators/base/generator.cjs
+++ b/generators/base/generator.cjs
@@ -20,21 +20,8 @@ const JHipsterBaseBlueprintGenerator = require('./generator-base-blueprint.cjs')
 
 const { PRIORITY_NAMES, PRIORITY_PREFIX } = require('./priorities.cjs');
 
-const {
-  INITIALIZING,
-  PROMPTING,
-  CONFIGURING,
-  COMPOSING,
-  LOADING,
-  PREPARING,
-  DEFAULT,
-  WRITING,
-  POST_WRITING,
-  PRE_CONFLICTS,
-  INSTALL,
-  POST_INSTALL,
-  END,
-} = PRIORITY_NAMES;
+const { INITIALIZING, PROMPTING, CONFIGURING, COMPOSING, LOADING, PREPARING, DEFAULT, WRITING, POST_WRITING, INSTALL, POST_INSTALL, END } =
+  PRIORITY_NAMES;
 
 const asPriority = priorityName => `${PRIORITY_PREFIX}${priorityName}`;
 
@@ -64,8 +51,6 @@ class BaseGenerator extends JHipsterBaseBlueprintGenerator {
   static WRITING = asPriority(WRITING);
 
   static POST_WRITING = asPriority(POST_WRITING);
-
-  static PRE_CONFLICTS = asPriority(PRE_CONFLICTS);
 
   static INSTALL = asPriority(INSTALL);
 

--- a/generators/base/generator.cjs
+++ b/generators/base/generator.cjs
@@ -74,7 +74,7 @@ class BaseGenerator extends JHipsterBaseBlueprintGenerator {
   static END = asPriority(END);
 
   constructor(args, options, features) {
-    super(args, options, { tasksMatchingPriority: true, taskPrefix: PRIORITY_PREFIX, ...features });
+    super(args, options, { tasksMatchingPriority: true, taskPrefix: PRIORITY_PREFIX, unique: 'namespace', ...features });
   }
 
   /**

--- a/generators/bootstrap/generator.mts
+++ b/generators/bootstrap/generator.mts
@@ -47,7 +47,7 @@ const { detectCrLf, normalizeLineEndings } = generatorUtils;
 
 export default class BootstrapGenerator extends BaseGenerator {
   constructor(args: any, options: any, features: any) {
-    super(args, options, { unique: 'namespace', customCommitTask: true, ...features });
+    super(args, options, { unique: 'namespace', uniqueGlobally: true, customCommitTask: true, ...features });
 
     if (this.options.help) return;
 

--- a/generators/bootstrap/generator.mts
+++ b/generators/bootstrap/generator.mts
@@ -22,14 +22,19 @@ import pTransform from 'p-transform';
 import { stat } from 'fs/promises';
 import { isBinaryFile } from 'isbinaryfile';
 
+import type { Transform, Readable } from 'stream';
+import type Environment from 'yeoman-environment';
+
 import BaseGenerator from '../base/index.mjs';
 import MultiStepTransform from './multi-step-transform/index.mjs';
 import { prettierTransform, generatedAnnotationTransform } from './transforms.mjs';
 import constants from '../generator-constants.cjs';
 import { GENERATOR_UPGRADE } from '../generator-list.mjs';
 import generatorUtils from '../utils.cjs';
+import { PRIORITY_NAMES } from '../base-application/priorities.mjs';
 import type { PreConflictsTaskGroup } from '../base/tasks.js';
 
+const { TRANSFORM, PRE_CONFLICTS } = PRIORITY_NAMES;
 const {
   createConflicterCheckTransform,
   createConflicterStatusTransform,
@@ -45,7 +50,14 @@ const { hasState, setModifiedFileState } = State;
 const { PRETTIER_EXTENSIONS } = constants;
 const { detectCrLf, normalizeLineEndings } = generatorUtils;
 
+const TRANSFORM_PRIORITY = BaseGenerator.asPriority(TRANSFORM);
+const PRE_CONFLICTS_PRIORITY = BaseGenerator.asPriority(PRE_CONFLICTS);
+
 export default class BootstrapGenerator extends BaseGenerator {
+  static TRANSFORM = TRANSFORM_PRIORITY;
+
+  static PRE_CONFLICTS = PRE_CONFLICTS_PRIORITY;
+
   constructor(args: any, options: any, features: any) {
     super(args, options, { unique: 'namespace', uniqueGlobally: true, customCommitTask: true, ...features });
 
@@ -86,8 +98,18 @@ export default class BootstrapGenerator extends BaseGenerator {
 
     // Force npm override later if needed
     this.env.options.nodePackageManager = 'npm';
+  }
 
-    this.queueMultistepTransform();
+  get transform() {
+    return this.asWritingTaskGroup({
+      queueTransform() {
+        this.queueMultistepTransform();
+      },
+    });
+  }
+
+  get [TRANSFORM_PRIORITY]() {
+    return this.transform;
   }
 
   get preConflicts(): PreConflictsTaskGroup<this> {
@@ -113,7 +135,7 @@ export default class BootstrapGenerator extends BaseGenerator {
     };
   }
 
-  get [BaseGenerator.PRE_CONFLICTS]() {
+  get [PRE_CONFLICTS_PRIORITY]() {
     return this.preConflicts;
   }
 
@@ -121,7 +143,17 @@ export default class BootstrapGenerator extends BaseGenerator {
    * Queue multi step templates transform
    */
   queueMultistepTransform() {
-    this.queueTransformStream(new MultiStepTransform() as any);
+    this.queueTask({
+      method() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const env: Environment = (this as any).env;
+        const stream = env.sharedFs.stream().pipe(patternFilter('**/*.jhi{,.*}', { dot: true })) as Readable;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return env.applyTransforms([new MultiStepTransform() as unknown as Transform], { stream } as any);
+      },
+      taskName: 'jhipster:transformStream',
+      queueName: 'transform',
+    });
   }
 
   /**

--- a/generators/client/generator.cjs
+++ b/generators/client/generator.cjs
@@ -170,18 +170,18 @@ module.exports = class JHipsterClientGenerator extends BaseApplicationGenerator 
   get composing() {
     return this.asComposingTaskGroup({
       async composeCommon() {
-        await this.composeWithJHipster(GENERATOR_COMMON, true);
+        await this.composeWithJHipster(GENERATOR_COMMON);
       },
       async composeCypress() {
         const testFrameworks = this.jhipsterConfig.testFrameworks;
         if (!Array.isArray(testFrameworks) || !testFrameworks.includes(CYPRESS)) return;
-        await this.composeWithJHipster(GENERATOR_CYPRESS, { existingProject: this.existingProject }, true);
+        await this.composeWithJHipster(GENERATOR_CYPRESS, { existingProject: this.existingProject });
       },
       async composeLanguages() {
         // We don't expose client/server to cli, composing with languages is used for test purposes.
         if (this.jhipsterConfig.enableTranslation === false) return;
 
-        await this.composeWithJHipster(GENERATOR_LANGUAGES, true);
+        await this.composeWithJHipster(GENERATOR_LANGUAGES);
       },
     });
   }

--- a/generators/database-changelog-liquibase/generator.cjs
+++ b/generators/database-changelog-liquibase/generator.cjs
@@ -37,7 +37,7 @@ const { prepareFieldForLiquibaseTemplates } = require('../../utils/liquibase.cjs
 
 module.exports = class DatabaseChangelogLiquibase extends BaseApplication {
   constructor(args, options, features) {
-    super(args, options, features);
+    super(args, options, { unique: undefined, ...features });
 
     if (this.options.help) return;
 

--- a/generators/database-changelog-liquibase/incremental-liquibase.spec.mts
+++ b/generators/database-changelog-liquibase/incremental-liquibase.spec.mts
@@ -80,7 +80,7 @@ enum ProductCategory {
   Laptop, Desktop, Phone, Tablet, Accessory
 }`;
 
-const generatorPath = join(__dirname, '../app/index.cjs');
+const generatorPath = join(__dirname, '../server/index.mjs');
 
 describe('jhipster:app --incremental-changelog', function () {
   this.timeout(45000);

--- a/generators/database-changelog/generator.mts
+++ b/generators/database-changelog/generator.mts
@@ -55,7 +55,7 @@ export default class DatabaseChangelogGenerator extends BaseApplication<Liquibas
   }
 
   async _postConstruct() {
-    this.dependsOnJHipster(GENERATOR_BOOTSTRAP_APPLICATION_SERVER);
+    await this.dependsOnJHipster(GENERATOR_BOOTSTRAP_APPLICATION_SERVER);
     if (!this.fromBlueprint) {
       await this.composeWithBlueprints(GENERATOR_DATABASE_CHANGELOG);
     }

--- a/generators/database-changelog/generator.spec.mts
+++ b/generators/database-changelog/generator.spec.mts
@@ -40,5 +40,5 @@ describe(`JHipster ${generator} generator`, () => {
     const instance = new Generator([], { help: true }, { bar: true });
     expect(instance.features.bar).toBe(true);
   });
-  describe.skip('blueprint support', () => testBlueprintSupport(generator));
+  describe('blueprint support', () => testBlueprintSupport(generator));
 });

--- a/generators/entity/generator.cjs
+++ b/generators/entity/generator.cjs
@@ -296,18 +296,14 @@ class EntityGenerator extends BaseGenerator {
     return {
       async composeEntities() {
         // We need to compose with others entities to update relationships.
-        await this.composeWithJHipster(
-          GENERATOR_ENTITIES,
-          {
-            entities: this.options.singleEntity ? [this.context.name] : undefined,
-            regenerate: true,
-            writeEveryEntity: false,
-            composedEntities: [this.context.name],
-            skipDbChangelog: this.options.skipDbChangelog,
-            skipInstall: this.options.skipInstall,
-          },
-          true
-        );
+        await this.composeWithJHipster(GENERATOR_ENTITIES, {
+          entities: this.options.singleEntity ? [this.context.name] : undefined,
+          regenerate: true,
+          writeEveryEntity: false,
+          composedEntities: [this.context.name],
+          skipDbChangelog: this.options.skipDbChangelog,
+          skipInstall: this.options.skipInstall,
+        });
       },
     };
   }

--- a/generators/server/generator.cjs
+++ b/generators/server/generator.cjs
@@ -209,13 +209,13 @@ module.exports = class JHipsterServerGenerator extends BaseApplicationGenerator 
   get composing() {
     return this.asComposingTaskGroup({
       async composeCommon() {
-        await this.composeWithJHipster(GENERATOR_COMMON, true);
+        await this.composeWithJHipster(GENERATOR_COMMON);
       },
 
       async composeLanguages() {
         // We don't expose client/server to cli, composing with languages is used for test purposes.
         if (this.jhipsterConfig.enableTranslation === false) return;
-        await this.composeWithJHipster(GENERATOR_LANGUAGES, true);
+        await this.composeWithJHipster(GENERATOR_LANGUAGES);
       },
     });
   }

--- a/test/app/composing.spec.mts
+++ b/test/app/composing.spec.mts
@@ -278,43 +278,4 @@ describe('jhipster:app composing', () => {
       });
     });
   });
-  describe(`when mocking ${mockedComposedGenerators}`, () => {
-    describe('with default options', () => {
-      let runContext;
-      let runResult;
-      before(async () => {
-        runContext = helpers.create(getGenerator('app'));
-        runResult = await runContext
-          .withOptions({
-            baseName: 'jhipster',
-            defaults: true,
-          })
-          .withMockedGenerators(mockedComposedGenerators)
-          .run();
-      });
-
-      after(() => runContext.cleanup());
-
-      it('should compose with common generator once', () => {
-        const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
-        assert(CommonGenerator.calledOnce);
-      });
-      it('should compose with languages generator once', () => {
-        const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
-        assert(LanguagesGenerator.calledOnce);
-      });
-      it('should not compose with entities generator', () => {
-        const EntityGenerator = runResult.mockedGenerators['jhipster:entities'];
-        assert.equal(EntityGenerator.callCount, 0);
-      });
-      it('should not compose with entity generator', () => {
-        const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-        assert.equal(EntityGenerator.callCount, 0);
-      });
-      it('should not compose with database-changelog generator', () => {
-        const IncrementalChangelogGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-        assert.equal(IncrementalChangelogGenerator.callCount, 0);
-      });
-    });
-  });
 });

--- a/test/generator-base.spec.mts
+++ b/test/generator-base.spec.mts
@@ -614,7 +614,6 @@ describe('Generator Base', () => {
       'default',
       'writing',
       'postWriting',
-      'preConflicts',
       'install',
       'end',
     ];
@@ -693,14 +692,6 @@ describe('Generator Base', () => {
           return {
             mocked() {
               mockedPriorities.postWriting();
-            },
-          };
-        }
-
-        get [Base.PRE_CONFLICTS]() {
-          return {
-            mocked() {
-              mockedPriorities.preConflicts();
             },
           };
         }


### PR DESCRIPTION
This method was added to prevent running a generator multiple times back in late jhipster v6 cycle.
Environment now has a feature that prevents running a generator more than once for each application root, which is the desired behavior for most of the generators.

This feature can be dropped from jhipster.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
