### PR TITLE
chore: fix spelling mistake in ColumnConverter_reactive.java.ejs

### DIFF
--- a/generators/sql/templates/src/main/java/package/repository/rowmapper/ColumnConverter_reactive.java.ejs
+++ b/generators/sql/templates/src/main/java/package/repository/rowmapper/ColumnConverter_reactive.java.ejs
@@ -69,7 +69,7 @@ public class ColumnConverter implements ColumnConverterReactive {
     }
 
     /**
-     * Convert a value from the {@link Row} to a type - throws an exception, it it's impossible.
+     * Convert a value from the {@link Row} to a type - throws an exception, if it's impossible.
      * @param row which contains the column values.
      * @param target class.
      * @param columnName the name of the column which to convert.


### PR DESCRIPTION
# Summary

Fixes a spelling/grammar mistake in `ColumnConverter_reactive.java.ejs` where `it it's` should be `if it's`. See https://github.com/jhipster/generator-jhipster/issues/21969 for more detail.

# Related Issues/PR(s)

- fixes #21969 

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
