### PR TITLE
use string value for matrix

### DIFF
--- a/test-integration/scripts/99-print-matrix.js
+++ b/test-integration/scripts/99-print-matrix.js
@@ -30,8 +30,8 @@ writeFileSync(
                 .include.filter(sample => !sample.disabled)
                 .map(sample => ({
                   ...sample,
-                  'skip-backend-tests': Boolean(sample['skip-backend-tests']),
-                  'skip-frontend-tests': Boolean(sample['skip-frontend-tests']),
+                  'skip-backend-tests': sample['skip-backend-tests'] ? 'true' : 'false',
+                  'skip-frontend-tests': sample['skip-frontend-tests'] ? 'true' : 'false',
                 }));
             } catch (_) {
               console.log(`File ${file} not found`);


### PR DESCRIPTION
Mongodb + webflux backend tests still running even after https://github.com/jhipster/generator-jhipster/pull/20599
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
