### PR TITLE
switch from proxyquire to @node-loaders/mock

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,6 +1,6 @@
 const { pathToFileURL } = require('url');
 
-const loaderPath = require.resolve('@node-loaders/esbuild/strict');
+const loaderPath = require.resolve('@node-loaders/auto/strict');
 const loaderUrl = pathToFileURL(loaderPath).href;
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,9 @@
         "jhipster": "dist/cli/jhipster.mjs"
       },
       "devDependencies": {
-        "@node-loaders/esbuild": "0.5.1",
+        "@node-loaders/auto": "0.6.0",
+        "@node-loaders/esbuild": "0.6.0",
+        "@node-loaders/mock": "0.7.0",
         "@types/chai": "4.3.4",
         "@types/mocha": "10.0.0",
         "@types/sinon-chai": "3.2.9",
@@ -81,7 +83,6 @@
         "jsdoc": "4.0.0",
         "mocha": "10.1.0",
         "mocha-expect-snapshot": "6.2.0",
-        "proxyquire": "2.1.3",
         "rimraf": "3.0.2",
         "sinon": "15.0.0",
         "sinon-chai": "3.7.0",
@@ -1192,6 +1193,18 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
+    "node_modules/@node-loaders/auto": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@node-loaders/auto/-/auto-0.6.0.tgz",
+      "integrity": "sha512-FqFEg0bwmd1K2FY3Or3Dh538RFJXCm/H1b7IRN8vvxY7MfDPg+tQLdmXwJPjJilCHASkOM9RKc8TrTFhM8unRw==",
+      "dev": true,
+      "dependencies": {
+        "@node-loaders/core": "^0.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.13.0 || >=18.12.0"
+      }
+    },
     "node_modules/@node-loaders/core": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@node-loaders/core/-/core-0.5.0.tgz",
@@ -1228,13 +1241,13 @@
       }
     },
     "node_modules/@node-loaders/esbuild": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@node-loaders/esbuild/-/esbuild-0.5.1.tgz",
-      "integrity": "sha512-KMs8hSwloa/9VRWWoCu4f6xZhLMfNXmNTdqTBRAG5khZCdelP7EyPnMbuLr3jmiMTk66aLTUZQWjclEups2KdQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@node-loaders/esbuild/-/esbuild-0.6.0.tgz",
+      "integrity": "sha512-5Kg8PJ7J/Vp/IgXRU8T4DvyNUf0FzD4yBaVPWTSSaxaeRK50aFI7R5i4LGLFD8uNoxq5ClQOfV4y4gmJtkkPMg==",
       "dev": true,
       "dependencies": {
         "@node-loaders/core": "^0.5.0",
-        "@node-loaders/resolve": "^0.4.0",
+        "@node-loaders/resolve": "^0.5.0",
         "esbuild": "^0.15.16",
         "get-tsconfig": "^4.2.0"
       },
@@ -1242,12 +1255,26 @@
         "node": "^14.15.0 || ^16.13.0 || >=18.12.0"
       }
     },
-    "node_modules/@node-loaders/resolve": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@node-loaders/resolve/-/resolve-0.4.0.tgz",
-      "integrity": "sha512-roPEAuwA4FHcQe25sNVywLKYveeaoH+jeU/wtfH/usTnN7ZMLxiXzhJ0hPT+/NRNxlB/nmkTo8haPwVxxF0xSQ==",
+    "node_modules/@node-loaders/mock": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@node-loaders/mock/-/mock-0.7.0.tgz",
+      "integrity": "sha512-Wwv1VezlFZ2ymPD4EUg0zzIPoK7Ts5Pgl1vGn31l2HLQX+ZhQThAjQSH2QYVJM4SYpOisv9iX4g2CDzRiAhIuQ==",
       "dev": true,
       "dependencies": {
+        "@node-loaders/core": "^0.5.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.13.0 || >=18.12.0"
+      }
+    },
+    "node_modules/@node-loaders/resolve": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@node-loaders/resolve/-/resolve-0.5.0.tgz",
+      "integrity": "sha512-6feEKzC330u91s9NVCRJ91puURYHMDyG+SBbu6CZza4UPwpKFxA1L97wia5ufowaj7Ee7eAVXtk7GPMiS1vHYA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^6.3.0",
         "locate-path": "^7.1.1",
         "read-pkg-up": "^9.1.0"
       },
@@ -5452,19 +5479,6 @@
         "minimatch": "^5.0.1"
       }
     },
-    "node_modules/fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
-      "dev": true,
-      "dependencies": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6624,15 +6638,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
-      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -7775,12 +7780,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8203,12 +8202,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -9828,17 +9821,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "node_modules/proxyquire": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
-      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
-      "dev": true,
-      "dependencies": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
-      }
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,9 @@
     "yeoman-generator": "5.7.0"
   },
   "devDependencies": {
-    "@node-loaders/esbuild": "0.5.1",
+    "@node-loaders/auto": "0.6.0",
+    "@node-loaders/esbuild": "0.6.0",
+    "@node-loaders/mock": "0.7.0",
     "@types/chai": "4.3.4",
     "@types/mocha": "10.0.0",
     "@types/sinon-chai": "3.2.9",
@@ -147,7 +149,6 @@
     "jsdoc": "4.0.0",
     "mocha": "10.1.0",
     "mocha-expect-snapshot": "6.2.0",
-    "proxyquire": "2.1.3",
     "rimraf": "3.0.2",
     "sinon": "15.0.0",
     "sinon-chai": "3.7.0",

--- a/test/cli/import-jdl.spec.cjs
+++ b/test/cli/import-jdl.spec.cjs
@@ -1,5 +1,5 @@
+const { mockRequire } = require('@node-loaders/mock/require');
 const path = require('path');
-const proxyquire = require('proxyquire');
 const fse = require('fs-extra');
 const assert = require('yeoman-assert');
 const expect = require('chai').expect;
@@ -76,7 +76,7 @@ const loadImportJdl = options => {
     },
     ...options,
   };
