### PR TITLE
cleanup config before applying defaults

### DIFF
--- a/generators/base-docker/docker-base.mjs
+++ b/generators/base-docker/docker-base.mjs
@@ -22,6 +22,7 @@ import _ from 'lodash';
 
 import { createBase64Secret } from '../../lib/utils/secret-utils.mjs';
 import { applicationTypes, buildToolTypes, getConfigWithDefaults } from '../../jdl/jhipster/index.mjs';
+import { deepCleanup } from '../base/support/index.mjs';
 
 const { MAVEN } = buildToolTypes;
 const { MONOLITH, MICROSERVICE, GATEWAY } = applicationTypes;
@@ -111,7 +112,7 @@ export function loadConfigs() {
   this.appsFolders.forEach((appFolder, index) => {
     const path = this.destinationPath(`${this.directoryPath + appFolder}`);
     if (this.fs.exists(`${path}/.yo-rc.json`)) {
-      const config = getConfigWithDefaults(this.getJhipsterConfig(`${path}/.yo-rc.json`).getAll());
+      const config = getConfigWithDefaults(deepCleanup(this.getJhipsterConfig(`${path}/.yo-rc.json`).getAll()));
       config.composePort = serverPort + index;
       this.loadAppConfig(config, config);
       this.loadServerConfig(config, config);

--- a/generators/base/generator-base.mjs
+++ b/generators/base/generator-base.mjs
@@ -68,6 +68,7 @@ import {
   LANGUAGES,
   CLIENT_DIST_DIR,
 } from '../generator-constants.mjs';
+import { deepCleanup } from './support/config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -2581,7 +2582,7 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
    * JHipster config with default values fallback
    */
   get jhipsterConfigWithDefaults() {
-    const configWithDefaults = getConfigWithDefaults(this.config.getAll());
+    const configWithDefaults = getConfigWithDefaults(deepCleanup(this.config.getAll()));
     _.defaults(configWithDefaults, {
       skipFakeData: false,
       skipCheckLengthOfIdentifier: false,

--- a/generators/base/support/config.mts
+++ b/generators/base/support/config.mts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2013-2023 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const filterUndefinedAndNullValues = value => value !== undefined && value !== null;
+
+/**
+ * Copy and remove null and undefined values
+ * @param object
+ * @returns
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function deepCleanup(
+  object: Record<string, any>,
+  filterValue: (any) => boolean = filterUndefinedAndNullValues
+): Record<string, any> {
+  const clone = {};
+  for (const [key, value] of Object.entries(object)) {
+    if (filterValue(value)) {
+      if (typeof value === 'object') {
+        if (Array.isArray(value)) {
+          clone[key] = value.filter(filterValue);
+        } else {
+          clone[key] = deepCleanup(value);
+        }
+      } else {
+        clone[key] = value;
+      }
+    }
+  }
+  return clone;
+}

--- a/generators/base/support/config.mts
+++ b/generators/base/support/config.mts
@@ -26,7 +26,7 @@ const filterUndefinedAndNullValues = value => value !== undefined && value !== n
  */
 // eslint-disable-next-line import/prefer-default-export
 export function deepCleanup(
-  object: Record<string, any> = {},
+  object: Record<string, any>,
   filterValue: (any) => boolean = filterUndefinedAndNullValues
 ): Record<string, any> {
   const clone = {};

--- a/generators/base/support/config.mts
+++ b/generators/base/support/config.mts
@@ -26,7 +26,7 @@ const filterUndefinedAndNullValues = value => value !== undefined && value !== n
  */
 // eslint-disable-next-line import/prefer-default-export
 export function deepCleanup(
-  object: Record<string, any>,
+  object: Record<string, any> = {},
   filterValue: (any) => boolean = filterUndefinedAndNullValues
 ): Record<string, any> {
   const clone = {};

--- a/generators/base/support/config.spec.mts
+++ b/generators/base/support/config.spec.mts
@@ -1,0 +1,16 @@
+import { jestExpect as expect } from 'mocha-expect-snapshot';
+import { deepCleanup } from './config.mjs';
+
+describe('generator - base - support - config', () => {
+  describe('deepCleanup', () => {
+    it('should cleanup objects', () => {
+      expect(deepCleanup({ foo: 'bar', foo2: undefined, foo3: null })).toMatchObject({ foo: 'bar' });
+    });
+    it('should cleanup property objects', () => {
+      expect(deepCleanup({ nested: { foo: 'bar', foo2: undefined, foo3: null } })).toMatchObject({ nested: { foo: 'bar' } });
+    });
+    it('should cleanup property arrays', () => {
+      expect(deepCleanup({ foo: ['bar', undefined, null] })).toMatchObject({ foo: ['bar'] });
+    });
+  });
+});

--- a/generators/base/support/index.mts
+++ b/generators/base/support/index.mts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2013-2023 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './config.mjs';

--- a/generators/entity/generator.mjs
+++ b/generators/entity/generator.mjs
@@ -151,7 +151,7 @@ export default class EntityGenerator extends BaseGenerator {
         this.loadTranslationConfig(undefined, this.application);
         // Try to load server config from microservice side, falling back to the app config.
         this.loadServerConfig(
-          getConfigWithDefaults({ ...deepCleanup(this.jhipsterConfig), ...deepCleanup(this.microserviceConfig) }),
+          getConfigWithDefaults({ ...deepCleanup(this.jhipsterConfig), ...deepCleanup(this.microserviceConfig ?? {}) }),
           this.application
         );
 

--- a/generators/entity/generator.mjs
+++ b/generators/entity/generator.mjs
@@ -27,6 +27,7 @@ import prompts from './prompts.mjs';
 import { JHIPSTER_CONFIG_DIR, ANGULAR_DIR } from '../generator-constants.mjs';
 import { applicationTypes, clientFrameworkTypes, getConfigWithDefaults, reservedKeywords } from '../../jdl/jhipster/index.mjs';
 import { GENERATOR_ENTITIES, GENERATOR_ENTITY } from '../generator-list.mjs';
+import { deepCleanup } from '../base/support/config.mjs';
 
 const { GATEWAY, MICROSERVICE } = applicationTypes;
 const { NO: CLIENT_FRAMEWORK_NO, ANGULAR } = clientFrameworkTypes;
@@ -149,7 +150,10 @@ export default class EntityGenerator extends BaseGenerator {
         this.loadClientConfig(undefined, this.application);
         this.loadTranslationConfig(undefined, this.application);
         // Try to load server config from microservice side, falling back to the app config.
-        this.loadServerConfig(getConfigWithDefaults({ ...this.jhipsterConfig, ...this.microserviceConfig }), this.application);
+        this.loadServerConfig(
+          getConfigWithDefaults({ ...deepCleanup(this.jhipsterConfig), ...deepCleanup(this.microserviceConfig) }),
+          this.application
+        );
 
         this.loadDerivedAppConfig(this.application);
         this.loadDerivedClientConfig(this.application);


### PR DESCRIPTION
When prompts are ignored, a null value is set to the store so subsequent prompts are ignored (`--ask-answered` option will show those questions again).

A null value at config will override the default value with the null value, causing a wrong config to be applied.
This PR removes undefined and null values so the default value will be correctly be returned.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
