### PR TITLE
Run tests in random rather than alphabetical order

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1391,8 +1391,9 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <!-- Force alphabetical order to have a reproducible build -->
-                        <runOrder>alphabetical</runOrder>
+                        <!-- Force random order. A fixed order hides potential problems with your tests -->
+			<!-- If you really need a specific order for some tests, use @TestMethodOrder -->
+                        <runOrder>random</runOrder>
                         <excludes>
                             <exclude>**/*IT*</exclude>
                             <exclude>**/*IntTest*</exclude>


### PR DESCRIPTION
Running tests in alphabetical order is a bad practice : it can hide unwanted dependencies between tests. Therefore I believe it is preferable to run them in random order so as that to spot problems as soon as possible. If some tests are flaky because of unwanted dependencies are incomplete cleanup, it's best to fix them rather than hide the problem and look away 🙈 
And if you really need a specific order for some tests, you can still use `@TestMethodOrder`.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
