### PR TITLE
cleanup generator-private methods

### DIFF
--- a/generators/app/generator.mjs
+++ b/generators/app/generator.mjs
@@ -24,7 +24,7 @@ import BaseGenerator from '../base-application/index.mjs';
 import { checkNode } from './support/index.mjs';
 import gitOptions from '../git/options.mjs';
 import serverOptions from '../server/options.mjs';
-import { cleanupOldFiles, upgradeFiles } from '../cleanup.mjs';
+import { cleanupOldFiles } from '../cleanup.mjs';
 import prompts from './prompts.mjs';
 import { packageJson } from '../../lib/index.mjs';
 import statistics from '../statistics.cjs';
@@ -488,7 +488,6 @@ export default class JHipsterAppGenerator extends BaseGenerator {
     return this.asWritingTaskGroup({
       cleanup({ application }) {
         cleanupOldFiles(this, application);
-        upgradeFiles(this);
       },
     });
   }

--- a/generators/base/generator-base-private.mjs
+++ b/generators/base/generator-base-private.mjs
@@ -17,10 +17,8 @@
  * limitations under the License.
  */
 
-import { rmSync, statSync } from 'fs';
 import _ from 'lodash';
 import Generator from 'yeoman-generator';
-import shelljs from 'shelljs';
 
 import { Logger } from './support/logging.mjs';
 
@@ -29,12 +27,8 @@ import { Logger } from './support/logging.mjs';
  */
 
 /**
- * This is the Generator base private class.
- * This provides all the private API methods used internally.
- * These methods should not be directly utilized using commonJS require,
- * as these can have breaking changes without a major version bump
+ * This class changes/corrects the yeoman-generator typescript definitions.
  *
- * The method signatures in private API can be changed without a major version change.
  * @class
  * @extends {Generator<JHipsterGeneratorOptions>}
  */
@@ -89,64 +83,5 @@ export default class PrivateBase extends Generator {
    */
   spawnCommand(command, args, opt) {
     return super.spawnCommand(command, args, opt);
-  }
-
-  /* ======================================================================== */
-  /* private methods use within generator (not exposed to modules) */
-  /* ======================================================================== */
-
-  /**
-   * Override yeoman generator's usage function to fine tune --help message.
-   */
-  usage() {
-    return super.usage().replace('yo jhipster:', 'jhipster ');
-  }
-
-  /**
-   * Remove File
-   *
-   * @param file
-   */
-  removeFile(file) {
-    const destination = this.destinationPath(file);
-    if (destination && shelljs.test('-f', destination)) {
-      this.logger.log(`Removing the file - ${destination}`);
-      rmSync(destination, { force: true });
-    }
-    return destination;
-  }
-
-  /**
-   * Remove Folder
-   *
-   * @param folder
-   */
-  removeFolder(folder) {
-    folder = this.destinationPath(folder);
-    try {
-      if (statSync(folder).isDirectory()) {
-        rmSync(folder, { recursive: true });
-      }
-    } catch (error) {
-      this.logger.log(`Could not remove folder ${folder}`);
-    }
-  }
-
-  /**
-   * @private
-   * Execute a git mv.
-   *
-   * @param {string} source
-   * @param {string} dest
-   * @returns {boolean} true if success; false otherwise
-   */
-  gitMove(from, to) {
-    const source = this.destinationPath(from);
-    const dest = this.destinationPath(to);
-    if (source && dest && shelljs.test('-f', source)) {
-      this.logger.info(`Renaming the file - ${source} to ${dest}`);
-      return !shelljs.exec(`git mv -f ${source} ${dest}`).code;
-    }
-    return true;
   }
 }

--- a/generators/base/generator.mts
+++ b/generators/base/generator.mts
@@ -23,6 +23,7 @@ import _ from 'lodash';
 import { simpleGit } from 'simple-git';
 import type { CopyOptions } from 'mem-fs-editor';
 import type { Data as TemplateData, Options as TemplateOptions } from 'ejs';
+import { statSync, rmSync } from 'fs';
 
 import SharedData from './shared-data.mjs';
 import JHipsterBaseBlueprintGenerator from './generator-base-blueprint.mjs';
@@ -90,6 +91,13 @@ export default class BaseGenerator extends JHipsterBaseBlueprintGenerator {
   }
 
   /**
+   * Override yeoman generator's usage function to fine tune --help message.
+   */
+  usage(): string {
+    return super.usage().replace('yo jhipster:', 'jhipster ');
+  }
+
+  /**
    * Get arguments for the priority
    */
   getArgsForPriority(priorityName: string) {
@@ -145,6 +153,38 @@ export default class BaseGenerator extends JHipsterBaseBlueprintGenerator {
         }
       }
     });
