### PR TITLE
Add Cypress task for logging

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
@@ -45,6 +45,18 @@ export default async (on: Cypress.PluginEvents, config: Cypress.PluginConfigOpti
     }
   });
 
+  // Allows logging with cy.task('log', 'message') or cy.task('table', object)
+  on('task', {
+    log(message) {
+      console.log(message);
+      return null;
+    },
+    table(message) {
+      console.table(message);
+      return null;
+    },
+  });
+
 <%_ if (cypressAudit) { _%>
   on('task', {
     lighthouse: lighthouse((lighthouseReport) => {


### PR DESCRIPTION
When developing 21-Points Health for the JHipster Mini-Book v7, I encountered a Cypress e2e testing issue that took me _hours_ to solve. The problem was caused by one of the list screens and I was finally able to figure it out by logging the response with `cy.task('table', response)`. When I did this, I saw it was intercepting `/points-by-week` (a new endpoint I'd added) instead of `/points` (the list screen's endpoint). 

I changed to the interception logic to fix this:

```diff
-    cy.intercept('GET', '/api/points+(?*|)').as('entitiesRequest');
+    cy.intercept('GET', '/api/points?size=*').as('entitiesRequest');
```

Since I found these methods helpful, I figured we should add them by default.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
