### PR TITLE
Don't lazy-load ManyToOne if relationship is required

### DIFF
--- a/generators/server/templates/entity/src/main/java/package/domain/Entity.java.jhi.jakarta_persistence.ejs
+++ b/generators/server/templates/entity/src/main/java/package/domain/Entity.java.jhi.jakarta_persistence.ejs
@@ -79,7 +79,7 @@ import org.hibernate.type.SqlTypes;
   <%_ if (relationship.relationshipOneToMany) { -%>
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "<%= relationship.otherEntityRelationshipName %>")
   <%_ } else if (relationship.relationshipManyToOne) { -%>
-    @ManyToOne(fetch = FetchType.LAZY<% if (relationship.relationshipRequired) { %>, optional = false<% } %>)
+    @ManyToOne(<% if (relationship.relationshipRequired) { %>optional = false<% } else { %>fetch = FetchType.LAZY<% } %>)
       <%_ if (relationship.relationshipValidate) { _%>
     <%- include('relationship_validators', { relationship }); -%>
       <%_ } _%>


### PR DESCRIPTION
This should fix the `ng-default` job in the SB3 branch. For more details, see https://github.com/jhipster/generator-jhipster/pull/19791#issuecomment-1316370985. 

---

Please make sure the below checklist is followed for Pull Requests.

- [x] The `ng-default` job is green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
