### PR TITLE
don't try to execute locally installed jhipster

### DIFF
--- a/bin/jhipster.mjs
+++ b/bin/jhipster.mjs
@@ -6,4 +6,4 @@ import { join } from 'path';
 import { fileURLToPath } from 'url';
 import esbuildx from '@node-loaders/esbuildx';
 
-esbuildx(join(fileURLToPath(import.meta.url), '../../cli/cli.mjs'));
+esbuildx(join(fileURLToPath(import.meta.url), '../../cli/jhipster.mjs'));

--- a/cli/jhipster.mjs
+++ b/cli/jhipster.mjs
@@ -18,8 +18,9 @@
  * limitations under the License.
  */
 import semver from 'semver';
-import path, { dirname } from 'path';
+import { dirname, relative } from 'path';
 import { fileURLToPath } from 'url';
+import chalk from 'chalk';
 
 import { logger } from './utils.mjs';
 import { packageJson } from '../lib/index.mjs';
@@ -30,53 +31,15 @@ const __dirname = dirname(__filename);
 const currentNodeVersion = process.versions.node;
 const minimumNodeVersion = packageJson.engines.node;
 
-const BUNDLED_VERSION_MESSAGE = 'Using bundled JHipster';
-const LOCAL_VERSION_MESSAGE = "Switching to JHipster installed locally in current project's node repository (node_modules)";
-
 if (!semver.satisfies(currentNodeVersion, minimumNodeVersion)) {
   logger.fatal(
     `You are running Node version ${currentNodeVersion}\nJHipster requires Node version ${minimumNodeVersion}\nPlease update your version of Node.`
   );
 }
 
-const preferLocalArg = process.argv.includes('--prefer-local');
-const preferGlobalArg = process.argv.includes('--prefer-global') || process.argv.includes('--bundled');
-
-if (preferLocalArg && preferGlobalArg) {
-  throw new Error('--prefer-local and --prefer-bundled cannot be used together');
+if (relative(__dirname, process.cwd()).startsWith('..')) {
+  logger.warn(`Since generator-jhipster v8, jhipster command will not redirect to the locally installed generator-jhipster.
+    If you want to execute the locally installed generator-jhipster run: ${chalk.yellow('npx jhipster')}`);
 }
 
-// Don't use commander for parsing command line to avoid polluting it in cli.js
-// --prefer-local: Always resolve node modules locally (useful when using linked module)
-const preferLocal = preferLocalArg || (!preferGlobalArg && !process.argv.includes('upgrade'));
-
-await requireCLI(preferLocal);
-
-/*
- * Require cli.js giving priority to local version over bundled one if it exists.
- */
-async function requireCLI(preferLocal) {
-  let message = BUNDLED_VERSION_MESSAGE;
-  /* eslint-disable global-require */
-  if (preferLocal) {
-    try {
-      const localCLI = require.resolve(path.join(process.cwd(), 'node_modules', 'generator-jhipster', 'dist', 'cli', 'cli.mjs'));
-      if (__dirname === path.dirname(localCLI)) {
-        message = LOCAL_VERSION_MESSAGE;
-      } else {
-        // load local version
-        /* eslint-disable import/no-dynamic-require */
-        logger.info(LOCAL_VERSION_MESSAGE);
-        await import(localCLI);
-        // await import(pathToFileURL(localCLI).href);
-        return;
-      }
-    } catch (e) {
-      // Unable to find local version, so bundled one will be loaded anyway
-    }
-  }
-  // load current jhipster
-  logger.info(message);
-  await import('./cli.mjs');
-  /* eslint-enable  */
-}
+await import('./cli.mjs');

--- a/cli/jhipster.mjs
+++ b/cli/jhipster.mjs
@@ -39,7 +39,7 @@ if (!semver.satisfies(currentNodeVersion, minimumNodeVersion)) {
 
 if (relative(__dirname, process.cwd()).startsWith('..')) {
   logger.warn(`Since JHipster v8, the jhipster command will not use the locally installed generator-jhipster.
-    If you want to execute the locally installed generator-jhipster run: ${chalk.yellow('npx jhipster')}`);
+    If you want to execute the locally installed generator-jhipster, run: ${chalk.yellow('npx jhipster')}`);
 }
 
 await import('./cli.mjs');

--- a/cli/jhipster.mjs
+++ b/cli/jhipster.mjs
@@ -38,7 +38,7 @@ if (!semver.satisfies(currentNodeVersion, minimumNodeVersion)) {
 }
 
 if (relative(__dirname, process.cwd()).startsWith('..')) {
-  logger.warn(`Since generator-jhipster v8, jhipster command will not redirect to the locally installed generator-jhipster.
+  logger.warn(`Since JHipster v8, the jhipster command will not use the locally installed generator-jhipster.
     If you want to execute the locally installed generator-jhipster run: ${chalk.yellow('npx jhipster')}`);
 }
 

--- a/cli/program.mjs
+++ b/cli/program.mjs
@@ -131,9 +131,6 @@ export const createProgram = ({ executableName = CLI_NAME, executableVersion } =
       .option('--skip-regenerate', "Don't regenerate identical files", false)
       .option('--skip-yo-resolve', 'Ignore .yo-resolve files', false)
       .addJHipsterOptions(command.options)
-      .addOption(new Option('--bundled', 'Use JHipster generators bundled with current cli'))
-      .addOption(new Option('--prefer-global', 'Alias for --blundled').hideHelp())
-      .addOption(new Option('--prefer-local', 'Prefer JHipster generators installed in current folder node repository.').hideHelp())
   );
 };
 

--- a/generators/base/__snapshots__/generator.spec.mts.snap
+++ b/generators/base/__snapshots__/generator.spec.mts.snap
@@ -18,7 +18,6 @@ Options:
   --skip-checks                           Check the status of the required tools
   --experimental                          Enable experimental features. Please note that these features may be unstable and may undergo breaking changes at any time
   -d, --debug                             Enable debugger
-  --bundled                               Use JHipster generators bundled with current cli
   -h, --help                              display help for command
 
 Commands:


### PR DESCRIPTION
Switch to locally installed package is not a good practice and not adopted by any other package I known of.
JHipster v7 installed globally will fail to load a jhipster 8 installed locally due to the switch to esm.

Drop this behavior and add a warning about this behavior change.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
