### PR TITLE
[Angular] Remove `row` CSS class on update form

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder/update/_entityFile-update.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder/update/_entityFile-update.component.html.ejs
@@ -44,7 +44,7 @@
   }
 _%>
 
-                <div class="row mb-3"<% if (field.autoGenerate) { %> *ngIf="editForm.controls.<%= field.fieldName %>.value !== null"<% } %>>
+                <div class="mb-3"<% if (field.autoGenerate) { %> *ngIf="editForm.controls.<%= field.fieldName %>.value !== null"<% } %>>
                     <label class="form-label" <%= jhiPrefix %>Translate="<%= translationKey %>" for="field_<%= fieldName %>"<% if (field.javadoc) { if (enableTranslation) { %> [ngbTooltip]="'<%= i18nKeyPrefix %>.help.<%= fieldName %>' | translate"<% } else { %> ngbTooltip="<%= field.javadoc %>"<% } } %>><%= fieldNameHumanized %></label>
   <%_ if (field.fieldIsEnum) { _%>
                     <select class="form-control" name="<%= fieldName %>" formControlName="<%= fieldName %>" id="field_<%= fieldName %>" data-cy="<%= fieldName %>">
@@ -164,7 +164,7 @@ _%>
 _%>
   <%_ if (relationship.relationshipManyToOne || (relationship.relationshipOneToOne && ownerSide)) { _%>
 
-                <div class="row mb-3">
+                <div class="mb-3">
                     <label class="form-label" <%= jhiPrefix %>Translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%- getWebappTranslation(translationKey) %></label>
                     <select class="form-control" id="field_<%= relationshipName %>" data-cy="<%= propertyName %>" name="<%= relationshipName %>" formControlName="<%= propertyName %>" [compareWith]="compare<%= otherEntity.entityAngularName %>">
     <%_ if (!relationshipRequired) { _%>
@@ -179,7 +179,7 @@ _%>
                 </div>
   <%_ } else if (relationship.relationshipManyToMany && ownerSide) { _%>
 
-                <div class="row mb-3">
+                <div class="mb-3">
                     <label <%= jhiPrefix %>Translate="<%= translationKey %>" for="field_<%= relationshipFieldNamePlural %>"><%- getWebappTranslation(translationKey) %></label>
                     <select class="form-control" id="field_<%= relationshipFieldNamePlural %>" data-cy="<%= relationshipFieldName %>" multiple name="<%= propertyName %>" formControlName="<%= propertyName %>" [compareWith]="compare<%= otherEntity.entityAngularName %>">
                         <option [ngValue]="<%= otherEntityName %>Option" *ngFor="let <%= otherEntityName %>Option of <%= otherEntity.entityInstancePlural %>SharedCollection">{{ <%= otherEntityName %>Option.<%= otherEntityField %> }}</option>


### PR DESCRIPTION
While developing 21-Points Health for the JHipster Mini-Book v7, I noticed the labels and input fields don't line up on the update form. Removing the `row` CSS class seems to fix this.

Before:

<img width="813" alt="Screen Shot 2022-11-30 at 12 18 17" src="https://user-images.githubusercontent.com/17892/204893799-3a735c76-775b-416f-ba91-d0d6698da95b.png">

After:

<img width="640" alt="Screen Shot 2022-11-30 at 12 27 34" src="https://user-images.githubusercontent.com/17892/204893818-0843b867-9c80-4dff-bf44-2d8158bc7cb3.png">

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
