### PR TITLE
Update Gradle Enterprise plugin version

### DIFF
--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -86,7 +86,7 @@ noHttpCheckstyleVersion=<%- javaDependencies['nohttp-checkstyle'] %>
 checkstyleVersion=<%- javaDependencies.checkstyle %>
 modernizerPluginVersion=1.6.2
 <%_ if (enableGradleEnterprise) { _%>
-gradleEnterprisePluginVersion=3.11.4
+gradleEnterprisePluginVersion=3.12.3
 gradleCommonCustomUserDataPluginVersion=1.8.2
 <%_ } _%>
 <%_ if (searchEngineElasticsearch) { _%>


### PR DESCRIPTION
Upgrade Gradle Enterprise plugin to 3.12.3

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X] Tests are added where necessary
- [X] The JDL part is updated if necessary
- [X] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
