### PR TITLE
drop jhipster-dependencies dependency from liquibase plugin

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1848,13 +1848,6 @@
                                     <artifactId>jakarta.validation-api</artifactId>
                                     <version>${validation-api.version}</version>
                                 </dependency>
-  <%_ if (devDatabaseTypePostgres) { _%>
-                                <dependency>
-                                    <groupId>tech.jhipster</groupId>
-                                    <artifactId>jhipster-framework</artifactId>
-                                    <version>${jhipster-dependencies.version}</version>
-                                </dependency>
-  <%_ } _%>
   <%_ if (devDatabaseTypeH2Disk) { _%>
                                 <dependency>
                                     <groupId>com.h2database</groupId>
@@ -2033,13 +2026,6 @@
                                     <artifactId>jakarta.validation-api</artifactId>
                                     <version>${validation-api.version}</version>
                                 </dependency>
-  <%_ if (prodDatabaseTypePostgres) { _%>
-                                <dependency>
-                                    <groupId>tech.jhipster</groupId>
-                                    <artifactId>jhipster-framework</artifactId>
-                                    <version>${jhipster-dependencies.version}</version>
-                                </dependency>
-  <%_ } _%>
                             </dependencies>
                         </plugin>
 <%_ } _%>


### PR DESCRIPTION
probably required due to the dropped custom postgresql dialect
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
