### PR TITLE
cleanup one todo method

### DIFF
--- a/generators/base/generator-base-todo.mjs
+++ b/generators/base/generator-base-todo.mjs
@@ -103,17 +103,6 @@ const isWin32 = os.platform() === 'win32';
 export default class JHipsterBaseGenerator extends PrivateBase {
   /**
    * @private
-   * Add external resources to root file(index.html).
-   *
-   * @param {string} resources - Resources added to root file.
-   * @param {string} comment - comment to add before resources content.
-   */
-  addExternalResourcesToRoot(resources, comment) {
-    this.needleApi.client.addExternalResourcesToRoot(resources, comment);
-  }
-
-  /**
-   * @private
    * Add a new element in the "global.json" translations.
    *
    * @param {string} key - Key for the menu entry

--- a/generators/client/generator.mjs
+++ b/generators/client/generator.mjs
@@ -30,6 +30,7 @@ import statistics from '../statistics.mjs';
 import { GENERATOR_BOOTSTRAP_APPLICATION, GENERATOR_CYPRESS, GENERATOR_COMMON, GENERATOR_CLIENT } from '../generator-list.mjs';
 
 import { testFrameworkTypes, clientFrameworkTypes } from '../../jdl/jhipster/index.mjs';
+import { createNeedleCallback } from '../base/support/index.mjs';
 
 const { ANGULAR, VUE, REACT } = clientFrameworkTypes;
 const { CYPRESS } = testFrameworkTypes;
@@ -148,9 +149,14 @@ export default class JHipsterClientGenerator extends BaseApplicationGenerator {
       },
 
       addExternalResource({ application, source }) {
-        source.addExternalResourceToRoot = (resources, comment) => {
-          this.needleApi.client.addExternalResourcesToApplicationRoot(application, resources, comment);
-        };
+        source.addExternalResourceToRoot = ({ resource, comment }) =>
+          this.editFile(
+            `${application.clientSrcDir}index.html`,
+            createNeedleCallback({
+              needle: 'add-resources-to-root',
+              contentToAdd: [comment ? `<!-- ${comment} -->` : undefined, resource].filter(i => i).join('\n'),
+            })
+          );
       },
     });
   }

--- a/generators/client/generator.mjs
+++ b/generators/client/generator.mjs
@@ -148,13 +148,6 @@ export default class JHipsterClientGenerator extends BaseApplicationGenerator {
       },
 
       addExternalResource({ application, source }) {
-        /**
-         * @private
-         * Add external resources to root file(index.html).
-         *
-         * @param {string} resources - Resources added to root file.
-         * @param {string} comment - comment to add before resources content.
-         */
         source.addExternalResourceToRoot = (resources, comment) => {
           this.needleApi.client.addExternalResourcesToApplicationRoot(application, resources, comment);
         };

--- a/generators/client/generator.mjs
+++ b/generators/client/generator.mjs
@@ -146,6 +146,19 @@ export default class JHipsterClientGenerator extends BaseApplicationGenerator {
       prepareForTemplates({ application }) {
         application.webappLoginRegExp = LOGIN_REGEX_JS;
       },
+
+      addExternalResource({ application, source }) {
+        /**
+         * @private
+         * Add external resources to root file(index.html).
+         *
+         * @param {string} resources - Resources added to root file.
+         * @param {string} comment - comment to add before resources content.
+         */
+        source.addExternalResourceToRoot = (resources, comment) => {
+          this.needleApi.client.addExternalResourcesToApplicationRoot(application, resources, comment);
+        };
+      },
     });
   }
 

--- a/generators/client/needle-api/needle-client.mts
+++ b/generators/client/needle-api/needle-client.mts
@@ -58,4 +58,22 @@ export default class extends needleBase {
       errorMessage
     );
   }
+
+  addExternalResourcesToApplicationRoot(application: any, resources: string, comment: string) {
+    const errorMessage = 'Resources are not added to JHipster app.';
+    const file = `${application.clientSrcDir}index.html`;
+    let resourcesBlock = '';
+    if (comment) {
+      resourcesBlock += `<!-- ${comment} -->\n`;
+    }
+    resourcesBlock += `${resources}\n`;
+    this.addBlockContentToFile(
+      {
+        file,
+        needle: 'jhipster-needle-add-resources-to-root',
+        splicable: resourcesBlock,
+      },
+      errorMessage
+    );
+  }
 }

--- a/generators/client/needle-api/needle-client.mts
+++ b/generators/client/needle-api/needle-client.mts
@@ -40,40 +40,4 @@ export default class extends needleBase {
 
     return styleBlock;
   }
