### PR TITLE
change base compare to use jit

### DIFF
--- a/.github/actions/compare-base/action.yml
+++ b/.github/actions/compare-base/action.yml
@@ -45,6 +45,7 @@ runs:
         git clone "${{ github.workspace }}/$JHI_CLI_PACKAGE" .
         git checkout @~1
         git log
+        npm ci --skip-scripts
         rm -f "$JHI_BIN_FOLDER/jhipster"
         npm uninstall -g $JHI_CLI_PACKAGE
         ln -s "${{ github.workspace }}/base/$JHI_CLI_PACKAGE/bin/jhipster.mjs" "$JHI_BIN_FOLDER/jhipster"

--- a/.github/actions/compare-base/action.yml
+++ b/.github/actions/compare-base/action.yml
@@ -45,7 +45,7 @@ runs:
         git clone "${{ github.workspace }}/$JHI_CLI_PACKAGE" .
         git checkout @~1
         git log
-        npm ci --skip-scripts
+        npm ci --ignore-scripts
         rm -f "$JHI_BIN_FOLDER/jhipster"
         npm uninstall -g $JHI_CLI_PACKAGE
         ln -s "${{ github.workspace }}/base/$JHI_CLI_PACKAGE/bin/jhipster.mjs" "$JHI_BIN_FOLDER/jhipster"

--- a/.github/actions/compare-base/action.yml
+++ b/.github/actions/compare-base/action.yml
@@ -47,8 +47,7 @@ runs:
         git log
         rm -f "$JHI_BIN_FOLDER/jhipster"
         npm uninstall -g $JHI_CLI_PACKAGE
-        npm install
-        npm install -g .
+        ln -s "${{ github.workspace }}/base/$JHI_CLI_PACKAGE/bin/jhipster.mjs" "$JHI_BIN_FOLDER/jhipster"
         jhipster --install-path
       shell: bash
     - name: 'MERGE: merge base config'


### PR DESCRIPTION
since https://github.com/jhipster/generator-jhipster/pull/21208 was merged, we can change the base compare to use jit.

- reduces base compare step by 3min
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