+  }
+
+  /**
+   * Remove File
+   * @param file
+   */
+  removeFile(...path: string[]) {
+    const destinationFile = this.destinationPath(...path);
+    try {
+      if (destinationFile && statSync(destinationFile).isFile()) {
+        this.logger.log(`Removing the file - ${destinationFile}`);
+        rmSync(destinationFile, { force: true });
+      }
+    } catch {
+      this.logger.log(`Could not remove file ${destinationFile}`);
+    }
+    return destinationFile;
+  }
+
+  /**
+   * Remove Folder
+   * @param path
+   */
+  removeFolder(...path: string[]) {
+    const destinationFolder = this.destinationPath(...path);
+    try {
+      if (statSync(destinationFolder).isDirectory()) {
+        rmSync(destinationFolder, { recursive: true });
+      }
+    } catch (error) {
+      this.logger.log(`Could not remove folder ${destinationFolder}`);
+    }
   }
 
   /**

--- a/generators/cleanup.mjs
+++ b/generators/cleanup.mjs
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-import { SERVER_MAIN_RES_DIR, ANGULAR_DIR, REACT_DIR, VUE_DIR, CLIENT_WEBPACK_DIR, DOCKER_DIR } from './generator-constants.mjs';
-import { languageSnakeCase, languageToJavaLanguage } from './languages/support/index.mjs';
+import { ANGULAR_DIR, REACT_DIR, VUE_DIR, CLIENT_WEBPACK_DIR, DOCKER_DIR } from './generator-constants.mjs';
 import { clientFrameworkTypes, authenticationTypes } from '../jdl/jhipster/index.mjs';
 
 const { ANGULAR, REACT, VUE } = clientFrameworkTypes;
@@ -34,6 +33,7 @@ const { OAUTH2, SESSION } = authenticationTypes;
  *
  * @param {any} generator - reference to generator
  */
+// eslint-disable-next-line import/prefer-default-export
 export function cleanupOldFiles(generator, data) {
   if (generator.isJhipsterVersionLessThan('3.2.0')) {
     // removeFile and removeFolder methods should be called here for files and folders to cleanup
@@ -336,34 +336,4 @@ export function cleanupOldFiles(generator, data) {
       generator.removeFile('.npmrc');
     }
   }
-}
-
-/**
- * Upgrade files.
- *
- * @param {any} generator - reference to generator
- */
-export function upgradeFiles(generator) {
-  let atLeastOneSuccess = false;
-  if (generator.isJhipsterVersionLessThan('6.1.0')) {
-    const languages = generator.config.get('languages');
-    if (languages) {
-      const langNameDiffer = function (lang) {
-        const langProp = languageSnakeCase(lang);
-        const langJavaProp = languageToJavaLanguage(lang);
-        return langProp !== langJavaProp ? [langProp, langJavaProp] : undefined;
-      };
-      languages
-        .map(langNameDiffer)
-        .filter(props => props)
-        .forEach(props => {
-          const code = generator.gitMove(
-            `${SERVER_MAIN_RES_DIR}i18n/messages_${props[0]}.properties`,
-            `${SERVER_MAIN_RES_DIR}i18n/messages_${props[1]}.properties`
-          );
-          atLeastOneSuccess = atLeastOneSuccess || code;
-        });
-    }
-  }
-  return atLeastOneSuccess;
 }

