### PR TITLE
add overrides at workspaces if angular is used

### DIFF
--- a/generators/workspaces/generator.mjs
+++ b/generators/workspaces/generator.mjs
@@ -24,7 +24,8 @@ import { GENERATOR_ANGULAR, GENERATOR_APP, GENERATOR_COMMON, GENERATOR_GIT } fro
 
 import { GENERATOR_JHIPSTER } from '../generator-constants.mjs';
 import BaseGenerator from '../base/index.mjs';
-import { deploymentOptions } from '../../jdl/jhipster/index.mjs';
+import { deploymentOptions, getConfigWithDefaults } from '../../jdl/jhipster/index.mjs';
+import { removeFieldsWithNullishValues } from '../base/support/config.mjs';
 
 const {
   DeploymentTypes: { DOCKERCOMPOSE },
@@ -190,6 +191,7 @@ export default class WorkspacesGenerator extends BaseGenerator {
 
         const {
           dependencies: { rxjs },
+          devDependencies: { webpack: webpackVersion },
         } = this.fs.readJSON(this.fetchFromInstalledJHipster(GENERATOR_ANGULAR, 'templates', 'package.json'));
 
         const {
@@ -201,7 +203,6 @@ export default class WorkspacesGenerator extends BaseGenerator {
             packages: this.packages,
           },
           devDependencies: {
-            rxjs, // Set version to workaround https://github.com/npm/cli/issues/4437
             concurrently,
           },
           scripts: {
@@ -212,6 +213,18 @@ export default class WorkspacesGenerator extends BaseGenerator {
             ...this._createWorkspacesScript('ci:backend:test', 'ci:frontend:test', 'webapp:test'),
           },
         });
+
+        const applications = this.loadApplications();
+        if (applications.some(app => app.clientFrameworkAngular)) {
+          this.packageJson.merge({
+            devDependencies: {
+              rxjs, // Set version to workaround https://github.com/npm/cli/issues/4437
+            },
+            overrides: {
+              webpack: webpackVersion,
+            },
+          });
+        }
       },
     };
   }
@@ -264,5 +277,27 @@ export default class WorkspacesGenerator extends BaseGenerator {
 
   _createWorkspacesScript(...scripts) {
     return Object.fromEntries(scripts.map(script => [`${script}`, `npm run ${script} --workspaces --if-present`]));
+  }
+
+  loadApplications() {
+    return this.workspacesConfig.packages
+      .map(appPath => {
+        const appConfig = this.readDestinationJSON(`${appPath}/.yo-rc.json`)[GENERATOR_JHIPSTER];
+        if (!appConfig) return undefined;
+
+        const app = getConfigWithDefaults(removeFieldsWithNullishValues(appConfig));
+
+        this.loadAppConfig(app, app);
+        this.loadServerConfig(app, app);
+        this.loadClientConfig(app, app);
+        this.loadPlatformConfig(app, app);
+
+        this.loadDerivedAppConfig(app);
+        this.loadDerivedClientConfig(app);
+        this.loadDerivedServerConfig(app);
+        this.loadDerivedPlatformConfig(app);
+        return app;
+      })
+      .filter(app => app);
   }
 }


### PR DESCRIPTION
angular-cli uses a fixed webpack version, but not locked as a peer dependency.
It's not possible to detect the used webpack version to match at others dependencies and avoid conflicts.
We set our own webpack version and override the one angular uses.

At monorepository this overrides is not applied, we need set the overrides at the root package.json too.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
