### PR TITLE
Cypress: reset default admin email after updating

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs
@@ -88,5 +88,19 @@ describe('/account/settings', () => {
       cy.get(submitSettingsSelector).click();
       cy.wait('@settingsSave').then(({ response }) => expect(response.statusCode).to.equal(400));
     });
+
+    after(() => {
+      cy.login(adminUsername, adminPassword);
+      cy.visit('/account/settings');
+      cy.get(emailSettingsSelector).should('have.value', 'admin@localhost.fr');
+      cy.get(emailSettingsSelector).clear().type('admin@localhost');
+      cy.intercept({
+        method: 'POST',
+        url: '/api/account',
+        times: 1,
+      }).as('settingsSave');
+      cy.get(submitSettingsSelector).click();
+      cy.wait('@settingsSave');
+    });
   });
 });


### PR DESCRIPTION
This seems to fix the failing webflux-mongodb job.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

