### PR TITLE
manage halzelcast version.

### DIFF
--- a/generators/app/__snapshots__/generator.spec.mts.snap
+++ b/generators/app/__snapshots__/generator.spec.mts.snap
@@ -246,6 +246,8 @@ Object {
   "humanizedBaseName": "JHipster",
   "incrementalChangelog": undefined,
   "javaDependencies": Object {
+    "hazelcast-hibernate53": "'HAZELCAST-HIBERNATE-53-VERSION'",
+    "hazelcast-spring": "'HAZELCAST-SPRING-VERSION'",
     "jib-maven-plugin": "'JIB-MAVEN-PLUGIN-VERSION'",
     "liquibase": "'LIQUIBASE-VERSION'",
   },
@@ -592,6 +594,8 @@ Object {
   "humanizedBaseName": "JHipster",
   "incrementalChangelog": undefined,
   "javaDependencies": Object {
+    "hazelcast-hibernate53": "'HAZELCAST-HIBERNATE-53-VERSION'",
+    "hazelcast-spring": "'HAZELCAST-SPRING-VERSION'",
     "jib-maven-plugin": "'JIB-MAVEN-PLUGIN-VERSION'",
     "liquibase": "'LIQUIBASE-VERSION'",
   },
@@ -939,6 +943,8 @@ Object {
   "humanizedBaseName": "JHipster",
   "incrementalChangelog": undefined,
   "javaDependencies": Object {
+    "hazelcast-hibernate53": "'HAZELCAST-HIBERNATE-53-VERSION'",
+    "hazelcast-spring": "'HAZELCAST-SPRING-VERSION'",
     "jib-maven-plugin": "'JIB-MAVEN-PLUGIN-VERSION'",
     "liquibase": "'LIQUIBASE-VERSION'",
   },

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -302,11 +302,10 @@ if (SPRING_BOOT_VERSION.indexOf('M') > -1 || SPRING_BOOT_VERSION.indexOf('RC') >
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-hppc"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 <%_ if (cacheProviderHazelcast) { _%>
-    implementation "com.hazelcast:hazelcast"
   <%_ if (enableHibernateCache) { _%>
-    implementation "com.hazelcast:hazelcast-hibernate53"
+    implementation "com.hazelcast:hazelcast-hibernate53:${hazelcastHibernate53Version}"
   <%_ } _%>
-    implementation "com.hazelcast:hazelcast-spring"
+    implementation "com.hazelcast:hazelcast-spring:${hazelcastSpringVersion}"
 <%_ } _%>
 <%_ if (cacheProviderInfinispan) { _%>
     implementation "org.infinispan:infinispan-hibernate-cache-v53"

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -44,6 +44,12 @@ liquibaseHibernate5Version=<%- javaDependencies.liquibase %>
 <%_ if (enableLiquibase) { _%>
 liquibaseTaskPrefix=liquibase
 <%_ } _%>
+<%_ if (cacheProviderHazelcast) { _%>
+hazelcastSpringVersion=<%- javaDependencies['hazelcast-spring'] %>
+  <%_ if (enableHibernateCache) { _%>
+hazelcastHibernate53Version=<%- javaDependencies['hazelcast-hibernate53'] %>
+  <%_ } _%>
+<%_ } _%>
 
 <%_ if (databaseTypeSql && reactive) { _%>
 commonsBeanutilsVersion=1.9.4

--- a/generators/server/templates/pom.xml
+++ b/generators/server/templates/pom.xml
@@ -7,21 +7,33 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-      <liquibase.version>4.17.2</liquibase.version>
-      <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
+        <liquibase.version>4.17.2</liquibase.version>
+        <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
+        <hazelcast-spring.version>5.2.0</hazelcast-spring.version>
+        <hazelcast-hibernate53.version>2.3.0</hazelcast-hibernate53.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>${jib-maven-plugin.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
                 <version>${liquibase.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>${jib-maven-plugin.version}</version>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-spring</artifactId>
+                <version>${hazelcast-spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-hibernate53</artifactId>
+                <version>${hazelcast-hibernate53.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -170,7 +170,12 @@
 <%_ if (searchEngineElasticsearch) { _%>
         <awaitility.version>4.2.0</awaitility.version>
 <%_ } _%>
-
+<%_ if (cacheProviderHazelcast) { _%>
+        <hazelcast-spring.version><%- javaDependencies['hazelcast-spring'] %></hazelcast-spring.version>
+  <%_ if (enableHibernateCache) { _%>
+        <hazelcast-hibernate53.version><%- javaDependencies['hazelcast-hibernate53'] %></hazelcast-hibernate53.version>
+  <%_ } _%>
+<%_ } _%>
         <!-- jhipster-needle-maven-property -->
     </properties>
 
@@ -246,19 +251,17 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 <%_ if (cacheProviderHazelcast) { _%>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
-        </dependency>
   <%_ if (enableHibernateCache) { _%>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-hibernate53</artifactId>
+            <version>${hazelcast-hibernate53.version}</version>
         </dependency>
   <%_ } _%>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-spring</artifactId>
+            <version>${hazelcast-spring.version}</version>
         </dependency>
 <%_ } _%>
 <%_ if (cacheProviderInfinispan) { _%>


### PR DESCRIPTION
Hazelcast versions will not be managed by spring-boot anymore.
Should fix sb3 error: https://github.com/jhipster/generator-jhipster/actions/runs/3450840319/jobs/5759813396.

hazelcast-hibernate53 version 2.3.0 is supposed to support hibernate6.

Targeting main to avoid future conflicts.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
