### PR TITLE
ci: use GITHUB_OUTPUT to expose outputs

### DIFF
--- a/.github/actions/build-matrix/action.yml
+++ b/.github/actions/build-matrix/action.yml
@@ -131,9 +131,9 @@ runs:
           echo "::endgroup::"
         fi
 
-        MATRIX=$(cat matrix.json)
         echo 'matrix<<EOF' >> $GITHUB_OUTPUT
         cat matrix.json >> $GITHUB_OUTPUT
+        echo '' >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
         rm matrix.json
       shell: bash

--- a/.github/actions/build-matrix/action.yml
+++ b/.github/actions/build-matrix/action.yml
@@ -132,9 +132,8 @@ runs:
         fi
 
         MATRIX=$(cat matrix.json)
+        echo 'matrix<<EOF' >> $GITHUB_OUTPUT
+        cat matrix.json >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
         rm matrix.json
-        MATRIX="${MATRIX//'%'/'%25'}"
-        MATRIX="${MATRIX//$'\n'/'%0A'}"
-        MATRIX="${MATRIX//$'\r'/'%0D'}"
-        echo "::set-output name=matrix::$MATRIX"
       shell: bash

--- a/.github/actions/compare-base/action.yml
+++ b/.github/actions/compare-base/action.yml
@@ -68,7 +68,7 @@ runs:
       id: base
       run: |
         $JHI_SCRIPTS/12-generate-project.sh --skip-jhipster-dependencies --skip-install --skip-git ${{ inputs.extra-args }}
-        echo "::set-output name=application-path::${{inputs.application-path}}"
+        echo "application-path=${{inputs.application-path}}" >> $GITHUB_OUTPUT
       env:
         JHI_FOLDER_APP: ${{ inputs.application-path }}
         JHI_JDL_SAMPLES: "${{ github.workspace }}/base/${{ env.JHI_CLI_PACKAGE || 'generator-jhipster' }}/test-integration/jdl-samples"

--- a/.github/actions/compare/action.yml
+++ b/.github/actions/compare/action.yml
@@ -57,6 +57,6 @@ runs:
           ':!.jhipster/**' ':!**/.jhipster/**' \
           ':!package-lock.json' ':!**/package-lock.json' \
           ':!**/keystore.p12' \
-          && echo "::set-output name=equals::true" \
-          || echo "::set-output name=has-changes::true"
+          && echo "equals=true" >> $GITHUB_OUTPUT \
+          || echo "has-changes=true" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -156,11 +156,11 @@ runs:
         # Use java backward compatible locale values https://bugs.openjdk.java.net/browse/JDK-8267069
         echo "java.locale.useOldISOCodes=true" >> $GITHUB_ENV
 
-        echo "::set-output name=application-path::${{inputs.application-path}}"
-        echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-        echo "::set-output name=java-version::$JHI_JDK"
-        echo "::set-output name=node-version::$JHI_NODE_VERSION"
-        echo "::set-output name=npm-version::$JHI_NPM_VERSION"
+        echo "application-path=${{inputs.application-path}}" >> $GITHUB_OUTPUT
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        echo "java-version=$JHI_JDK" >> $GITHUB_OUTPUT
+        echo "node-version=$JHI_NODE_VERSION" >> $GITHUB_OUTPUT
+        echo "npm-version=$JHI_NPM_VERSION" >> $GITHUB_OUTPUT
 
         echo "Variables added to environment"
         cat $GITHUB_ENV

--- a/test-integration/scripts/99-build-changes.sh
+++ b/test-integration/scripts/99-build-changes.sh
@@ -13,42 +13,42 @@ WORKFLOW_REACT=false
 WORKFLOW_VUE=false
 
 if [[ "true" == "$SKIP_WORKFLOW" ]]; then
-  echo "::set-output name=angular::false"
-  echo "::set-output name=react::false"
-  echo "::set-output name=vue::false"
-  echo "::set-output name=client-common::false"
+  echo "angular=false" >> $GITHUB_OUTPUT
+  echo "react=false" >> $GITHUB_OUTPUT
+  echo "vue=false" >> $GITHUB_OUTPUT
+  echo "client-common=false" >> $GITHUB_OUTPUT
 
-  echo "::set-output name=workflow-angular::false"
-  echo "::set-output name=workflow-react::false"
-  echo "::set-output name=workflow-vue::false"
+  echo "workflow-angular=false" >> $GITHUB_OUTPUT
+  echo "workflow-react=false" >> $GITHUB_OUTPUT
+  echo "workflow-vue=false" >> $GITHUB_OUTPUT
 
