### PR TITLE
Mark GenerateGitPropertiesTask as non cacheable

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -233,6 +233,10 @@ gitProperties {
     keys = ["git.branch", "git.commit.id.abbrev", "git.commit.id.describe"]
 }
 
+tasks.withType(com.gorylenko.GenerateGitPropertiesTask).configureEach {
+  outputs.doNotCacheIf("Task is always executed") { true }
+}
+
 checkstyle {
     toolVersion "${checkstyleVersion}"
     configFile file("checkstyle.xml")


### PR DESCRIPTION
The `GenerateGitPropertiesTask` Gradle task pulled by the `com.gorylenko.gradle-git-properties` plugin is executed systematically as using `upToDateWhen { false }`.

Marking the task as non cacheable is interesting to first avoid overhead and second ease detection of performance regression as this one won't appear anymore as a cache miss.
