### PR TITLE
allow mapstructExpression also in related fields

### DIFF
--- a/generators/server/templates/entity/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/server/templates/entity/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -109,9 +109,17 @@ public interface <%= entityClass %>Mapper extends EntityMapper<<%= dtoClass %>, 
     @Mapping(target = "<%= field.propertyName %>", source = "<%= field.propertyName %>")
     <%_ } _%>
     <%_ if (!relatedField.id) { _%>
+      <%_ if (relatedField.mapstructExpression) { _%>
+    @Mapping(target = "<%= relatedField.propertyName %>", expression = "<%- relatedField.mapstructExpression %>")
+      <%_ } else { _%>
     @Mapping(target = "<%= relatedField.propertyName %>", source = "<%= relatedField.propertyName %>")
+      <%_ } _%>
     <%_ } _%>
+      <%_ if (relatedField.mapstructExpression) { _%>
+    <%- otherEntity.dtoClass %> toDto<%= this._.upperFirst(mapperName) %>(<%- otherEntity.persistClass %> s);
+    <%_ } else { _%>
     <%- otherEntity.dtoClass %> toDto<%= this._.upperFirst(mapperName) %>(<%- otherEntity.persistClass %> <%= otherEntity.persistInstance %>);
+      <%_ } _%>
     <%_ if (collection) { %>
       <%_ const collectionMapperName = otherEntity.entityInstance + this._.upperFirst(relatedField.propertyName) + 'Set'; _%>
 

--- a/test-integration/samples/jdl-entities/entities.jdl
+++ b/test-integration/samples/jdl-entities/entities.jdl
@@ -1,5 +1,5 @@
 @ChangelogDate(20200804035352)
-entity JdlFieldTest {
+entity MapstructExpressionTest {
   id Long
 
   name String
@@ -8,4 +8,11 @@ entity JdlFieldTest {
   value String
 }
 
-dto JdlFieldTest with mapstruct
+@ChangelogDate(20200804035353)
+entity MapstructExpressionRelatedFieldTest
+
+relationship ManyToOne {
+  MapstructExpressionRelatedFieldTest to MapstructExpressionTest{parent(value)}
+}
+
+dto MapstructExpressionTest,MapstructExpressionRelatedFieldTest with mapstruct

--- a/test-integration/samples/jdl-entities/entities.jdl
+++ b/test-integration/samples/jdl-entities/entities.jdl
@@ -11,8 +11,8 @@ entity MapstructExpressionTest {
 @ChangelogDate(20200804035353)
 entity MapstructExpressionRelatedFieldTest
 
-relationship ManyToOne {
-  MapstructExpressionRelatedFieldTest to MapstructExpressionTest{parent(value)}
+relationship OneToMany {
+  MapstructExpressionTest to MapstructExpressionRelatedFieldTest{parent(value)}
 }
 
 dto MapstructExpressionTest,MapstructExpressionRelatedFieldTest with mapstruct


### PR DESCRIPTION
Fix #19845

Currently if the .jdl contains a mapstructExpression it works for direct fields but not for related fields. This results in a compile error. 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
