### PR TITLE
React - Import bootstrap variable scss file

### DIFF
--- a/generators/react/templates/src/main/webapp/app/app.scss.ejs
+++ b/generators/react/templates/src/main/webapp/app/app.scss.ejs
@@ -16,7 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-// Override Boostrap variables
+// Override Bootstrap variables
+@import 'bootstrap-variables';
 <%_ if (!clientThemeNone) { _%>
 @import 'bootswatch/dist/<%= clientTheme %>/variables';
 <%_ } _%>


### PR DESCRIPTION
I had an issue with overriding bootstrap variables only with **react** client

In `bootstrap-variables.scss`

`$primary: red;`

To make it work, we need to add `@import 'bootstrap-variables’`; in `app.scss`


---

Please make sure the below checklist is followed for Pull Requests.

- [X ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ X] Tests are added where necessary
- [X ] The JDL part is updated if necessary
- [X ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [X ] Documentation is added/updated where necessary
- [X ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