-
-  addExternalResourcesToRoot(resources: string, comment: string) {
-    const errorMessage = 'Resources are not added to JHipster app.';
-    const file = `${this.clientSrcDir}index.html`;
-    let resourcesBlock = '';
-    if (comment) {
-      resourcesBlock += `<!-- ${comment} -->\n`;
-    }
-    resourcesBlock += `${resources}\n`;
-    this.addBlockContentToFile(
-      {
-        file,
-        needle: 'jhipster-needle-add-resources-to-root',
-        splicable: resourcesBlock,
-      },
-      errorMessage
-    );
-  }
-
-  addExternalResourcesToApplicationRoot(application: any, resources: string, comment: string) {
-    const errorMessage = 'Resources are not added to JHipster app.';
-    const file = `${application.clientSrcDir}index.html`;
-    let resourcesBlock = '';
-    if (comment) {
-      resourcesBlock += `<!-- ${comment} -->\n`;
-    }
-    resourcesBlock += `${resources}\n`;
-    this.addBlockContentToFile(
-      {
-        file,
-        needle: 'jhipster-needle-add-resources-to-root',
-        splicable: resourcesBlock,
-      },
-      errorMessage
-    );
-  }
 }

--- a/generators/client/needle-client.spec.mts
+++ b/generators/client/needle-client.spec.mts
@@ -1,7 +1,6 @@
-import { dryRunHelpers as helpers, result as runResult } from '../support/index.mjs';
 import ClientGenerator from '../../generators/client/index.mjs';
-import { CLIENT_MAIN_SRC_DIR } from '../../generators/generator-constants.mjs';
-import { getGenerator } from '../support/index.mjs';
+import { CLIENT_MAIN_SRC_DIR } from '../generator-constants.mjs';
+import { dryRunHelpers as helpers, result as runResult, getGenerator } from '../../test/support/index.mjs';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockBlueprintSubGen: any = class extends ClientGenerator {
@@ -21,7 +20,10 @@ const mockBlueprintSubGen: any = class extends ClientGenerator {
     return this.asPostWritingTaskGroup({
       // @ts-ignore
       async additionalResource({ source }) {
-        source.addExternalResourceToRoot('<link rel="stylesheet" href="content/css/my.css">', 'Comment added by JHipster API');
+        source.addExternalResourceToRoot({
+          resource: '<link rel="stylesheet" href="content/css/my.css">',
+          comment: 'Comment added by JHipster API',
+        });
       },
     });
   }

--- a/generators/client/types.d.mts
+++ b/generators/client/types.d.mts
@@ -17,3 +17,21 @@ export type ClientApplication = CommonClientServerApplication &
     webappLoginRegExp: string;
     webappEnumerationsDir?: string;
   };
+
+/**
+ * @private
+ * Add external resources to root file(index.html).
+ */
+export type ClientResources = {
+  /**
+   * @param {string} resource - Resources added to root file.
+   */
+  resource: string;
+  /**
+   * @param {string} comment - comment to add before resources content.
+   */
+  comment?: string | null;
+};
+export type ClientSourceType = {
+  addExternalResourceToRoot?(resources: ClientResources): void;
+};

--- a/generators/client/types.d.mts
+++ b/generators/client/types.d.mts
@@ -18,20 +18,19 @@ export type ClientApplication = CommonClientServerApplication &
     webappEnumerationsDir?: string;
   };
 
-/**
- * @private
- * Add external resources to root file(index.html).
- */
 export type ClientResources = {
   /**
-   * @param {string} resource - Resources added to root file.
+   * resources added to root file.
    */
   resource: string;
   /**
-   * @param {string} comment - comment to add before resources content.
+   * comment to add before resources content.
    */
-  comment?: string | null;
+  comment?: string;
 };
 export type ClientSourceType = {
+  /**
+   * Add external resources to root file(index.html).
+   */
   addExternalResourceToRoot?(resources: ClientResources): void;
 };

--- a/test/needle-api/needle-client.spec.mts
+++ b/test/needle-api/needle-client.spec.mts
@@ -18,12 +18,12 @@ const mockBlueprintSubGen: any = class extends ClientGenerator {
   }
 
   get [ClientGenerator.POST_WRITING]() {
-    const customPhaseSteps = {
-      addExternalResourcesToRootStep() {
-        this.addExternalResourcesToRoot('<link rel="stylesheet" href="content/css/my.css">', 'Comment added by JHipster API');
+    return this.asPostWritingTaskGroup({
+      // @ts-ignore
+      async additionalResource({ source }) {
+        source.addExternalResourceToRoot('<link rel="stylesheet" href="content/css/my.css">', 'Comment added by JHipster API');
       },
-    };
-    return { ...customPhaseSteps };
+    });
   }
 };
 


### PR DESCRIPTION
Remove one generator-base-todo method.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
