### PR TITLE
Fix broken Hibernate mapping of Instants

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -251,6 +251,7 @@ spring:
     open-in-view: false
     properties:
       hibernate.jdbc.time_zone: UTC
+      hibernate.type.preferred_instant_jdbc_type: TIMESTAMP
       hibernate.id.new_generator_mappings: true
       hibernate.connection.provider_disables_autocommit: true
       hibernate.cache.use_second_level_cache: <% if (enableHibernateCache) { %>true<% } else { %>false<% } %>

--- a/generators/sql/templates/src/test/java/package/config/timezone/HibernateTimeZoneIT.java.ejs
+++ b/generators/sql/templates/src/test/java/package/config/timezone/HibernateTimeZoneIT.java.ejs
@@ -77,7 +77,6 @@ class HibernateTimeZoneIT {
             .ofPattern("yyyy-MM-dd");
     }
 
-    /* TODO: temp relief for integration tests, ***revisit required***
     @Test
     @Transactional
     void storeInstantWithZoneIdConfigShouldBeStoredOnGMTTimeZone() {
@@ -88,7 +87,7 @@ class HibernateTimeZoneIT {
         String expectedValue = dateTimeFormatter.format(dateTimeWrapper.getInstant());
 
         assertThatDateStoredValueIsEqualToInsertDateValueOnGMTTimeZone(resultSet, expectedValue);
-    } */
+    }
 
     @Test
     @Transactional

--- a/generators/sql/templates/src/test/resources/config/application-testdev.yml.ejs
+++ b/generators/sql/templates/src/test/resources/config/application-testdev.yml.ejs
@@ -81,6 +81,7 @@ spring:
       hibernate.cache.use_query_cache: false
       hibernate.generate_statistics: false
       hibernate.hbm2ddl.auto: none #TODO: temp relief for integration tests, revisit required
+      hibernate.type.preferred_instant_jdbc_type: TIMESTAMP
       hibernate.jdbc.time_zone: UTC
       hibernate.query.fail_on_pagination_over_collection_fetch: true
 <%_ } _%>

--- a/generators/sql/templates/src/test/resources/config/application-testprod.yml.ejs
+++ b/generators/sql/templates/src/test/resources/config/application-testprod.yml.ejs
@@ -64,5 +64,6 @@ spring:
       hibernate.cache.use_query_cache: false
       hibernate.generate_statistics: false
       hibernate.hbm2ddl.auto: none #TODO: temp relief for integration tests, revisit required
+      hibernate.type.preferred_instant_jdbc_type: TIMESTAMP
       hibernate.jdbc.time_zone: UTC
       hibernate.query.fail_on_pagination_over_collection_fetch: true


### PR DESCRIPTION
So it will be stored as UTC values inside the database, instead of Local timezone. 
This was a breaking change introduced Hibernate 6, this fix restores the previous behavior, and re-enables the test which could warn about in the future, if similar thing happens.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
