### PR TITLE
Fix missing interpolation on Angular client when translation is disabled

### DIFF
--- a/generators/client/templates/entity/angular/src/main/webapp/app/entities/update/entity-management-update.component.html.ejs
+++ b/generators/client/templates/entity/angular/src/main/webapp/app/entities/update/entity-management-update.component.html.ejs
@@ -50,7 +50,7 @@ _%>
                     <select class="form-control" name="<%= fieldName %>" formControlName="<%= fieldName %>" id="field_<%= fieldName %>" data-cy="<%= fieldName %>">
     <%_ const enumPrefix = frontendAppName + '.'+ fieldType; _%>
                         <option [ngValue]="null"><% if (enableTranslation) { %>{{ '<%= enumPrefix %>.null' | translate }}<% } %></option>
-                        <option *ngFor="let <%= this._.lowerFirst(fieldType) %> of <%- this._.lowerFirst(fieldType) %>Values" [value]="<%= this._.lowerFirst(fieldType) %>"><% if (enableTranslation) { %>{{ '<%= enumPrefix %>.' + <%= this._.lowerFirst(fieldType) %> | translate }}<% } else { %><%= this._.lowerFirst(fieldType) %><% } %></option>
+                        <option *ngFor="let <%= this._.lowerFirst(fieldType) %> of <%- this._.lowerFirst(fieldType) %>Values" [value]="<%= this._.lowerFirst(fieldType) %>"><% if (enableTranslation) { %>{{ '<%= enumPrefix %>.' + <%= this._.lowerFirst(fieldType) %> | translate }}<% } else { %> {{ <%= this._.lowerFirst(fieldType) %> }} <% } %></option>
                     </select>
   <%_ } else { _%>
     <%_ if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>


### PR DESCRIPTION
Fix #19477

<!--
PR description.

This is a small change to add interpolation to the update form on the enumeration options. We noticed that when you do not enable translation that the update form generated does not display the options correctly and there's an issue to that effect #19477 
So this update id merged will correct that issue.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
Closes #19477