--- a/generators/docker-compose/files.mjs
+++ b/generators/docker-compose/files.mjs
@@ -26,7 +26,9 @@ const { OAUTH2 } = authenticationTypes;
 export function writeFiles() {
   return {
     cleanup() {
-      this.removeFile('realm-config/jhipster-users-0.json');
+      if (this.isJhipsterVersionLessThan('7.10.0')) {
+        this.removeFile('realm-config/jhipster-users-0.json');
+      }
     },
 
     writeDockerCompose() {

--- a/generators/languages/generator.mjs
+++ b/generators/languages/generator.mjs
@@ -33,6 +33,7 @@ import { updateLanguagesTask as updateLanguagesInReact } from '../react/support/
 import { updateLanguagesTask as updateLanguagesInVue } from '../vue/support/index.mjs';
 import { updateLanguagesTask as updateLanguagesInJava } from '../server/support/index.mjs';
 import { SERVER_MAIN_RES_DIR, SERVER_TEST_RES_DIR } from '../generator-constants.mjs';
+import upgradeFilesTask from './upgrade-files-task.mjs';
 
 /**
  * This is the base class for a generator that generates entities.
@@ -268,6 +269,7 @@ export default class LanguagesGenerator extends BaseApplicationGenerator {
   // Public API method used by the getter and also by Blueprints
   get writing() {
     return {
+      upgradeFilesTask,
       async writeClientTranslations({ application }) {
         if (!application.enableTranslation || application.skipClient) return;
         await Promise.all(

--- a/generators/languages/index.mts
+++ b/generators/languages/index.mts
@@ -17,3 +17,4 @@
  * limitations under the License.
  */
 export { default } from './generator.mjs';
+export { default as upgradeFilesTask } from './upgrade-files-task.mjs';

--- a/generators/languages/upgrade-files-task.mts
+++ b/generators/languages/upgrade-files-task.mts
@@ -1,0 +1,52 @@
+import shelljs from 'shelljs';
+
+import BaseGenerator from '../base/index.mjs';
+import { SERVER_MAIN_RES_DIR } from '../generator-constants.mjs';
+import { languageSnakeCase, languageToJavaLanguage } from './support/index.mjs';
+
+/**
+ * Execute a git mv.
+ * A git mv operation is required due to file casing change eg: en_us -> en_US at a case insensitive OS.
+ *
+ * @param source
+ * @param dest
+ * @returns {boolean} true if success; false otherwise
+ */
+function gitMove(this: BaseGenerator, from: string, to: string) {
+  const source = this.destinationPath(from);
+  const dest = this.destinationPath(to);
+  if (source && dest && shelljs.test('-f', source)) {
+    this.logger.info(`Renaming the file - ${source} to ${dest}`);
+    return !shelljs.exec(`git mv -f ${source} ${dest}`).code;
+  }
+  return true;
+}
+
+/**
+ * Upgrade files.
+ */
+export default function upgradeFilesTask(this: BaseGenerator) {
+  let atLeastOneSuccess = false;
+  if (this.isJhipsterVersionLessThan('6.1.0')) {
+    const languages = this.config.get('languages');
+    if (languages) {
+      const langNameDiffer = function (lang) {
+        const langProp = languageSnakeCase(lang);
+        const langJavaProp = languageToJavaLanguage(lang);
+        return langProp !== langJavaProp ? [langProp, langJavaProp] : undefined;
+      };
+      languages
+        .map(langNameDiffer)
+        .filter(props => props)
+        .forEach(props => {
+          const code = gitMove.call(
+            this,
+            `${SERVER_MAIN_RES_DIR}i18n/messages_${props[0]}.properties`,
+            `${SERVER_MAIN_RES_DIR}i18n/messages_${props[1]}.properties`
+          );
+          atLeastOneSuccess = atLeastOneSuccess || code;
+        });
+    }
+  }
+  return atLeastOneSuccess;
+}

--- a/generators/upgrade/generator.mjs
+++ b/generators/upgrade/generator.mjs
@@ -26,7 +26,7 @@ import path from 'path';
 import childProcess from 'child_process';
 
 import BaseGenerator from '../base/index.mjs';
-import { upgradeFiles } from '../cleanup.mjs';
+import { upgradeFilesTask as upgradeLanguagesFilesTask } from '../languages/index.mjs';
 import { SERVER_MAIN_RES_DIR } from '../generator-constants.mjs';
 import statistics from '../statistics.cjs';
 import { parseBluePrints } from '../../utils/blueprint.mjs';
@@ -162,7 +162,7 @@ export default class UpgradeGenerator extends BaseGenerator {
   }
 
   _upgradeFiles() {
-    if (upgradeFiles(this)) {
+    if (upgradeLanguagesFilesTask.call(this)) {
       const gitCommit = this.gitExec(['commit', '-q', '-m', '"Upgrade preparation."', '--no-verify'], { silent: this.silent });
       if (gitCommit.code !== 0) throw new Error(`Unable to prepare upgrade:\n${gitCommit.stderr}`);
       this.success('Upgrade preparation');


### PR DESCRIPTION
- move some methods to base/generator.mts (typescript).
- extract upgradeFilesTask.
- move `gitMove` implementation locally at upgradeFilesTask it's used only once for now. (shouldn't be exposed due to api contract).
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
