### PR TITLE
(fix): Fix 'ERROR! Template file cli/commands.mjs was not found at..'

### DIFF
--- a/generators/generate-blueprint/files.mjs
+++ b/generators/generate-blueprint/files.mjs
@@ -37,7 +37,7 @@ export const files = {
     },
     {
       condition: ctx => ctx.commands.length > 0,
-      templates: ['cli/commands.mjs'],
+      templates: ['cli/commands.cjs'],
     },
   ],
 };


### PR DESCRIPTION
<!--
When generating a blueprint with CLI, the following error is observed:

```
✖ An error occured while running jhipster:generate-blueprint#writing
ERROR! ERROR! Template file cli/commands.mjs was not found at [path-to-jhipster]/generator-jhipster/dist/generators/generate-blueprint/templates
```
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
