### PR TITLE
move entity to base-application

### DIFF
--- a/generators/base-application/generator-ts.mts
+++ b/generators/base-application/generator-ts.mts
@@ -1,0 +1,51 @@
+import _ from 'lodash';
+import type Storage from 'yeoman-generator/lib/util/storage.js';
+
+import BaseGenerator from '../base/index.mjs';
+import { JHIPSTER_CONFIG_DIR } from '../generator-constants.mjs';
+import { getEntitiesFromDir } from './support/index.mjs';
+
+const { upperFirst } = _;
+
+// Temporary Generator with Typescript implementations
+export default class BaseApplicationTsGenerator extends BaseGenerator {
+  /**
+   * Get all the generator configuration from the .yo-rc.json file
+   * @param entityName - Name of the entity to load.
+   * @param create - Create storage if doesn't exists.
+   */
+  getEntityConfig(entityName: string, create = false): Storage | undefined {
+    const entityPath = this.destinationPath(JHIPSTER_CONFIG_DIR, `${upperFirst(entityName)}.json`);
+    if (!create && !this.fs.exists(entityPath)) return undefined;
+    return this.createStorage(entityPath, { sorted: true } as any);
+  }
+
+  /**
+   * get sorted list of entitiy names according to changelog date (i.e. the order in which they were added)
+   */
+  getExistingEntityNames(): string[] {
+    return this.getExistingEntities().map(entity => entity.name);
+  }
+
+  /**
+   * get sorted list of entities according to changelog date (i.e. the order in which they were added)
+   */
+  getExistingEntities(): { name: string; definition: Record<string, any> }[] {
+    function isBefore(e1, e2) {
+      return e1.definition.changelogDate - e2.definition.changelogDate;
+    }
+
+    const configDir = this.destinationPath(JHIPSTER_CONFIG_DIR);
+
+    const entities: { name: string; definition: Record<string, any> }[] = [];
+    for (const entityName of [...new Set(((this.jhipsterConfig.entities as string[]) || []).concat(getEntitiesFromDir(configDir)))]) {
+      const definition = this.getEntityConfig(entityName)?.getAll();
+      if (definition) {
+        entities.push({ name: entityName, definition });
+      }
+    }
+    entities.sort(isBefore);
+    this.jhipsterConfig.entities = entities.map(({ name }) => name);
+    return entities;
+  }
+}

--- a/generators/base-application/generator.mjs
+++ b/generators/base-application/generator.mjs
@@ -18,7 +18,7 @@
  */
 import _ from 'lodash';
 
-import BaseGenerator from '../base/index.mjs';
+import BaseApplicationTsGenerator from './generator-ts.mjs';
 import { CUSTOM_PRIORITIES, PRIORITY_NAMES, QUEUES } from './priorities.mjs';
 import { JHIPSTER_CONFIG_DIR } from '../generator-constants.mjs';
 
@@ -52,16 +52,16 @@ const {
   POST_WRITING_ENTITIES_QUEUE,
 } = QUEUES;
 
-const asPriority = BaseGenerator.asPriority;
+const asPriority = BaseApplicationTsGenerator.asPriority;
 
 /**
  * This is the base class for a generator that generates entities.
  *
  * @class
  * @template ApplicationType
- * @extends {BaseGenerator}
+ * @extends {BaseApplicationTsGenerator}
  */
-export default class BaseApplicationGenerator extends BaseGenerator {
+export default class BaseApplicationGenerator extends BaseApplicationTsGenerator {
   static CONFIGURING_EACH_ENTITY = asPriority(CONFIGURING_EACH_ENTITY);
 
   static LOADING_ENTITIES = asPriority(LOADING_ENTITIES);

--- a/generators/base-application/support/entities.mts
+++ b/generators/base-application/support/entities.mts
@@ -16,7 +16,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { existsSync, mkdirSync, opendirSync } from 'fs';
+import { extname, basename } from 'path';
 
-export * from './enum.mjs';
-export * from './entities.mjs';
-export * from './field-utils.mjs';
+// eslint-disable-next-line import/prefer-default-export
+export function getEntitiesFromDir(configDir: string): string[] {
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir);
+  }
+  const dir = opendirSync(configDir);
+  const entityNames: string[] = [];
+  let dirent = dir.readSync();
+  while (dirent !== null) {
+    const extension = extname(dirent.name);
+    if (dirent.isFile() && extension === '.json') {
+      entityNames.push(basename(dirent.name, extension));
+    }
+    dirent = dir.readSync();
+  }
+  dir.closeSync();
+  return entityNames;
+}

