### PR TITLE
Improve liquibase gradle experience

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -242,6 +242,9 @@ liquibase {
 
     runList = project.ext.runList
 }
+
+liquibaseDiff.dependsOn compileJava
+liquibaseDiffChangeLog.dependsOn compileJava
 <%_ } _%>
 
 gitProperties {


### PR DESCRIPTION
<!--
PR description.
-->
In the official documentation (screenshot below) there is a similar workflow for maven and gradle users regarding liquibase plugin usage.  
For gradle users we can enhance this experience by removing the step 3 (compilation).  
I was looking for having the same experience for maven users but I don't get something nice.  

I would like to have your feedback about this change  

![image](https://user-images.githubusercontent.com/9569081/210789075-5d527694-f056-4156-9b12-64ef056266c0.png)

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