-  echo "::set-output name=client::${CLIENT}"
-  echo "::set-output name=server::${SERVER}"
-  echo "::set-output name=common::${COMMON}"
-  echo "::set-output name=workspaces::${WORKSPACES}"
-  echo "::set-output name=e2e::${E2E}"
-  echo "::set-output name=any::${ANY}"
-  echo "::set-output name=matrix::{}"
+  echo "client=${CLIENT}" >> $GITHUB_OUTPUT
+  echo "server=${SERVER}" >> $GITHUB_OUTPUT
+  echo "common=${COMMON}" >> $GITHUB_OUTPUT
+  echo "workspaces=${WORKSPACES}" >> $GITHUB_OUTPUT
+  echo "e2e=${E2E}" >> $GITHUB_OUTPUT
+  echo "any=${ANY}" >> $GITHUB_OUTPUT
+  echo "matrix={}" >> $GITHUB_OUTPUT
   exit 0
 fi
 
 if [[ "true" == "$SKIP_CHANGES_DETECTION" ]]; then
-  echo "::set-output name=angular::true"
-  echo "::set-output name=react::true"
-  echo "::set-output name=vue::true"
-  echo "::set-output name=client-common::true"
+  echo "angular=true" >> $GITHUB_OUTPUT
+  echo "react=true" >> $GITHUB_OUTPUT
+  echo "vue=true" >> $GITHUB_OUTPUT
+  echo "client-common=true" >> $GITHUB_OUTPUT
 
-  echo "::set-output name=workflow-angular::true"
-  echo "::set-output name=workflow-react::true"
-  echo "::set-output name=workflow-vue::true"
+  echo "workflow-angular=true" >> $GITHUB_OUTPUT
+  echo "workflow-react=true" >> $GITHUB_OUTPUT
+  echo "workflow-vue=true" >> $GITHUB_OUTPUT
 
-  echo "::set-output name=client::true"
-  echo "::set-output name=server::true"
-  echo "::set-output name=common::true"
-  echo "::set-output name=workspaces::true"
-  echo "::set-output name=e2e::true"
-  echo "::set-output name=any::true"
-  echo "::set-output name=matrix::{}"
+  echo "client=true" >> $GITHUB_OUTPUT
+  echo "server=true" >> $GITHUB_OUTPUT
+  echo "common=true" >> $GITHUB_OUTPUT
+  echo "workspaces=true" >> $GITHUB_OUTPUT
+  echo "e2e=true" >> $GITHUB_OUTPUT
+  echo "any=true" >> $GITHUB_OUTPUT
+  echo "matrix={}" >> $GITHUB_OUTPUT
   exit 0
 fi
 
@@ -151,18 +151,18 @@ if [ "true" == "$SERVER" ] || [ "true" == "$CLIENT_COMMON" ] || [ "true" == "$CO
   WORKFLOW_VUE=true
 fi
 
-echo "::set-output name=angular::${ANGULAR}"
-echo "::set-output name=react::${REACT}"
-echo "::set-output name=vue::${VUE}"
-echo "::set-output name=client-common::${CLIENT_COMMON}"
+echo "angular=${ANGULAR}" >> $GITHUB_OUTPUT
+echo "react=${REACT}" >> $GITHUB_OUTPUT
+echo "vue=${VUE}" >> $GITHUB_OUTPUT
+echo "client-common=${CLIENT_COMMON}" >> $GITHUB_OUTPUT
 
-echo "::set-output name=workflow-angular::${WORKFLOW_ANGULAR}"
-echo "::set-output name=workflow-react::${WORKFLOW_REACT}"
-echo "::set-output name=workflow-vue::${WORKFLOW_VUE}"
+echo "workflow-angular=${WORKFLOW_ANGULAR}" >> $GITHUB_OUTPUT
+echo "workflow-react=${WORKFLOW_REACT}" >> $GITHUB_OUTPUT
+echo "workflow-vue=${WORKFLOW_VUE}" >> $GITHUB_OUTPUT
 
-echo "::set-output name=client::${CLIENT}"
-echo "::set-output name=server::${SERVER}"
-echo "::set-output name=common::${COMMON}"
-echo "::set-output name=workspaces::${WORKSPACES}"
-echo "::set-output name=e2e::${E2E}"
-echo "::set-output name=any::${ANY}"
+echo "client=${CLIENT}" >> $GITHUB_OUTPUT
+echo "server=${SERVER}" >> $GITHUB_OUTPUT
+echo "common=${COMMON}" >> $GITHUB_OUTPUT
+echo "workspaces=${WORKSPACES}" >> $GITHUB_OUTPUT
+echo "e2e=${E2E}" >> $GITHUB_OUTPUT
+echo "any=${ANY}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub Actions have depreciated the set-output command to avoid vulnerabilities

See changelog https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
