### PR TITLE
disable ejs cache

### DIFF
--- a/generators/base/generator-base.mjs
+++ b/generators/base/generator-base.mjs
@@ -1801,6 +1801,7 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
           ...(options?.renderOptions ?? {}),
           // Set root for ejs to lookup for partials.
           root: rootTemplatesAbsolutePath,
+          cache: false,
         };
         // TODO drop for v8 final release
         const data = jhipster7Proxy(this, context, { ignoreWarnings: true });


### PR DESCRIPTION
Ejs cache is misbehaving in some use cases.
Mainly when regenerating multiples applications (microservices) samples.

Reproduce, execute twice:
```
jhipster jdl https://raw.githubusercontent.com/jhipster/generator-jhipster/main/test-integration/jdl-samples/mf-ng-eureka-jwt-psql-ehcache/blog-store.jdl --skip-install
```

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