--- a/generators/base/generator-base.mjs
+++ b/generators/base/generator-base.mjs
@@ -55,7 +55,6 @@ import {
 } from '../../jdl/jhipster/index.mjs';
 import { databaseData, getJdbcUrl, getR2dbcUrl, prepareSqlApplicationProperties } from '../sql/support/index.mjs';
 import {
-  JHIPSTER_CONFIG_DIR,
   SERVER_MAIN_SRC_DIR,
   SERVER_TEST_SRC_DIR,
   SERVER_MAIN_RES_DIR,
@@ -686,30 +685,6 @@ export default class JHipsterBaseGenerator extends PrivateBase {
    */
   getMicroserviceAppName(microserviceName) {
     return _.camelCase(microserviceName) + (microserviceName.endsWith('App') ? '' : 'App');
-  }
-
-  /**
-   * get sorted list of entitiy names according to changelog date (i.e. the order in which they were added)
-   */
-  getExistingEntityNames() {
-    return this.getExistingEntities().map(entity => entity.name);
-  }
-
-  /**
-   * @private
-   * Read entity json from config folder.
-   * @param {string} entityName - Entity name
-   * @return {object} entity definition
-   */
-  readEntityJson(entityName) {
-    const file = path.join(path.dirname(this.config.path), JHIPSTER_CONFIG_DIR, `${entityName}.json`);
-    try {
-      return this.fs.readJSON(file);
-    } catch (error) {
-      this.logger.warn(`Unable to parse ${file}, is the entity file malformed or invalid?`);
-      this.logger.debug('Error:', error);
-      return undefined;
-    }
   }
 
   /**

--- a/generators/base/generator.mts
+++ b/generators/base/generator.mts
@@ -16,8 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { existsSync, mkdirSync, opendirSync } from 'fs';
-import { basename, extname, join as joinPath, dirname } from 'path';
+import { basename, join as joinPath, dirname } from 'path';
 import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
@@ -44,7 +43,6 @@ import type {
   CheckResult,
 } from './api.mjs';
 import type { BaseTaskGroup } from './tasks.mjs';
-import { JHIPSTER_CONFIG_DIR } from '../generator-constants.mjs';
 import { packageJson } from '../../lib/index.mjs';
 import { type BaseApplication } from '../base-application/types.mjs';
 import { GENERATOR_BOOTSTRAP } from '../generator-list.mjs';
@@ -527,49 +525,6 @@ export default class BaseGenerator extends JHipsterBaseBlueprintGenerator {
       ...process.env,
       LANG: 'en',
     });
-  }
-
-  /**
-   * Get all the generator configuration from the .yo-rc.json file
-   * @param entityName - Name of the entity to load.
-   * @param {boolean} create - Create storage if doesn't exists.
-   */
-  getEntityConfig(entityName: string, create = false): Storage | undefined {
-    const entityPath = this.destinationPath(JHIPSTER_CONFIG_DIR, `${_.upperFirst(entityName)}.json`);
-    if (!create && !this.fs.exists(entityPath)) return undefined;
-    return this.createStorage(entityPath, { sorted: true } as any);
-  }
-
-  /**
-   * get sorted list of entities according to changelog date (i.e. the order in which they were added)
-   */
-  getExistingEntities() {
-    function isBefore(e1, e2) {
-      return e1.definition.changelogDate - e2.definition.changelogDate;
-    }
-
-    const configDir = this.destinationPath(JHIPSTER_CONFIG_DIR);
-    if (!existsSync(configDir)) {
-      mkdirSync(configDir);
-    }
-    const dir = opendirSync(configDir);
-    const entityNames: string[] = [];
-    let dirent = dir.readSync();
-    while (dirent !== null) {
-      const extension = extname(dirent.name);
-      if (dirent.isFile() && extension === '.json') {
-        entityNames.push(basename(dirent.name, extension));
-      }
-      dirent = dir.readSync();
-    }
-    dir.closeSync();
-
-    const entities = [...new Set(((this.jhipsterConfig.entities as string[]) || []).concat(entityNames))]
-      .map(entityName => ({ name: entityName, definition: this.getEntityConfig(entityName)?.getAll() }))
-      .filter(entity => entity && entity.definition)
-      .sort(isBefore);
-    this.jhipsterConfig.entities = entities.map(({ name }) => name);
-    return entities;
   }
 
   private createSharedData(jhipsterOldVersion: string | null): SharedData<BaseApplication> {

--- a/generators/bootstrap-application-base/utils.mjs
+++ b/generators/bootstrap-application-base/utils.mjs
@@ -28,7 +28,7 @@ const { STRING: TYPE_STRING } = CommonDBTypes;
 
 // eslint-disable-next-line import/prefer-default-export
 export function createUserEntity(customUserData = {}, application) {
-  const userEntityDefinition = this.readEntityJson('User');
+  const userEntityDefinition = this.getEntityConfig('User')?.getAll();
   if (userEntityDefinition) {
     if (userEntityDefinition.relationships && userEntityDefinition.relationships.length > 0) {
       this.logger.warn('Relationships on the User entity side will be disregarded');

--- a/generators/entities/generator.mjs
+++ b/generators/entities/generator.mjs
@@ -16,12 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import BaseGenerator from '../base/index.mjs';
+import BaseApplicationGenerator from '../base-application/index.mjs';
 import { JHIPSTER_CONFIG_DIR } from '../generator-constants.mjs';
 import { GENERATOR_ENTITIES, GENERATOR_APP } from '../generator-list.mjs';
 import { getDefaultAppName } from '../project-name/support/index.mjs';
 
-export default class EntitiesGenerator extends BaseGenerator {
+export default class EntitiesGenerator extends BaseApplicationGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'namespace', ...features });
 
@@ -124,7 +124,7 @@ export default class EntitiesGenerator extends BaseGenerator {
     };
   }
 
-  get [BaseGenerator.COMPOSING]() {
+  get [BaseApplicationGenerator.COMPOSING]() {
     return this.delegateTasksToBlueprint(() => this.composing);
   }
 }

--- a/generators/entity/generator.mjs
+++ b/generators/entity/generator.mjs
@@ -22,7 +22,7 @@ import fs from 'fs';
 import _ from 'lodash';
 import path from 'path';
 
-import BaseGenerator from '../base/index.mjs';
+import BaseApplicationGenerator from '../base-application/index.mjs';
 import prompts from './prompts.mjs';
 import { JHIPSTER_CONFIG_DIR, ANGULAR_DIR } from '../generator-constants.mjs';
 import { applicationTypes, clientFrameworkTypes, getConfigWithDefaults, reservedKeywords } from '../../jdl/jhipster/index.mjs';
@@ -34,7 +34,7 @@ const { GATEWAY, MICROSERVICE } = applicationTypes;
 const { NO: CLIENT_FRAMEWORK_NO, ANGULAR } = clientFrameworkTypes;
 const { isReservedClassName } = reservedKeywords;
 
-export default class EntityGenerator extends BaseGenerator {
+export default class EntityGenerator extends BaseApplicationGenerator {
   constructor(args, options, features) {
     super(args, options, { unique: 'argument', ...features });
 
@@ -263,7 +263,7 @@ export default class EntityGenerator extends BaseGenerator {
     };
   }
 
-  get [BaseGenerator.INITIALIZING]() {
+  get [BaseApplicationGenerator.INITIALIZING]() {
     return this.delegateTasksToBlueprint(() => this.initializing);
   }
 
@@ -284,7 +284,7 @@ export default class EntityGenerator extends BaseGenerator {
     };
   }
 
-  get [BaseGenerator.PROMPTING]() {
+  get [BaseApplicationGenerator.PROMPTING]() {
     return this.delegateTasksToBlueprint(() => this.prompting);
   }
 
@@ -305,7 +305,7 @@ export default class EntityGenerator extends BaseGenerator {
     };
   }
 
-  get [BaseGenerator.COMPOSING]() {
+  get [BaseApplicationGenerator.COMPOSING]() {
     return this.delegateTasksToBlueprint(() => this.composing);
   }
 
@@ -328,7 +328,7 @@ export default class EntityGenerator extends BaseGenerator {
     };
   }
 
-  get [BaseGenerator.WRITING]() {
+  get [BaseApplicationGenerator.WRITING]() {
     return this.delegateTasksToBlueprint(() => this.writing);
   }
 
@@ -341,7 +341,7 @@ export default class EntityGenerator extends BaseGenerator {
     };
   }
 
-  get [BaseGenerator.END]() {
+  get [BaseApplicationGenerator.END]() {
     return this.delegateTasksToBlueprint(() => this.end);
   }
 

--- a/generators/info/generator.mts
+++ b/generators/info/generator.mts
@@ -66,13 +66,6 @@ export default class InfoGenerator extends BaseApplicationGenerator<BaseApplicat
         console.log(`\n<details>\n<summary>.yo-rc.json file</summary>\n<pre>\n${result}\n</pre>\n</details>\n`);
       },
 
-      displayEntities() {
-        console.log('\n##### **JDL for the Entity configuration(s) `entityName.json` files generated in the `.jhipster` directory**\n');
-        const jdl = this.generateJDLFromEntities();
-        console.log('<details>\n<summary>JDL entity definitions</summary>\n');
-        console.log(`<pre>\n${jdl?.toString()}\n</pre>\n</details>\n`);
-      },
-
       async checkJava() {
         console.log('\n##### **Environment and Tools**\n');
         await this.checkCommand('java', ['-version'], ({ stderr }) => console.log(stderr));
@@ -95,6 +88,20 @@ export default class InfoGenerator extends BaseApplicationGenerator<BaseApplicat
 
       async checkDocker() {
         await this.checkCommand('docker', ['-v']);
+      },
+
+      checkApplication() {
+        if (this.jhipsterConfig.baseName === undefined) {
+          this.logger.warn("Current location doesn't contain a valid JHipster application");
+          this.cancelCancellableTasks();
+        }
+      },
+
+      displayEntities() {
+        console.log('\n##### **JDL for the Entity configuration(s) `entityName.json` files generated in the `.jhipster` directory**\n');
+        const jdl = this.generateJDLFromEntities();
+        console.log('<details>\n<summary>JDL entity definitions</summary>\n');
+        console.log(`<pre>\n${jdl?.toString()}\n</pre>\n</details>\n`);
       },
     });
   }

--- a/generators/info/generator.mts
+++ b/generators/info/generator.mts
@@ -22,14 +22,13 @@
 import chalk from 'chalk';
 import type { ExecaReturnValue } from 'execa';
 
-import BaseGenerator from '../base/index.mjs';
+import BaseApplicationGenerator from '../base-application/index.mjs';
 import JSONToJDLEntityConverter from '../../jdl/converters/json-to-jdl-entity-converter.js';
 import JSONToJDLOptionConverter from '../../jdl/converters/json-to-jdl-option-converter.js';
 import type { JHipsterGeneratorFeatures, JHipsterGeneratorOptions } from '../base/api.mjs';
-import { getEntitiesFromDir } from '../base-application/support/entities.mjs';
-import { JHIPSTER_CONFIG_DIR } from '../generator-constants.mjs';
+import { type BaseApplication } from '../base-application/types.mjs';
 
-export default class InfoGenerator extends BaseGenerator {
+export default class InfoGenerator extends BaseApplicationGenerator<BaseApplication> {
   constructor(args: string | string[], options: JHipsterGeneratorOptions, features: JHipsterGeneratorFeatures) {
     super(args, options, { unique: 'namespace', ...features });
 
@@ -45,7 +44,7 @@ export default class InfoGenerator extends BaseGenerator {
     this.env.options.skipInstall = true;
   }
 
-  get [BaseGenerator.INITIALIZING]() {
+  get [BaseApplicationGenerator.INITIALIZING]() {
     return this.asInitializingTaskGroup({
       sayHello() {
         this.logger.info(chalk.white('Welcome to the JHipster Information Sub-Generator\n'));
@@ -115,9 +114,8 @@ export default class InfoGenerator extends BaseGenerator {
     let jdlObject;
     const entities = new Map();
     try {
-      const entityNames = getEntitiesFromDir(this.destinationPath(JHIPSTER_CONFIG_DIR));
-      entityNames.forEach(entityName => {
-        entities.set(entityName, this.readDestinationJSON(`${JHIPSTER_CONFIG_DIR}/${entityName}.json`));
+      this.getExistingEntities().forEach(entity => {
+        entities.set(entity.name, entity.definition);
       });
       jdlObject = JSONToJDLEntityConverter.convertEntitiesToJDL({
         entities,

--- a/generators/info/generator.mts
+++ b/generators/info/generator.mts
@@ -26,6 +26,8 @@ import BaseGenerator from '../base/index.mjs';
 import JSONToJDLEntityConverter from '../../jdl/converters/json-to-jdl-entity-converter.js';
 import JSONToJDLOptionConverter from '../../jdl/converters/json-to-jdl-option-converter.js';
 import type { JHipsterGeneratorFeatures, JHipsterGeneratorOptions } from '../base/api.mjs';
+import { getEntitiesFromDir } from '../base-application/support/entities.mjs';
+import { JHIPSTER_CONFIG_DIR } from '../generator-constants.mjs';
 
 export default class InfoGenerator extends BaseGenerator {
   constructor(args: string | string[], options: JHipsterGeneratorOptions, features: JHipsterGeneratorFeatures) {
@@ -113,8 +115,9 @@ export default class InfoGenerator extends BaseGenerator {
     let jdlObject;
     const entities = new Map();
     try {
-      this.getExistingEntities().forEach(entity => {
-        entities.set(entity.name, entity.definition);
+      const entityNames = getEntitiesFromDir(this.destinationPath(JHIPSTER_CONFIG_DIR));
+      entityNames.forEach(entityName => {
+        entities.set(entityName, this.readDestinationJSON(`${JHIPSTER_CONFIG_DIR}/${entityName}.json`));
       });
       jdlObject = JSONToJDLEntityConverter.convertEntitiesToJDL({
         entities,

--- a/test/cli/environment-builder.spec.mts
+++ b/test/cli/environment-builder.spec.mts
@@ -303,12 +303,9 @@ describe('cli - EnvironmentBuilder', () => {
     after(() => {
       EnvironmentBuilder.prototype.getEnvironment.restore();
     });
-    it('calls getEnvironment', () => {
-      return helpers
-        .create('jhipster:info', { cwd: process.cwd(), autoCleanup: false }, { createEnv: EnvironmentBuilder.createEnv })
-        .run(() => {
-          expect(EnvironmentBuilder.prototype.getEnvironment.callCount).to.be.equal(1);
-        });
+    it('calls getEnvironment', async () => {
+      await helpers.run('jhipster:info', { cwd: process.cwd(), autoCleanup: false }, { createEnv: EnvironmentBuilder.createEnv });
+      expect(EnvironmentBuilder.prototype.getEnvironment.callCount).to.be.equal(1);
     });
   });
 });


### PR DESCRIPTION
Move entity operations from generators/base to generators/base-application.
Generate a temporary `generator-ts.mts` to keep ts implementation while `generator` is js.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
