### PR TITLE
change version to 7.10.0

### DIFF
--- a/.github/workflows/generator-generate-blueprint.yml
+++ b/.github/workflows/generator-generate-blueprint.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir generator-jhipster-foo
           cd generator-jhipster-foo
           cp $JHI_INTEG/generate-blueprint-samples/default/.yo-rc.json .
-          jhipster generate-blueprint --force --link-jhipster-dependency --generate-snapshots
+          jhipster generate-blueprint --force --link-jhipster-dependency --generate-snapshots --skip-install
           npm link generator-jhipster
           npm link
       - name: 'GENERATION: config'

--- a/generators/app/__snapshots__/generator.spec.mts.snap
+++ b/generators/app/__snapshots__/generator.spec.mts.snap
@@ -381,7 +381,7 @@ exports[`generator - app with default config should match snapshot 1`] = `
   "jhiTablePrefix": "jhi",
   "jhipsterDependenciesVersion": "JHIPSTER_DEPENDENCIES_VERSION",
   "jhipsterPackageJson": Any<Object>,
-  "jhipsterVersion": "7.9.3",
+  "jhipsterVersion": Any<String>,
   "jwtSecretKey": "SECRET--64",
   "languages": [
     "en",
@@ -919,7 +919,7 @@ exports[`generator - app with gateway should match snapshot 1`] = `
   "jhiTablePrefix": "jhi",
   "jhipsterDependenciesVersion": "JHIPSTER_DEPENDENCIES_VERSION",
   "jhipsterPackageJson": Any<Object>,
-  "jhipsterVersion": "7.9.3",
+  "jhipsterVersion": Any<String>,
   "jwtSecretKey": Any<String>,
   "languages": [
     "en",
@@ -1456,7 +1456,7 @@ exports[`generator - app with microservice should match snapshot 1`] = `
   "jhiTablePrefix": "jhi",
   "jhipsterDependenciesVersion": "JHIPSTER_DEPENDENCIES_VERSION",
   "jhipsterPackageJson": Any<Object>,
-  "jhipsterVersion": "7.9.3",
+  "jhipsterVersion": Any<String>,
   "jwtSecretKey": Any<String>,
   "languages": [
     "en",

--- a/generators/app/generator.spec.mts
+++ b/generators/app/generator.spec.mts
@@ -58,6 +58,7 @@ describe(`generator - ${generator}`, () => {
         expect(runResult.generator.sharedData.getApplication()).toMatchSnapshot({
           user: expect.any(Object),
           jhipsterPackageJson: expect.any(Object),
+          jhipsterVersion: expect.any(String),
         });
       });
     });
@@ -78,6 +79,7 @@ describe(`generator - ${generator}`, () => {
           user: expect.any(Object),
           jhipsterPackageJson: expect.any(Object),
           jwtSecretKey: expect.any(String),
+          jhipsterVersion: expect.any(String),
         });
       });
     });
@@ -97,6 +99,7 @@ describe(`generator - ${generator}`, () => {
         expect(runResult.generator.sharedData.getApplication()).toMatchSnapshot({
           jhipsterPackageJson: expect.any(Object),
           jwtSecretKey: expect.any(String),
+          jhipsterVersion: expect.any(String),
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-jhipster",
-  "version": "7.9.3",
+  "version": "7.10.0",
   "description": "Spring Boot + Angular/React/Vue in one handy generator",
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
Version 7.10.0 won't happen.

This will allow to update [jhipster samples](https://github.com/jhipster/jdl-samples) with new jdl specifications at v7.10.0 branch.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
