### PR TITLE
Drop vue2-filters

### DIFF
--- a/generators/vue/__snapshots__/generator.spec.mts.snap
+++ b/generators/vue/__snapshots__/generator.spec.mts.snap
@@ -200,6 +200,12 @@ exports[`generator - vue gateway-jwt-skipUserManagement(true)-withAdminUi(false)
   "src/app/shared/alert/alert.service.ts": {
     "stateCleared": "modified",
   },
+  "src/app/shared/computables/arrays.ts": {
+    "stateCleared": "modified",
+  },
+  "src/app/shared/computables/index.ts": {
+    "stateCleared": "modified",
+  },
   "src/app/shared/config/axios-interceptor.ts": {
     "stateCleared": "modified",
   },
@@ -691,6 +697,12 @@ exports[`generator - vue gateway-oauth2-withAdminUi(true)-skipJhipsterDependenci
   "src/app/shared/alert/alert.service.ts": {
     "stateCleared": "modified",
   },
+  "src/app/shared/computables/arrays.ts": {
+    "stateCleared": "modified",
+  },
+  "src/app/shared/computables/index.ts": {
+    "stateCleared": "modified",
+  },
   "src/app/shared/config/axios-interceptor.ts": {
     "stateCleared": "modified",
   },
@@ -1161,6 +1173,12 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "src/app/shared/alert/alert.service.ts": {
     "stateCleared": "modified",
   },
+  "src/app/shared/computables/arrays.ts": {
+    "stateCleared": "modified",
+  },
+  "src/app/shared/computables/index.ts": {
+    "stateCleared": "modified",
+  },
   "src/app/shared/config/axios-interceptor.ts": {
     "stateCleared": "modified",
   },
@@ -1608,6 +1626,12 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
     "stateCleared": "modified",
   },
   "src/main/webapp2/app/shared/alert/alert.service.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp2/app/shared/computables/arrays.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp2/app/shared/computables/index.ts": {
     "stateCleared": "modified",
   },
   "src/main/webapp2/app/shared/config/axios-interceptor.ts": {
@@ -2185,6 +2209,12 @@ exports[`generator - vue monolith-jwt-skipUserManagement(false)-withAdminUi(true
   "src/main/webapp2/app/shared/alert/alert.service.ts": {
     "stateCleared": "modified",
   },
+  "src/main/webapp2/app/shared/computables/arrays.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp2/app/shared/computables/index.ts": {
+    "stateCleared": "modified",
+  },
   "src/main/webapp2/app/shared/config/axios-interceptor.ts": {
     "stateCleared": "modified",
   },
@@ -2670,6 +2700,12 @@ exports[`generator - vue monolith-oauth2-withAdminUi(false)-skipJhipsterDependen
   "src/main/webapp/app/shared/alert/alert.service.ts": {
     "stateCleared": "modified",
   },
+  "src/main/webapp/app/shared/computables/arrays.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/app/shared/computables/index.ts": {
+    "stateCleared": "modified",
+  },
   "src/main/webapp/app/shared/config/axios-interceptor.ts": {
     "stateCleared": "modified",
   },
@@ -3102,6 +3138,12 @@ exports[`generator - vue monolith-session-skipUserManagement(true)-withAdminUi(f
     "stateCleared": "modified",
   },
   "src/main/webapp/app/shared/alert/alert.service.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/app/shared/computables/arrays.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/app/shared/computables/index.ts": {
     "stateCleared": "modified",
   },
   "src/main/webapp/app/shared/config/axios-interceptor.ts": {

--- a/generators/vue/files-vue.mjs
+++ b/generators/vue/files-vue.mjs
@@ -112,6 +112,8 @@ export const vueFiles = {
         'core/ribbon/ribbon.vue',
         'core/ribbon/ribbon.component.ts',
         'shared/date/filters.ts',
+        'shared/computables/arrays.ts',
+        'shared/computables/index.ts',
         'shared/sort/jhi-sort-indicator.component.ts',
         'shared/sort/jhi-sort-indicator.vue',
         'shared/sort/sorts.ts',

--- a/generators/vue/templates/package.json
+++ b/generators/vue/templates/package.json
@@ -8,15 +8,12 @@
     "bootstrap-vue": "2.23.1",
     "bootswatch": "5.2.3",
     "vue": "2.7.14",
-    "vue-class-component": "7.2.6",
     "vue-cookie": "1.1.4",
     "vue-infinite-loading": "2.4.5",
     "vue-router": "3.6.5",
     "vue-i18n": "8.28.2",
-    "vue-property-decorator": "9.1.2",
     "vuelidate": "0.7.7",
-    "vuex": "3.6.2",
-    "vue2-filters": "0.14.0"
+    "vuex": "3.6.2"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "1.2.0",

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -46,7 +46,6 @@
     "vue-i18n": "<%= nodeDependencies['vue-i18n'] %>",
     "vue-infinite-loading": "<%= nodeDependencies['vue-infinite-loading'] %>",
     "vue-router": "<%= nodeDependencies['vue-router'] %>",
-    "vue2-filters": "<%= nodeDependencies['vue2-filters'] %>",
     "vuelidate": "<%= nodeDependencies['vuelidate'] %>",
     "vuex": "<%= nodeDependencies['vuex'] %>"
   },

--- a/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
@@ -1,4 +1,6 @@
-import { defineComponent, inject, ref, Ref } from 'vue';
+import { computed, defineComponent, inject, ref, Ref } from 'vue';
+
+import { orderAndFilterBy } from '@/shared/computables';
 import ConfigurationService from './configuration.service';
 
 export default defineComponent({
@@ -13,6 +15,14 @@ export default defineComponent({
     const configKeys: Ref<any[]> = ref([]);
     const filtered = ref('');
 
+    const filteredConfiguration = computed(() =>
+      orderAndFilterBy(configuration.value, {
+        filterByTerm: filtered.value,
+        orderByProp: orderProp.value,
+        reverse: reverse.value,
+      })
+    );
+
     return {
       configurationService,
       orderProp,
@@ -21,6 +31,7 @@ export default defineComponent({
       configuration,
       configKeys,
       filtered,
+      filteredConfiguration,
     };
   },
   mounted() {

--- a/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
@@ -1,10 +1,8 @@
 import { defineComponent, inject, ref, Ref } from 'vue';
-import Vue2Filters from 'vue2-filters';
 import ConfigurationService from './configuration.service';
 
 export default defineComponent({
   name: '<%=jhiPrefixCapitalized%>Configuration',
-  mixins: [Vue2Filters.mixin],
   setup() {
     const configurationService = inject('configurationService', () => new ConfigurationService(), true);
 

--- a/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.vue.ejs
@@ -3,22 +3,21 @@
     <h2 id="configuration-page-heading" v-text="$t('configuration.title')" data-cy="configurationPageHeading">Configuration</h2>
 
     <div v-if="allConfiguration && configuration">
-      <span v-text="$t('configuration.filter')">Filter (by prefix)</span> <input type="text" v-model="filtered"
-        class="form-control" />
+      <span v-text="$t('configuration.filter')">Filter (by prefix)</span> <input type="text" v-model="filtered" class="form-control" />
       <h3>Spring configuration</h3>
       <table class="table table-striped table-bordered table-responsive d-table" aria-describedby="Configuration">
         <thead>
           <tr>
-            <th class="w-40" v-on:click="changeOrder('prefix')" scope="col"><span
-                v-text="$t('configuration.table.prefix')">Prefix</span></th>
+            <th class="w-40" v-on:click="changeOrder('prefix')" scope="col">
+              <span v-text="$t('configuration.table.prefix')">Prefix</span>
+            </th>
             <th class="w-60" v-on:click="changeOrder('properties')" scope="col">
               <span v-text="$t('configuration.table.properties')">Properties</span>
             </th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="entry in orderBy(filterBy(configuration, filtered), orderProp, reverse ? 1 : -1)"
-            :key="entry.prefix">
+          <tr v-for="entry in filteredConfiguration" :key="entry.prefix">
             <td>
               <span>{{ entry.prefix }}</span>
             </td>

--- a/generators/vue/templates/src/main/webapp/app/admin/logs/logs.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/logs/logs.component.ts.ejs
@@ -1,10 +1,8 @@
 import { defineComponent, inject, ref, Ref } from 'vue';
-import Vue2Filters from 'vue2-filters';
 import LogsService from './logs.service';
 
 export default defineComponent({
   name: '<%=jhiPrefixCapitalized%>Logs',
-  mixins: [Vue2Filters.mixin],
   setup() {
     const logsService = inject('logsService', () => new LogsService(), true);
 

--- a/generators/vue/templates/src/main/webapp/app/admin/logs/logs.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/logs/logs.component.ts.ejs
@@ -1,4 +1,6 @@
-import { defineComponent, inject, ref, Ref } from 'vue';
+import { computed, defineComponent, inject, ref, Ref } from 'vue';
+
+import { orderAndFilterBy } from '@/shared/computables';
 import LogsService from './logs.service';
 
 export default defineComponent({
@@ -10,6 +12,13 @@ export default defineComponent({
     const filtered = ref('');
     const orderProp = ref('name');
     const reverse = ref(false);
+    const filteredLoggers = computed(() =>
+      orderAndFilterBy(loggers.value, {
+        filterByTerm: filtered.value,
+        orderByProp: orderProp.value,
+        reverse: reverse.value,
+      })
+    );
 
     return {
       logsService,
@@ -17,6 +26,7 @@ export default defineComponent({
       filtered,
       orderProp,
       reverse,
+      filteredLoggers,
     };
   },
   mounted() {

--- a/generators/vue/templates/src/main/webapp/app/admin/logs/logs.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/logs/logs.vue.ejs
@@ -15,34 +15,51 @@
           </tr>
         </thead>
 
-        <tr v-for="logger in orderBy(filterBy(loggers, filtered), orderProp, reverse === true ? 1 : -1)"
-          :key="logger.name">
+        <tr v-for="logger in filteredLoggers" :key="logger.name">
           <td>
             <small>{{ logger.name }}</small>
           </td>
           <td>
-            <button v-on:click="updateLevel(logger.name, 'TRACE')"
-              :class="logger.level === 'TRACE' ? 'btn-primary' : 'btn-light'" class="btn btn-sm">
+            <button
+              v-on:click="updateLevel(logger.name, 'TRACE')"
+              :class="logger.level === 'TRACE' ? 'btn-primary' : 'btn-light'"
+              class="btn btn-sm"
+            >
               TRACE
             </button>
-            <button v-on:click="updateLevel(logger.name, 'DEBUG')"
-              :class="logger.level === 'DEBUG' ? 'btn-success' : 'btn-light'" class="btn btn-sm">
+            <button
+              v-on:click="updateLevel(logger.name, 'DEBUG')"
+              :class="logger.level === 'DEBUG' ? 'btn-success' : 'btn-light'"
+              class="btn btn-sm"
+            >
               DEBUG
             </button>
-            <button v-on:click="updateLevel(logger.name, 'INFO')"
-              :class="logger.level === 'INFO' ? 'btn-info' : 'btn-light'" class="btn btn-sm">
+            <button
+              v-on:click="updateLevel(logger.name, 'INFO')"
+              :class="logger.level === 'INFO' ? 'btn-info' : 'btn-light'"
+              class="btn btn-sm"
+            >
               INFO
             </button>
-            <button v-on:click="updateLevel(logger.name, 'WARN')"
-              :class="logger.level === 'WARN' ? 'btn-warning' : 'btn-light'" class="btn btn-sm">
+            <button
+              v-on:click="updateLevel(logger.name, 'WARN')"
+              :class="logger.level === 'WARN' ? 'btn-warning' : 'btn-light'"
+              class="btn btn-sm"
+            >
               WARN
             </button>
-            <button v-on:click="updateLevel(logger.name, 'ERROR')"
-              :class="logger.level === 'ERROR' ? 'btn-danger' : 'btn-light'" class="btn btn-sm">
+            <button
+              v-on:click="updateLevel(logger.name, 'ERROR')"
+              :class="logger.level === 'ERROR' ? 'btn-danger' : 'btn-light'"
+              class="btn btn-sm"
+            >
               ERROR
             </button>
-            <button v-on:click="updateLevel(logger.name, 'OFF')"
-              :class="logger.level === 'OFF' ? 'btn-secondary' : 'btn-light'" class="btn btn-sm">
+            <button
+              v-on:click="updateLevel(logger.name, 'OFF')"
+              :class="logger.level === 'OFF' ? 'btn-secondary' : 'btn-light'"
+              class="btn btn-sm"
+            >
               OFF
             </button>
           </td>

--- a/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics-modal.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics-modal.component.ts.ejs
@@ -1,5 +1,4 @@
 import { defineComponent, ref, Ref, computed, PropType } from 'vue';
-import Vue2Filters from 'vue2-filters';
 
 export default defineComponent({
   name: '<%=jhiPrefixCapitalized%>MetricsModal',
@@ -8,7 +7,6 @@ export default defineComponent({
       type: Array as PropType<any[]>,
     },
   },
-  mixins: [Vue2Filters.mixin],
   setup(props) {
     const threadDumpFilter: Ref<any> = ref(null);
 

--- a/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics-modal.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics-modal.component.ts.ejs
@@ -1,5 +1,7 @@
 import { defineComponent, ref, Ref, computed, PropType } from 'vue';
 
+import { filterBy } from '@/shared/computables';
+
 export default defineComponent({
   name: '<%=jhiPrefixCapitalized%>MetricsModal',
   props: {
@@ -8,7 +10,8 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const threadDumpFilter: Ref<any> = ref(null);
+    const threadDumpFilter: Ref<any> = ref('');
+    const filteredThreadDump = computed(() => filterBy(props.threadDump, { filterByTerm: threadDumpFilter.value }));
 
     const threadDumpData = computed(() => {
       const data = {
@@ -38,6 +41,7 @@ export default defineComponent({
     return {
       threadDumpFilter,
       threadDumpData,
+      filteredThreadDump,
     };
   },
   methods: {

--- a/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics-modal.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics-modal.vue.ejs
@@ -1,23 +1,27 @@
 <template>
   <div class="modal-body">
-    <span class="badge badge-primary" v-on:click="threadDumpFilter = ''">All&nbsp;<span
-        class="badge badge-pill badge-default">{{ threadDumpData.threadDumpAll }}</span></span>&nbsp;
-    <span class="badge badge-success" v-on:click="threadDumpFilter = 'RUNNABLE'">Runnable&nbsp;<span
-        class="badge badge-pill badge-default">{{ threadDumpData.threadDumpRunnable }}</span></span>&nbsp;
-    <span class="badge badge-info" v-on:click="threadDumpFilter = 'WAITING'">Waiting&nbsp;<span
-        class="badge badge-pill badge-default">{{ threadDumpData.threadDumpWaiting }}</span></span>&nbsp;
-    <span class="badge badge-warning" v-on:click="threadDumpFilter = 'TIMED_WAITING'">Timed Waiting&nbsp;<span
-        class="badge badge-pill badge-default">{{ threadDumpData.threadDumpTimedWaiting }}</span></span>&nbsp;
-    <span class="badge badge-danger" v-on:click="threadDumpFilter = 'BLOCKED'">Blocked&nbsp;<span
-        class="badge badge-pill badge-default">{{ threadDumpData.threadDumpBlocked }}</span></span>&nbsp;
+    <span class="badge badge-primary" v-on:click="threadDumpFilter = ''"
+      >All&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpData.threadDumpAll }}</span></span
+    >&nbsp;
+    <span class="badge badge-success" v-on:click="threadDumpFilter = 'RUNNABLE'"
+      >Runnable&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpData.threadDumpRunnable }}</span></span
+    >&nbsp;
+    <span class="badge badge-info" v-on:click="threadDumpFilter = 'WAITING'"
+      >Waiting&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpData.threadDumpWaiting }}</span></span
+    >&nbsp;
+    <span class="badge badge-warning" v-on:click="threadDumpFilter = 'TIMED_WAITING'"
+      >Timed Waiting&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpData.threadDumpTimedWaiting }}</span></span
+    >&nbsp;
+    <span class="badge badge-danger" v-on:click="threadDumpFilter = 'BLOCKED'"
+      >Blocked&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpData.threadDumpBlocked }}</span></span
+    >&nbsp;
     <div class="mt-2">&nbsp;</div>
     Filter
     <input type="text" v-model="threadDumpFilter" class="form-control" />
-    <div class="pad" v-for="(entry, key) of filterBy(threadDump, threadDumpFilter)" :key="key">
+    <div class="pad" v-for="(entry, key) of filteredThreadDump" :key="key">
       <h6>
-        <span class="badge"
-          :class="getBadgeClass(entry.threadState)">{{ entry.threadState }}</span>&nbsp;{{ entry.threadName }} (ID
-        {{ entry.threadId }})
+        <span class="badge" :class="getBadgeClass(entry.threadState)">{{ entry.threadState }}</span
+        >&nbsp;{{ entry.threadName }} (ID {{ entry.threadId }})
         <a v-on:click="entry.show = !entry.show" href="javascript:void(0);">
           <span :hidden="entry.show" v-text="$t('metrics.jvm.threads.dump.show')">Show StackTrace</span>
           <span :hidden="!entry.show" v-text="$t('metrics.jvm.threads.dump.hide')">Hide StackTrace</span>
@@ -26,7 +30,10 @@
       <div class="card" :hidden="!entry.show">
         <div class="card-body">
           <div v-for="(st, key) of entry.stackTrace" :key="key" class="break">
-            <samp>{{ st.className }}.{{ st.methodName }}(<code>{{ st.fileName }}:{{ st.lineNumber }}</code>)</samp>
+            <samp
+              >{{ st.className }}.{{ st.methodName }}(<code>{{ st.fileName }}:{{ st.lineNumber }}</code
+              >)</samp
+            >
             <span class="mt-1"></span>
           </div>
         </div>

--- a/generators/vue/templates/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -1,4 +1,3 @@
-import Vue2Filters from 'vue2-filters';
 import UserManagementService from './user-management.service';
 import AlertService from '@/shared/alert/alert.service';
 import { computed, defineComponent, inject, Ref, ref } from 'vue';
@@ -6,7 +5,6 @@ import { useStore } from '@/store';
 
 export default defineComponent({
   name: '<%=jhiPrefixCapitalized%>UserManagementComponent',
-  mixins: [Vue2Filters.mixin],
   mounted(): void {
     this.loadAll();
   },

--- a/generators/vue/templates/src/main/webapp/app/entities/_entityFolder/_entityFile.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/entities/_entityFolder/_entityFile.component.ts.ejs
@@ -1,5 +1,4 @@
 import { defineComponent, inject, ref, Ref } from 'vue';
-import Vue2Filters from 'vue2-filters';
 import { I<%= entityAngularName %> } from '@/shared/model/<%= entityModelFileName %>.model';
 <%_ if (anyFieldIsBlobDerived || paginationInfiniteScroll) { _%>
 import useDataUtils from '@/shared/data/data-utils.service';
@@ -9,7 +8,6 @@ import AlertService from '@/shared/alert/alert.service';
 
 export default defineComponent({
   name: '<%= entityAngularName %>',
-  mixins: [Vue2Filters.mixin],
   setup() {
 <%_ if (anyFieldIsBlobDerived || paginationInfiniteScroll) { _%>
     const dataUtils = useDataUtils();

--- a/generators/vue/templates/src/main/webapp/app/shared/computables/arrays.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/computables/arrays.ts.ejs
@@ -1,0 +1,78 @@
+<%#
+ Copyright 2013-2023 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+const compareString = (a: string, b: string): number => {
+  if (b == null) return 1;
+  if (a == null) return -1;
+
+  return a.localeCompare(b);
+};
+
+const asString = (val): string => {
+  return typeof val === 'string' ? val : '' + val;
+};
+
+const compareAny = (a, b): number => {
+  if (b == null) return 1;
+  if (a == null) return -1;
+
+  return a - b;
+};
+
+export type OrderByOptions = { orderByProp: string; reverse?: boolean };
+
+export const orderBy = (array: any[], opts: OrderByOptions) => {
+  if (!Array.isArray(array)) return array;
+
+  const { orderByProp, reverse = false } = opts;
+  let sorted: any[];
+  if (array.some(el => typeof el[orderByProp] === 'string')) {
+    sorted = array.sort((a, b) => compareString(asString(a), asString(b)));
+  } else {
+    sorted = array.sort((a, b) => compareAny(a, b));
+  }
+  if (reverse) {
+    sorted.reverse();
+  }
+  return sorted;
+};
+
+export type FilterByOptions = { filterByTerm: string; filterMaxDepth?: number };
+
+const filterObject = (val: any, opts: FilterByOptions): boolean => {
+  const { filterByTerm, filterMaxDepth = 2 } = opts;
+  if (typeof val === 'string') {
+    return val.toLocaleLowerCase().startsWith(filterByTerm);
+  }
+  if (typeof val === 'object') {
+    if (filterMaxDepth < 0) return false;
+    for (const value of Object.values(val)) {
+      if (filterObject(value, { filterByTerm, filterMaxDepth: filterMaxDepth - 1 })) return true;
+    }
+    return false;
+  }
+  return ('' + val).toLocaleLowerCase().startsWith(filterByTerm);
+};
+
+export const filterBy = (array: any, opts: FilterByOptions) => {
+  return Array.isArray(array) && opts.filterByTerm
+    ? array.filter(el => filterObject(el, { ...opts, filterByTerm: opts.filterByTerm.toLocaleLowerCase() }))
+    : array;
+};
+
+export const orderAndFilterBy = (array: any, opts: FilterByOptions & OrderByOptions) => orderBy(filterBy(array, opts), opts);

--- a/generators/vue/templates/src/main/webapp/app/shared/computables/index.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/computables/index.ts.ejs
@@ -1,0 +1,19 @@
+<%#
+ Copyright 2013-2023 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+export * from './arrays';

--- a/generators/vue/templates/src/main/webapp/app/shared/config/config.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/config/config.ts.ejs
@@ -45,7 +45,6 @@ import { faWrench } from '@fortawesome/free-solid-svg-icons/faWrench';
 
 import VueCookie from 'vue-cookie';
 import Vuelidate from 'vuelidate';
-import Vue2Filters from 'vue2-filters';
 
 import * as filters from '@/shared/date/filters';
 
@@ -58,7 +57,6 @@ const dateTimeFormats: DateTimeFormats = {
 export function initVueApp(vue) {
   vue.use(VueCookie);
   vue.use(Vuelidate);
-  vue.use(Vue2Filters);
   filters.initFilters();
 }
 

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/metrics/metrics-modal.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/metrics/metrics-modal.component.spec.ts.ejs
@@ -26,13 +26,7 @@ describe('Metrics Component', () => {
       i18n,
 <%_ } _%>
       localVue,
-    });
-    metricsModal = wrapper.vm;
-  });
-
-  describe('init', () => {
-    it('should count the numbers of each thread type', async () => {
-      await wrapper.setProps({
+      propsData: {
         threadDump: [
           { name: 'test1', threadState: 'RUNNABLE' },
           { name: 'test2', threadState: 'WAITING' },
@@ -41,8 +35,13 @@ describe('Metrics Component', () => {
           { name: 'test5', threadState: 'BLOCKED' },
           { name: 'test5', threadState: 'NONE' },
         ],
-      });
+      },
+    });
+    metricsModal = wrapper.vm;
+  });
 
+  describe('init', () => {
+    it('should count the numbers of each thread type', async () => {
       expect(metricsModal.threadDumpData.threadDumpRunnable).toBe(1);
       expect(metricsModal.threadDumpData.threadDumpWaiting).toBe(1);
       expect(metricsModal.threadDumpData.threadDumpTimedWaiting).toBe(1);

--- a/generators/vue/templates/webpack/webpack.microfrontend.js.jhi.vue.ejs
+++ b/generators/vue/templates/webpack/webpack.microfrontend.js.jhi.vue.ejs
@@ -43,7 +43,6 @@ const { DefinePlugin } = require('webpack');
           vuelidate: { singleton: true, shareScope: 'default' },
           'vue-i18n': { singleton: true, shareScope: 'default' },
           'vue-router': { singleton: true, shareScope: 'default' },
-          'vue2-filters': { singleton: true, shareScope: 'default' },
           vuex: { singleton: true, shareScope: 'default' },
           '@/shared/security/authority': {
             singleton: true,


### PR DESCRIPTION
Vue 3 dropped filters support.

- removes class-component and property-decorators from dependabot package.json.
- Implement orderBy and filterBy replacement

Related to https://github.com/jhipster/generator-jhipster/issues/12558.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
