### PR TITLE
add time to dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
     rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'
+      # Before cache workflow
+      time: '23:00'
     open-pull-requests-limit: 10
     labels:
       - 'theme: jhipster-internals'
@@ -35,6 +37,8 @@ updates:
     rebase-strategy: 'auto'
     schedule:
       interval: 'daily'
+      # Angular workflow is quite big. Give at least 2h interval.
+      time: '03:00'
     open-pull-requests-limit: 10
     versioning-strategy: increase
     labels:
@@ -51,6 +55,7 @@ updates:
     rebase-strategy: 'auto'
     schedule:
       interval: 'daily'
+      time: '00:00'
     open-pull-requests-limit: 10
     versioning-strategy: increase
     labels:
@@ -62,6 +67,7 @@ updates:
     rebase-strategy: 'auto'
     schedule:
       interval: 'daily'
+      time: '07:00'
     open-pull-requests-limit: 10
     versioning-strategy: increase
     labels:
@@ -74,6 +80,7 @@ updates:
     rebase-strategy: 'auto'
     schedule:
       interval: 'daily'
+      time: '01:00'
     open-pull-requests-limit: 10
     versioning-strategy: increase
     labels:
@@ -90,6 +97,7 @@ updates:
     rebase-strategy: 'auto'
     schedule:
       interval: 'daily'
+      time: '02:00'
     open-pull-requests-limit: 10
     versioning-strategy: increase
     labels:
@@ -111,6 +119,7 @@ updates:
     directory: '/generators/server/templates/'
     schedule:
       interval: 'daily'
+      time: '00:20'
     open-pull-requests-limit: 5
     labels:
       - 'theme: dependencies'
@@ -121,6 +130,8 @@ updates:
     directory: '/generators/server/templates/'
     schedule:
       interval: 'daily'
+      # Maven doesn't have many PRs, but it triggers every client workflow. Let 2h of interval.
+      time: '05:00'
     open-pull-requests-limit: 5
     labels:
       - 'theme: dependencies'
@@ -131,6 +142,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      time: '00:30'
     open-pull-requests-limit: 10
     labels:
       - 'theme: github_actions'


### PR DESCRIPTION
Dependabot is taking too long.
When a PR is merged, many times it causes a rebase due to conflicts on unrelated package.json.
Add time to schedule to make dependabot's PRs behave better
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