-  return proxyquire('../../cli/import-jdl.cjs', options);
+  return mockRequire('../../cli/import-jdl.cjs', options);
 };
 
 const defaultAddedOptions = {};

--- a/test/cli/jdl.spec.cjs
+++ b/test/cli/jdl.spec.cjs
@@ -4,7 +4,7 @@ const assert = require('yeoman-assert');
 const expect = require('chai').expect;
 const https = require('https');
 const fse = require('fs-extra');
-const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+const { mockRequire } = require('@node-loaders/mock/require');
 const sinon = require('sinon');
 
 const { testInTempDir, revertTempDir } = require('./utils/utils.cjs');
@@ -95,7 +95,7 @@ describe('jdl command test', () => {
       const env = { env: 'foo' };
       const fork = { fork: 'foo' };
       beforeEach(() => {
-        return proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo.jdl']], options, env, fork).then(jdlFiles => {
+        return mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo.jdl']], options, env, fork).then(jdlFiles => {
           resolved = jdlFiles;
         });
       });
@@ -119,7 +119,7 @@ describe('jdl command test', () => {
       const env = { env: 'foo' };
       const fork = { fork: 'foo' };
       beforeEach(() => {
-        return proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo.jdl', 'bar.jdl']], options, env, fork);
+        return mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo.jdl', 'bar.jdl']], options, env, fork);
       });
       it('should not call https.get', () => {
         expect(https.get.callCount).to.be.equal(0);
@@ -139,7 +139,7 @@ describe('jdl command test', () => {
           https.get.restore();
         });
         it('should return file not found', () => {
-          return proxyquire('../../cli/jdl.cjs', {})(
+          return mockRequire('../../cli/jdl.cjs', {})(
             [['foo.jdl']],
             { bar: 'foo', skipSampleRepository: true },
             { env: 'foo' },
@@ -172,7 +172,7 @@ describe('jdl command test', () => {
           https.get.restore();
         });
         it('should call https.get', () => {
-          return proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })(
+          return mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })(
             [['https://raw.githubusercontent.com/jhipster/jdl-samples/main/foo.jdl']],
             { bar: 'foo', skipSampleRepository: true },
             { env: 'foo' },
@@ -183,7 +183,7 @@ describe('jdl command test', () => {
           });
         });
         it('should call importJdl', () => {
-          return proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })(
+          return mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })(
             [['https://raw.githubusercontent.com/jhipster/jdl-samples/main/foo.jdl']],
             { bar: 'foo', skipSampleRepository: true },
             { env: 'foo' },
@@ -226,9 +226,11 @@ describe('jdl command test', () => {
         const env = { env: 'foo' };
         const fork = { fork: 'foo' };
         beforeEach(() => {
-          return proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo.jh']], options, env, fork).then(jdlFiles => {
-            resolved = jdlFiles;
-          });
+          return mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo.jh']], options, env, fork).then(
+            jdlFiles => {
+              resolved = jdlFiles;
+            }
+          );
         });
         it('should pass to https.get with jdl-sample repository', () => {
           expect(https.get.getCall(0).args[0]).to.be.equal(
@@ -254,7 +256,7 @@ describe('jdl command test', () => {
 
       describe('when passing foo', () => {
         beforeEach(() => {
-          return proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo']]);
+          return mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([['foo']]);
         });
         it('should append jdl extension and pass to https.get with jdl-sample repository', () => {
           expect(https.get.getCall(0).args[0]).to.be.equal(
@@ -273,7 +275,7 @@ describe('jdl command test', () => {
       describe('with a complete url', () => {
         const url = 'https://raw.githubusercontent.com/jhipster/jdl-samples/main/bar.jdl';
         beforeEach(() => {
-          return proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([[url]]);
+          return mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': importJdlStub })([[url]]);
         });
         it('should forward the url to get', () => {
           expect(https.get.getCall(0).args[0]).to.be.equal(url);
@@ -306,14 +308,14 @@ describe('jdl command test', () => {
         });
 
         it('should not create the destination file', done => {
-          proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': () => {} })([['foo.jh']]).catch(error => {
+          mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': () => {} })([['foo.jh']]).catch(error => {
             assert.noFile('foo.jh');
             done();
           });
         });
 
         it('should print error message', done => {
-          proxyquire('../../cli/jdl.cjs', { './import-jdl.cjs': () => {} })([['foo.jh']]).catch(error => {
+          mockRequire('../../cli/jdl.cjs', { './import-jdl.cjs': () => {} })([['foo.jh']]).catch(error => {
             assert.equal(
               error.message,
               'Error downloading https://raw.githubusercontent.com/jhipster/jdl-samples/main/foo.jh: 404 - Custom message'


### PR DESCRIPTION
`@node-loaders/mock` provides esm and commonjs modules mocking support.
This will make the cli transition to esm easier due to existing module mocking usage.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
