### PR TITLE
fix cypress race condition that causes random failures at react frontend 

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -61,7 +61,7 @@ describe('/account/settings', () => {
   });
 
   it("should be able to change 'user' email settings", () => {
-    cy.get(emailSettingsSelector).clear().type('user@localhost.fr');
+    cy.get(emailSettingsSelector).focus().clear().type('user@localhost.fr');
     cy.get(submitSettingsSelector).click();
     cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(200));
   });
@@ -70,7 +70,7 @@ describe('/account/settings', () => {
     before(() => {
       cy.login(adminUsername, adminPassword);
       cy.visit('/account/settings');
-      cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
+      cy.get(emailSettingsSelector).focus().clear().type('admin@localhost.fr');
       cy.intercept({
         method: 'POST',
         url: '/api/account',
@@ -81,7 +81,7 @@ describe('/account/settings', () => {
     });
 
     it("should not be able to change 'user' email to same value", () => {
-      cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
+      cy.get(emailSettingsSelector).focus().clear().type('admin@localhost.fr');
       cy.get(submitSettingsSelector).click();
       cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(400));
   });

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -71,7 +71,7 @@ describe('/account/settings', () => {
     before(() => {
       cy.login(adminUsername, adminPassword);
       cy.visit('/account/settings');
-      cy.get(emailSettingsSelector).should('have.value', 'admin@localhost.fr');
+      cy.get(emailSettingsSelector).should('have.value', 'admin@localhost');
       cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
       cy.intercept({
         method: 'POST',

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -61,6 +61,7 @@ describe('/account/settings', () => {
   });
 
   it("should be able to change 'user' email settings", () => {
+    cy.get(emailSettingsSelector).invoke('val').should('not.be.empty');
     cy.get(emailSettingsSelector).focus().clear().type('user@localhost.fr');
     cy.get(submitSettingsSelector).click();
     cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(200));

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -83,6 +83,7 @@ describe('/account/settings', () => {
     });
 
     it("should not be able to change 'user' email to same value", () => {
+      cy.get(emailSettingsSelector).invoke('val').should('not.be.empty');
       cy.get(emailSettingsSelector).focus().clear().type('admin@localhost.fr');
       cy.get(submitSettingsSelector).click();
       cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(400));

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -61,8 +61,8 @@ describe('/account/settings', () => {
   });
 
   it("should be able to change 'user' email settings", () => {
-    cy.get(emailSettingsSelector).invoke('val').should('not.be.empty');
-    cy.get(emailSettingsSelector).focus().clear().type('user@localhost.fr');
+    cy.get(emailSettingsSelector).invoke('val').should('have.value', 'user@localhost.fr');
+    cy.get(emailSettingsSelector).clear().type('user@localhost.fr');
     cy.get(submitSettingsSelector).click();
     cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(200));
   });
@@ -71,8 +71,8 @@ describe('/account/settings', () => {
     before(() => {
       cy.login(adminUsername, adminPassword);
       cy.visit('/account/settings');
-      cy.get(emailSettingsSelector).invoke('val').should('not.be.empty');
-      cy.get(emailSettingsSelector).focus().clear().type('admin@localhost.fr');
+      cy.get(emailSettingsSelector).invoke('val').should('have.value', 'admin@localhost.fr');
+      cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
       cy.intercept({
         method: 'POST',
         url: '/api/account',
@@ -83,10 +83,10 @@ describe('/account/settings', () => {
     });
 
     it("should not be able to change 'user' email to same value", () => {
-      cy.get(emailSettingsSelector).invoke('val').should('not.be.empty');
-      cy.get(emailSettingsSelector).focus().clear().type('admin@localhost.fr');
+      cy.get(emailSettingsSelector).invoke('val').should('have.value', 'user@localhost.fr');
+      cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
       cy.get(submitSettingsSelector).click();
       cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(400));
-  });
+    });
   });
 });

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -61,7 +61,7 @@ describe('/account/settings', () => {
   });
 
   it("should be able to change 'user' email settings", () => {
-    cy.get(emailSettingsSelector).invoke('val').should('have.value', 'user@localhost.fr');
+    cy.get(emailSettingsSelector).should('have.value', 'user@localhost.fr');
     cy.get(emailSettingsSelector).clear().type('user@localhost.fr');
     cy.get(submitSettingsSelector).click();
     cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(200));
@@ -71,7 +71,7 @@ describe('/account/settings', () => {
     before(() => {
       cy.login(adminUsername, adminPassword);
       cy.visit('/account/settings');
-      cy.get(emailSettingsSelector).invoke('val').should('have.value', 'admin@localhost.fr');
+      cy.get(emailSettingsSelector).should('have.value', 'admin@localhost.fr');
       cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
       cy.intercept({
         method: 'POST',
@@ -83,7 +83,7 @@ describe('/account/settings', () => {
     });
 
     it("should not be able to change 'user' email to same value", () => {
-      cy.get(emailSettingsSelector).invoke('val').should('have.value', 'user@localhost.fr');
+      cy.get(emailSettingsSelector).should('have.value', 'user@localhost.fr');
       cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
       cy.get(submitSettingsSelector).click();
       cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(400));

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -70,6 +70,7 @@ describe('/account/settings', () => {
     before(() => {
       cy.login(adminUsername, adminPassword);
       cy.visit('/account/settings');
+      cy.get(emailSettingsSelector).invoke('val').should('not.be.empty');
       cy.get(emailSettingsSelector).focus().clear().type('admin@localhost.fr');
       cy.intercept({
         method: 'POST',


### PR DESCRIPTION
A race condition is probably happening where cypress tries to clear an input that’s not yet loaded. The end result is the old value concatenated with the new value.

The fix is to wait the input to have the expected value before clearing it.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
