### PR TITLE
Bump lint-staged from 13.1.0 to 13.1.1 in /generators/common/templates

### DIFF
--- a/generators/common/__snapshots__/generator.spec.mjs.snap
+++ b/generators/common/__snapshots__/generator.spec.mjs.snap
@@ -266,7 +266,7 @@ To configure CI for your project, run the ci-cd sub-generator (\`jhipster ci-cd\
   },
   "devDependencies": {
     "husky": "7.0.4",
-    "lint-staged": "13.1.0"
+    "lint-staged": "13.1.1"
   }
 }
 ",

--- a/generators/common/templates/package.json
+++ b/generators/common/templates/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "concurrently": "7.6.0",
     "husky": "7.0.4",
-    "lint-staged": "13.1.0",
+    "lint-staged": "13.1.1",
     "npm": "8.19.2",
     "wait-on": "7.0.1"
   }


### PR DESCRIPTION
Fix #21051 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
