### PR TITLE
drop --prod from npm ci at scripts

### DIFF
--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -69,6 +69,6 @@ else
     cd generator-jhipster
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 
-    npm ci --prod
+    npm ci
     npm install -g .
 fi

--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -53,7 +53,7 @@ if [[ "$JHI_REPO" == *"/generator-jhipster" || "$JHI_GEN_BRANCH" == "local" ]]; 
 
     cd "$JHI_CLI_PACKAGE_PATH"
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
-    npm ci --prod
+    npm ci
     npm install -g "$JHI_CLI_PACKAGE_PATH"
 
 elif [[ "$JHI_GEN_BRANCH" == "release" ]]; then


### PR DESCRIPTION
We need development dependencies to build the typescript project.
Related to windows daily builds.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
