### PR TITLE
$$ bug-bounty $$

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-jhipster",
-  "version": "7.9.2",
+  "version": "7.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-jhipster",
-      "version": "7.9.2",
+      "version": "7.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "5.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-jhipster",
-  "version": "7.9.2",
+  "version": "7.9.3",
   "description": "Spring Boot + Angular/React/Vue in one handy generator",
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
Missing rate limit for current password field (Password Change) Account Takeover on https://start.jhipster.tech/

Vulnerable site : https://start.jhipster.tech/

Steps to reproduce the bug:

1)Go to Account> Change Password. Enter any (wrong password) In the old password field.
2)Now enter the new password and Turn the Intercept ON.
3)Capture the request & Send the request to Intruder and add a Payload Marker on the current password value.
4)Add the payload for the password field having a list of more than 200 passwords or more for the test and start the attack.

Impact :
There is no rate limit enabled for the "Old Password" field on changing password on your website. A malicious minded user can continually try to brute force an account password. If a user forgets to logout an account in some public computer then the attacker is able to know the correct password, and also able to change the password to a new one by inputting a large number of payloads.

Mitigation : 
Add rate limit on Old password field.