### PR TITLE
Switch from vuex to pinia.

### DIFF
--- a/generators/languages/languages.spec.mjs
+++ b/generators/languages/languages.spec.mjs
@@ -87,7 +87,7 @@ const noLanguageFiles = languageValue => {
 const containsLanguageInVueStore = languageValue => {
   it(`add language ${languageValue} into translation-store.ts, webpack.common.js`, () => {
     const langKey = languageValue.includes('-') ? `'${languageValue}'` : `${languageValue}`;
-    runResult.assertFileContent(`${CLIENT_MAIN_SRC_DIR}app/shared/config/store/translation-store.ts`, `${langKey}: { name:`);
+    runResult.assertFileContent(`${CLIENT_MAIN_SRC_DIR}app/shared/config/languages.ts`, `${langKey}: { name:`);
     runResult.assertFileContent(
       `${CLIENT_WEBPACK_DIR}webpack.common.js`,
       `{ pattern: './src/main/webapp/i18n/${languageValue}/*.json', fileName: './i18n/${languageValue}.json' }`

--- a/generators/vue/__snapshots__/generator.spec.mts.snap
+++ b/generators/vue/__snapshots__/generator.spec.mts.snap
@@ -727,6 +727,9 @@ exports[`generator - vue gateway-oauth2-withAdminUi(true)-skipJhipsterDependenci
   "src/app/shared/config/dayjs.ts": {
     "stateCleared": "modified",
   },
+  "src/app/shared/config/languages.ts": {
+    "stateCleared": "modified",
+  },
   "src/app/shared/config/store/account-store.ts": {
     "stateCleared": "modified",
   },
@@ -1664,6 +1667,9 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "src/main/webapp2/app/shared/config/dayjs.ts": {
     "stateCleared": "modified",
   },
+  "src/main/webapp2/app/shared/config/languages.ts": {
+    "stateCleared": "modified",
+  },
   "src/main/webapp2/app/shared/config/store/account-store.ts": {
     "stateCleared": "modified",
   },
@@ -2243,6 +2249,9 @@ exports[`generator - vue monolith-jwt-skipUserManagement(false)-withAdminUi(true
     "stateCleared": "modified",
   },
   "src/main/webapp2/app/shared/config/dayjs.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp2/app/shared/config/languages.ts": {
     "stateCleared": "modified",
   },
   "src/main/webapp2/app/shared/config/store/account-store.ts": {

--- a/generators/vue/files-vue.mjs
+++ b/generators/vue/files-vue.mjs
@@ -94,7 +94,7 @@ export const vueFiles = {
     {
       condition: generator => generator.enableTranslation,
       ...clientApplicationBlock,
-      templates: ['locale/translation.service.ts', 'shared/config/store/translation-store.ts'],
+      templates: ['locale/translation.service.ts', 'shared/config/store/translation-store.ts', 'shared/config/languages.ts'],
     },
   ],
   sharedVueApp: [

--- a/generators/vue/support/update-languages.mts
+++ b/generators/vue/support/update-languages.mts
@@ -45,12 +45,12 @@ function generateDateTimeFormat(language: string, index: number, length: number)
 function updateLanguagesInPipeTask(this: BaseGenerator, { application, control = {} }: UpdateClientLanguagesTaskParam) {
   const { clientSrcDir, languagesDefinition = [] } = application;
   const { ignoreNeedlesError: ignoreNonExisting } = control;
-  const newContent = `languages: {
-        ${generateLanguagesWebappOptions(languagesDefinition).join(',\n        ')}
-        // jhipster-needle-i18n-language-key-pipe - JHipster will add/remove languages in this object
+  const newContent = `$1{
+  ${generateLanguagesWebappOptions(languagesDefinition).join(',\n  ')},
+  // jhipster-needle-i18n-language-key-pipe - JHipster will add/remove languages in this object
     }`;
-  this.editFile(`${clientSrcDir}app/shared/config/store/translation-store.ts`, { ignoreNonExisting }, content =>
-    content.replace(/languages:.*\{([^\]]*jhipster-needle-i18n-language-key-pipe[^}]*)}/g, newContent)
+  this.editFile(`${clientSrcDir}app/shared/config/languages.ts`, { ignoreNonExisting }, content =>
+    content.replace(/(languages =.*)\{([^\]]*jhipster-needle-i18n-language-key-pipe[^}]*)}/g, newContent)
   );
 }
 

--- a/generators/vue/templates/package.json
+++ b/generators/vue/templates/package.json
@@ -11,6 +11,7 @@
     "bootstrap-vue": "2.23.1",
     "bootswatch": "5.2.3",
     "js-cookie": "3.0.5",
+    "pinia": "2.0.35",
     "vue": "2.7.14",
     "vue-router": "3.6.5",
     "vue-i18n": "8.28.2",
@@ -18,6 +19,7 @@
     "vuex": "3.6.2"
   },
   "devDependencies": {
+    "@pinia/testing": "0.0.16",
     "@rushstack/eslint-patch": "1.2.0",
     "@types/jest": "29.5.1",
     "@types/node": "16.18.25",

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -54,7 +54,7 @@
     "vue-router": "<%= nodeDependencies['vue-router'] %>"
   },
   "devDependencies": {
-    "@pinia/testing": "<%= nodeDependencies['@pinia/testingh'] %>",
+    "@pinia/testing": "<%= nodeDependencies['@pinia/testing'] %>",
     "@rushstack/eslint-patch": "<%= nodeDependencies['@rushstack/eslint-patch'] %>",
     "@types/jest": "<%= nodeDependencies['@types/jest'] %>",
     "@types/node": "<%= nodeDependencies['@types/node'] %>",

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -45,15 +45,16 @@
     "sockjs-client": "1.5.2",
     "rxjs": "7.4.0",
 <%_ } _%>
+    "pinia": "<%= nodeDependencies.pinia %>",
     "vue": "<%= nodeDependencies['vue'] %>",
 <%_ if (enableTranslation) { _%>
     "vue-i18n": "<%= nodeDependencies['vue-i18n'] %>",
     "vue-i18n-bridge": "<%= nodeDependencies['vue-i18n-bridge'] %>",
 <%_ } _%>
-    "vue-router": "<%= nodeDependencies['vue-router'] %>",
-    "vuex": "<%= nodeDependencies['vuex'] %>"
+    "vue-router": "<%= nodeDependencies['vue-router'] %>"
   },
   "devDependencies": {
+    "@pinia/testing": "<%= nodeDependencies['@pinia/testingh'] %>",
     "@rushstack/eslint-patch": "<%= nodeDependencies['@rushstack/eslint-patch'] %>",
     "@types/jest": "<%= nodeDependencies['@types/jest'] %>",
     "@types/node": "<%= nodeDependencies['@types/node'] %>",

--- a/generators/vue/templates/src/main/webapp/app/account/account.service.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/account.service.ts.ejs
@@ -1,17 +1,8 @@
 import axios from 'axios';
 import { Store } from 'vuex';
-<%_ if (enableTranslation) { _%>
-import TranslationService from '@/locale/translation.service';
-<%_ } _%>
 
 export default class AccountService {
-  constructor(
-    private store: Store<any>,
-<%_ if (enableTranslation) { _%>
-    private translationService: TranslationService,
-<%_ } _%>
-  ) {
-  }
+  constructor(private store: Store<any>) {}
 
   public async update(): Promise<void> {
     if (!this.store.getters.profilesLoaded) {
@@ -40,12 +31,6 @@ export default class AccountService {
       if (response.status === 200 && response.data) {
         const account = response.data;
         this.store.commit('authenticated', account);
-<%_ if (enableTranslation) { _%>
-        if (this.store.getters.currentLanguage !== account.langKey) {
-          this.store.commit('currentLanguage', account.langKey);
-          this.translationService.refreshTranslation(this.store.getters.currentLanguage);
-        }
-<%_ } _%>
         return true;
       }
     } catch (error) {}

--- a/generators/vue/templates/src/main/webapp/app/account/account.service.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/account.service.ts.ejs
@@ -1,13 +1,14 @@
 import axios from 'axios';
-import { Store } from 'vuex';
+
+import { AccountStore } from '@/store';
 
 export default class AccountService {
-  constructor(private store: Store<any>) {}
+  constructor(private store: AccountStore) {}
 
   public async update(): Promise<void> {
-    if (!this.store.getters.profilesLoaded) {
+    if (!this.store.profilesLoaded) {
       await this.retrieveProfiles();
-      this.store.commit('profilesLoaded');
+      this.store.setProfilesLoaded();
     }
     await this.loadAccount();
   }
@@ -16,8 +17,8 @@ export default class AccountService {
     try {
       const res = await axios.get<any>('management/info');
       if (res.data && res.data.activeProfiles) {
-        this.store.commit('setRibbonOnProfiles', res.data['display-ribbon-on-profiles']);
-        this.store.commit('setActiveProfiles', res.data['activeProfiles']);
+        this.store.setRibbonOnProfiles(res.data['display-ribbon-on-profiles']);
+        this.store.setActiveProfiles(res.data['activeProfiles']);
       }
       return true;
     } catch (error) {
@@ -30,18 +31,18 @@ export default class AccountService {
       const response = await axios.get<any>('api/account');
       if (response.status === 200 && response.data) {
         const account = response.data;
-        this.store.commit('authenticated', account);
+        this.store.setAuthentication(account);
         return true;
       }
     } catch (error) {}
 
-    this.store.commit('logout');
+    this.store.logout();
     return false;
   }
 
   public async loadAccount() {
-    if (this.store.getters.logon) {
-      return this.store.getters.logon;
+    if (this.store.logon) {
+      return this.store.logon;
     }
 <%_ if (authenticationTypeJwt) { _%>
     const token = localStorage.getItem('<%=jhiPrefixDashed %>-authenticationToken') || sessionStorage.getItem('<%=jhiPrefixDashed %>-authenticationToken');
@@ -53,8 +54,8 @@ export default class AccountService {
     }
 
     const promise = this.retrieveAccount();
-    this.store.commit('authenticate', promise);
-    promise.then(() => this.store.commit('authenticate', null));
+    this.store.authenticate(promise);
+    promise.then(() => this.store.authenticate(null));
     await promise;
   }
 
@@ -67,11 +68,11 @@ export default class AccountService {
   }
 
   public get authenticated(): boolean {
-    return this.store.getters.authenticated;
+    return this.store.authenticated;
   }
 
   public get userAuthorities(): string[] {
-    return this.store.getters.account?.authorities;
+    return this.store.account?.authorities;
   }
 
   private checkAuthorities(authorities: string[]): boolean {

--- a/generators/vue/templates/src/main/webapp/app/account/change-password/change-password.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/change-password/change-password.component.ts.ejs
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref, Ref } from 'vue';
+import { ComputedRef, defineComponent, inject, ref, Ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
@@ -6,8 +6,6 @@ import { useVuelidate } from '@vuelidate/core'
 import { maxLength, minLength, required, sameAs } from '@vuelidate/validators';
 import axios from 'axios';
 import { mapGetters } from 'vuex';
-
-import { useStore } from '@/store';
 
 export default defineComponent({
   validations() {
@@ -28,8 +26,8 @@ export default defineComponent({
     };
   },
   computed: mapGetters(['account']),
-  setup(prop) {
-    const username = computed(() => useStore().getters.account?.login ?? '');
+  setup() {
+    const username = inject<ComputedRef<string>>('currentUsername');
     const success: Ref<string> = ref(null);
     const error: Ref<string> = ref(null);
     const doNotMatch: Ref<string> = ref(null);

--- a/generators/vue/templates/src/main/webapp/app/account/change-password/change-password.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/change-password/change-password.component.ts.ejs
@@ -5,7 +5,6 @@ import { useI18n } from 'vue-i18n-bridge';
 import { useVuelidate } from '@vuelidate/core'
 import { maxLength, minLength, required, sameAs } from '@vuelidate/validators';
 import axios from 'axios';
-import { mapGetters } from 'vuex';
 
 export default defineComponent({
   validations() {
@@ -25,7 +24,6 @@ export default defineComponent({
       },
     };
   },
-  computed: mapGetters(['account']),
   setup() {
     const username = inject<ComputedRef<string>>('currentUsername');
     const success: Ref<string> = ref(null);

--- a/generators/vue/templates/src/main/webapp/app/account/change-password/change-password.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/change-password/change-password.vue.ejs
@@ -2,7 +2,7 @@
     <div>
         <div class="row justify-content-center">
             <div class="col-md-8 toastify-container">
-                <h2 v-if="account" id="password-title">
+                <h2 v-if="username" id="password-title">
                     <span v-html="t$('password.title', { username: username })">
                       Password for [<strong>{{ username }}</strong>]</span>
                 </h2>

--- a/generators/vue/templates/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -1,4 +1,4 @@
-import { defineComponent, inject, ref, Ref } from 'vue';
+import { computed, defineComponent, inject, ref, Ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
@@ -44,6 +44,7 @@ export default defineComponent({
   setup(prop) {
     const loginService = inject<LoginService>('loginService');
     const registerService = inject('registerService', () => new RegisterService(), true);
+    const currentLanguage = inject('currentLanguage', () => computed(() => navigator.language ?? '<%- nativeLanguage %>'), true);
 
     const error: Ref<string> = ref('');
     const errorEmailExists: Ref<string> = ref('');
@@ -63,6 +64,7 @@ export default defineComponent({
 
     return {
       openLogin,
+      currentLanguage,
       registerService,
       error,
       errorEmailExists,
@@ -81,11 +83,7 @@ export default defineComponent({
       this.error = null;
       this.errorUserExists = null;
       this.errorEmailExists = null;
-<%_ if (enableTranslation) { _%>
-      this.registerAccount.langKey = this.$store.getters.currentLanguage;
-<%_ } else { _%>
-      this.registerAccount.langKey = 'en';
-<%_ } _%>
+      this.registerAccount.langKey = this.currentLanguage;
       this.registerService
         .processRegistration(this.registerAccount)
         .then(() => {

--- a/generators/vue/templates/src/main/webapp/app/account/sessions/sessions.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/sessions/sessions.component.ts.ejs
@@ -15,8 +15,8 @@ export default defineComponent({
     const error: Ref<string> = ref(null);
     const sessions: Ref<any[]> = ref([]);
 
-    const authenticated = computed(() => store.getters.authenticated);
-    const username = computed(() => store.getters.account?.login ?? '');
+    const authenticated = computed(() => store.authenticated);
+    const username = computed(() => store.account?.login ?? '');
 
     return {
       success,

--- a/generators/vue/templates/src/main/webapp/app/account/settings/settings.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/settings/settings.component.ts.ejs
@@ -1,6 +1,7 @@
-import { computed, defineComponent, ref, Ref } from 'vue';
+import { computed, ComputedRef, defineComponent, inject, ref, Ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
+import languages from '@/shared/config/languages';
 <%_ } _%>
 import { useVuelidate } from '@vuelidate/core'
 import { email, maxLength, minLength, required } from '@vuelidate/validators';
@@ -32,26 +33,25 @@ const validations = {
 export default defineComponent({
   name: 'Settings',
   validations,
-  setup(prop) {
+  setup() {
     const store = useStore();
 
     const success: Ref<string> = ref(null);
     const error: Ref<string> = ref(null);
     const errorEmailExists: Ref<string> = ref(null);
-    const languages: Ref<string[]> = ref(store.getters.languages || []);
 
     const settingsAccount = computed(() => store.getters.account);
-    const username = computed(() => store.getters.account?.login ?? '');
+    const username = inject<ComputedRef<string>>('currentUsername', () => computed(() => store.getters.account?.login), true);
 
     return {
       success,
       error,
       errorEmailExists,
-      languages,
       settingsAccount,
       username,
       v$: useVuelidate(),
 <%_ if (enableTranslation) { _%>
+      languages: languages(),
       t$: useI18n().t,
 <%_ } _%>
     };

--- a/generators/vue/templates/src/main/webapp/app/account/settings/settings.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/settings/settings.component.ts.ejs
@@ -40,8 +40,8 @@ export default defineComponent({
     const error: Ref<string> = ref(null);
     const errorEmailExists: Ref<string> = ref(null);
 
-    const settingsAccount = computed(() => store.getters.account);
-    const username = inject<ComputedRef<string>>('currentUsername', () => computed(() => store.getters.account?.login), true);
+    const settingsAccount = computed(() => store.account);
+    const username = inject<ComputedRef<string>>('currentUsername', () => computed(() => store.account?.login), true);
 
     return {
       success,

--- a/generators/vue/templates/src/main/webapp/app/account/settings/settings.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/settings/settings.vue.ejs
@@ -89,6 +89,7 @@
               </small>
             </div>
           </div>
+<%_ if (enableTranslation) { _%>
           <div class="form-group" v-if="languages && Object.keys(languages).length > 1">
             <label for="langKey" v-text="t$('settings.form.language')">Language</label>
             <select class="form-control" id="langKey" name="langKey" v-model="settingsAccount.langKey" data-cy="langKey">
@@ -96,6 +97,7 @@
               </option>
             </select>
           </div>
+<%_ } _%>
           <button type="submit" :disabled="v$.settingsAccount.$invalid" class="btn btn-primary"
             v-text="t$('settings.form.button')" data-cy="submit">
             Save

--- a/generators/vue/templates/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
@@ -1,4 +1,4 @@
-import <% if (authenticationUsesCsrf) { %>Vue, <% } %>{ defineComponent, inject, ref, Ref, onMounted, onUnmounted } from 'vue';
+import { defineComponent, inject, ref, Ref, onMounted, onUnmounted } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 
 import { useDateFormat } from '@/shared/composables'
 import TrackerService from './tracker.service';
+import { useRoute } from 'vue-router/composables';
 
 export default defineComponent({
   name: '<%=jhiPrefixCapitalized%>TrackerComponent',
@@ -13,7 +14,8 @@ export default defineComponent({
     const { formatDateShort: formatDate } = useDateFormat();
     const trackerService = inject<TrackerService>('trackerService');
     const activities: Ref<any[]> = ref([]);
-    const subscription: Ref<Subscription> = ref(null);
+    const route = useRoute();
+    let subscription: Subscription;
 
     const showActivity = (activity: any) => {
       let existingActivity = false;
@@ -34,15 +36,17 @@ export default defineComponent({
     };
 
     onMounted(() => {
-      subscription.value = trackerService.subscribe(activity => {
+      subscription = trackerService.subscribe(activity => {
         showActivity(activity);
       });
+      // Make sure current session shows on the list
+      trackerService.sendActivity(route.fullPath);
     });
 
     onUnmounted(() => {
-      if (subscription.value) {
-        subscription.value.unsubscribe();
-        subscription.value = null;
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = null;
       }
     });
 

--- a/generators/vue/templates/src/main/webapp/app/admin/tracker/tracker.service.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/tracker/tracker.service.ts.ejs
@@ -1,44 +1,47 @@
-import { provide } from 'vue';
-import VueRouter from 'vue-router';
+import { ComputedRef, inject, ref, watch } from 'vue';
 import { useRouter } from 'vue-router/composables';
 import * as SockJS from 'sockjs-client';
 import { map } from 'rxjs';
-import { Store } from 'vuex';
-import { RxStomp } from '@stomp/rx-stomp';
+import { RxStomp, RxStompState } from '@stomp/rx-stomp';
 import Cookies from 'js-cookie';
-
-import { useStore } from '@/store';
-import { AccountStateStorable } from '@/shared/config/store/account-store';
 
 const DESTINATION_TRACKER = '/topic/tracker';
 const DESTINATION_ACTIVITY = '/topic/activity';
 
-export const useTrackerService = () => {
+export const useTrackerService = ({ stomp }: { stomp?: RxStomp } = {}) => {
   const router = useRouter();
-  const store = useStore();
-  return new TrackerService(router, store);
+  const authenticated = inject<ComputedRef<boolean>>('authenticated');
+  const trackerService = new TrackerService({ stomp });
+
+  router.afterEach(to => trackerService.sendActivity(to.fullPath));
+
+  watch(trackerService.status, value => {
+    if (value === 'open') {
+      trackerService.sendActivity(router.currentRoute.fullPath);
+    }
+  });
+
+  watch(
+    authenticated,
+    (value, prevValue) => {
+      if (value === prevValue) return;
+      if (value) {
+        trackerService.connect();
+      } else {
+        trackerService.disconnect();
+      }
+    },
+    { immediate: true }
+  );
+  return trackerService;
 };
 
 export default class TrackerService {
+  public status = ref<'open' | 'connecting' | 'closing' | 'closed'>('closed');
   private rxStomp: RxStomp;
 
-  constructor(
-      private router: VueRouter,
-      private store: Store<AccountStateStorable>
-    ) {
-    this.stomp = new RxStomp();
-    this.router.afterEach(() => this.sendActivity());
-
-    this.store.watch(
-      (_state, getters) => getters.authenticated,
-      (value, oldValue) => {
-        if (value === oldValue) return;
-        if (value) {
-          return this.connect();
-        }
-        return this.disconnect();
-      }
-    );
+  constructor({ stomp }: { stomp?: RxStomp }) {
+    this.stomp = stomp ?? new RxStomp();
   }
 
   get stomp() {
@@ -52,18 +55,32 @@ export default class TrackerService {
         console.log(new Date(), msg);
       },
     });
-    this.rxStomp.connected$.subscribe(() => {
-      this.sendActivity();
+
+    this.rxStomp.connectionState$.subscribe(state => {
+      switch (state) {
+        case RxStompState.CONNECTING:
+          this.status.value = 'connecting';
+          return;
+        case RxStompState.OPEN:
+          this.status.value = 'open';
+          return;
+        case RxStompState.CLOSING:
+          this.status.value = 'closing';
+          return;
+        case RxStompState.CLOSED:
+          this.status.value = 'closed';
+          return;
+      }
     });
   }
 
-  private connect(): void {
+  public connect(): void {
     this.updateCredentials();
-    return this.rxStomp.activate();
+    this.rxStomp.activate();
   }
 
-  private disconnect(): Promise<void> {
-    return this.rxStomp.deactivate();
+  public async disconnect(): Promise<void> {
+    await this.rxStomp.deactivate();
   }
 <%_ if (authenticationTypeJwt) { _%>
 
@@ -99,15 +116,15 @@ export default class TrackerService {
 <%_ if (authenticationUsesCsrf) { _%>
       connectHeaders: {
         ['X-XSRF-TOKEN']: Cookies.get('JSESSIONID') || Cookies.get('XSRF-TOKEN'),
-      }
+      },
 <%_ } _%>
     });
   }
 
-  private sendActivity(): void {
+  public sendActivity(page: string): void {
     this.rxStomp.publish({
       destination: DESTINATION_ACTIVITY,
-      body: JSON.stringify({ page: this.router.currentRoute.fullPath }),
+      body: JSON.stringify({ page }),
     });
   }
 

--- a/generators/vue/templates/src/main/webapp/app/admin/user-management/user-management-edit.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/user-management/user-management-edit.component.ts.ejs
@@ -8,6 +8,9 @@ import UserManagementService from './user-management.service';
 import { IUser, User } from '@/shared/model/user.model';
 import { useAlertService } from '@/shared/alert/alert.service';
 import { useRoute } from 'vue-router/composables';
+<%_ if (enableTranslation) { _%>
+import languages from '@/shared/config/languages';
+<%_ } _%>
 
 const loginValidator = (value: string) => {
   if (!value) {
@@ -50,7 +53,6 @@ export default defineComponent({
     const userAccount: Ref<IUser> = ref({ ...new User(), authorities: [] });
     const isSaving: Ref<boolean> = ref(false);
     const authorities: Ref<string[]> = ref([]);
-    const languages: Ref<string[]> = ref([]);
 
     const initAuthorities = async () => {
       const response = await userManagementService.retrieveAuthorities();
@@ -73,10 +75,10 @@ export default defineComponent({
       userAccount,
       isSaving,
       authorities,
-      languages,
       userManagementService,
       v$: useVuelidate(),
 <%_ if (enableTranslation) { _%>
+      languages: languages(),
       t$: useI18n().t,
 <%_ } _%>
     };

--- a/generators/vue/templates/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -1,11 +1,10 @@
-import UserManagementService from './user-management.service';
-import { useAlertService } from '@/shared/alert/alert.service';
-import { computed, defineComponent, inject, Ref, ref } from 'vue';
+import { ComputedRef, defineComponent, inject, Ref, ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
+import UserManagementService from './user-management.service';
+import { useAlertService } from '@/shared/alert/alert.service';
 
-import { useStore } from '@/store';
 import { useDateFormat } from '@/shared/composables'
 
 export default defineComponent({
@@ -17,6 +16,7 @@ export default defineComponent({
     const alertService = inject('alertService', () => useAlertService(), true);
     const { formatDateShort: formatDate } = useDateFormat();
     const userManagementService = inject('userManagementService', () => new UserManagementService(), true);
+    const username = inject<ComputedRef<string>>('currentUsername');
 
     const error = ref('');
     const success = ref('');
@@ -34,8 +34,6 @@ export default defineComponent({
     const totalItems = ref(0);
     const queryCount: Ref<number> = ref(null);
 <%_ } _%>
-
-    const username = computed(() => useStore().getters.account?.login ?? '');
 
     return {
       formatDate,

--- a/generators/vue/templates/src/main/webapp/app/core/error/error.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/error/error.component.ts.ejs
@@ -1,26 +1,25 @@
-import { defineComponent, inject, Ref, ref } from 'vue';
+import { ComputedRef, defineComponent, inject, Ref, ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
 import LoginService from '@/account/login.service';
 import { useRoute } from 'vue-router/composables';
-import { useStore } from '@/store';
 
 export default defineComponent({
   name: 'Error',
   setup() {
     const loginService = inject<LoginService>('loginService');
+    const authenticated = inject<ComputedRef<boolean>>('authenticated');
     const errorMessage: Ref<string> = ref(null);
     const error403: Ref<boolean> = ref(false);
     const error404: Ref<boolean> = ref(false);
     const route = useRoute();
-    const store = useStore();
 
     if (route.meta) {
       errorMessage.value = route.meta.errorMessage ?? null;
       error403.value = route.meta.error403 ?? false;
       error404.value = route.meta.error404 ?? false;
-      if (!store.getters.authenticated && error403.value) {
+      if (!authenticated.value && error403.value) {
 <%_ if (!authenticationTypeOauth2) { _%>
         loginService.openLogin();
 <%_ } else { %>

--- a/generators/vue/templates/src/main/webapp/app/core/home/home.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/home/home.component.ts.ejs
@@ -1,17 +1,16 @@
-import { computed, ComputedRef, defineComponent, inject } from 'vue';
+import { ComputedRef, defineComponent, inject } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
 
 import LoginService from '@/account/login.service';
-import { useStore } from '@/store';
 
 export default defineComponent({
-  setup(this: any, prop) {
+  setup() {
     const loginService = inject<LoginService>('loginService');
 
-    const authenticated: ComputedRef<string> = computed(() => useStore().getters.authenticated);
-    const username: ComputedRef<string> = computed(() => useStore().getters.account?.login ?? '');
+    const authenticated = inject<ComputedRef<boolean>>('authenticated');
+    const username = inject<ComputedRef<string>>('currentUsername');
 
     const openLogin = () => {
 <%_ if (!authenticationTypeOauth2) { _%>

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n-bridge';
 import LoginService from '@/account/login.service';
 import type AccountService from '@/account/account.service';
 <%_ if (enableTranslation) { _%>
-import TranslationService from '@/locale/translation.service';
+import languages from '@/shared/config/languages';
 <%_ } _%>
 import EntitiesMenu from '@/entities/entities-menu.vue';
 
@@ -25,16 +25,19 @@ export default defineComponent({
   setup() {
     const loginService = inject<LoginService>('loginService');
     const accountService = inject<AccountService>('accountService');
+    const currentLanguage = inject('currentLanguage', () => computed(() => navigator.language ?? '<%- nativeLanguage %>'), true);
 <%_ if (enableTranslation) { _%>
-    const translationService = inject<TranslationService>('translationService');
+    const changeLanguage = inject<(string) => Promise<void>>('changeLanguage');
+
+    const isActiveLanguage = (key: string) => {
+      return key === currentLanguage.value;
+    };
 <%_ } _%>
 
     const router = useRouter();
     const store = useStore();
 
     const version = 'v' + VERSION;
-    const currentLanguage = computed(() => store.getters.currentLanguage);
-    const languages = computed(() => store.getters.languages);
     const hasAnyAuthorityValues: Ref<any> = ref({});
 
     const openAPIEnabled = computed(() => store.getters.activeProfiles.indexOf('api-docs') > -1);
@@ -55,11 +58,12 @@ export default defineComponent({
       loginService,
       openLogin,
 <%_ if (enableTranslation) { _%>
-      translationService,
+      changeLanguage,
+      languages: languages(),
+      isActiveLanguage,
 <%_ } _%>
       version,
       currentLanguage,
-      languages,
       hasAnyAuthorityValues,
       openAPIEnabled,
       inProduction,
@@ -69,21 +73,7 @@ export default defineComponent({
 <%_ } _%>
     };
   },
-<%_ if (enableTranslation) { _%>
-  created() {
-    const currentLanguage = Object.keys(this.languages).includes(navigator.language) ? navigator.language : this.currentLanguage;
-    this.translationService.refreshTranslation(currentLanguage);
-  },
-<%_ } _%>
   methods: {
-<%_ if (enableTranslation) { _%>
-    changeLanguage(newLanguage: string) : void {
-      this.translationService.refreshTranslation(newLanguage);
-    },
-    isActiveLanguage(key: string) : boolean {
-      return key === this.currentLanguage;
-    },
-<%_ } _%>
     subIsActive(input) {
       const paths = Array.isArray(input) ? input : [input];
       return paths.some(path => {

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -40,9 +40,9 @@ export default defineComponent({
     const version = 'v' + VERSION;
     const hasAnyAuthorityValues: Ref<any> = ref({});
 
-    const openAPIEnabled = computed(() => store.getters.activeProfiles.indexOf('api-docs') > -1);
-    const inProduction = computed(() => store.getters.activeProfiles.indexOf('prod') > -1);
-    const authenticated = computed(() => store.getters.authenticated);
+    const openAPIEnabled = computed(() => store.activeProfiles.indexOf('api-docs') > -1);
+    const inProduction = computed(() => store.activeProfiles.indexOf('prod') > -1);
+    const authenticated = computed(() => store.authenticated);
 
     const openLogin = () => {
 <%_ if (!authenticationTypeOauth2) { _%>
@@ -52,10 +52,42 @@ export default defineComponent({
 <%_ } _%>
     };
 
+    const subIsActive = (input: string | string[]) => {
+      const paths = Array.isArray(input) ? input : [input];
+      return paths.some(path => {
+        return router.currentRoute.path.indexOf(path) === 0; // current path starts with this path string
+      });
+    };
+
+    const logout = async () => {
+<%_ if (authenticationTypeJwt) { _%>
+      localStorage.removeItem('<%=jhiPrefixDashed %>-authenticationToken');
+      sessionStorage.removeItem('<%=jhiPrefixDashed %>-authenticationToken');
+      store.logout();
+      if (router.currentRoute.path !== '/') {
+        router.push('/');
+      }
+<%_ } else { _%>
+      const response = await loginService.logout();
+      store.logout();
+  <%_ if (authenticationTypeOauth2) { _%>
+      window.location.href = response.data.logoutUrl;
+      const next = response.data?.logoutUrl ?? '/';
+      if (router.currentRoute.path !== next) {
+        router.push(next);
+      }
+  <%_ } else { _%>
+      if (router.currentRoute.path !== '/') {
+        router.push('/');
+      }
+  <%_ } _%>
+<%_ } _%>
+    },
+
     return {
-      router,
+      logout,
+      subIsActive,
       accountService,
-      loginService,
       openLogin,
 <%_ if (enableTranslation) { _%>
       changeLanguage,
@@ -74,38 +106,6 @@ export default defineComponent({
     };
   },
   methods: {
-    subIsActive(input) {
-      const paths = Array.isArray(input) ? input : [input];
-      return paths.some(path => {
-        return this.$route.path.indexOf(path) === 0; // current path starts with this path string
-      });
-    },
-    logout(): Promise<any> {
-<%_ if (!authenticationTypeJwt) { _%>
-      return this.loginService.logout().then(response => {
-        this.$store.commit('logout');
-  <%_ if (authenticationTypeOauth2) { _%>
-        window.location.href = response.data.logoutUrl;
-        const next = response.data?.logoutUrl ?? '/';
-        if (this.$route.path !== next) {
-          return this.$router.push(next);
-        }
-  <%_ } else { _%>
-        if (this.$route.path !== '/') {
-          return this.$router.push('/');
-        }
-  <%_ } _%>
-      });
-<%_ } else { _%>
-      localStorage.removeItem('<%=jhiPrefixDashed %>-authenticationToken');
-      sessionStorage.removeItem('<%=jhiPrefixDashed %>-authenticationToken');
-      this.$store.commit('logout');
-      if (this.$route.path !== '/') {
-        return this.$router.push('/');
-      }
-<%_ } _%>
-      return Promise.resolve(this.$router.currentRoute);
-    },
     hasAnyAuthority(authorities: any): boolean {
       this.accountService
         .hasAnyAuthorityAndCheckAuth(authorities)

--- a/generators/vue/templates/src/main/webapp/app/core/ribbon/ribbon.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/ribbon/ribbon.component.ts.ejs
@@ -8,9 +8,9 @@ export default defineComponent({
   name: 'Ribbon',
   setup(prop) {
     const store = useStore();
-    const ribbonEnv = computed(() => store.getters.ribbonOnProfiles);
+    const ribbonEnv = computed(() => store.ribbonOnProfiles);
     const ribbonEnabled = computed(
-      () => store.getters.ribbonOnProfiles && store.getters.activeProfiles.indexOf(store.getters.ribbonOnProfiles) > -1
+      () => store.ribbonOnProfiles && store.activeProfiles.indexOf(store.ribbonOnProfiles) > -1
     );
 
     return {

--- a/generators/vue/templates/src/main/webapp/app/entities/_entityFolder/_entityFile-update.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/entities/_entityFolder/_entityFile-update.component.ts.ejs
@@ -1,4 +1,4 @@
-import { defineComponent, inject, ref, Ref } from 'vue';
+import { computed, defineComponent, inject, ref, Ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
@@ -138,7 +138,7 @@ export default defineComponent({
     const <%- this._.lowerFirst(importedType) %>Values: Ref<string[]> = ref(Object.keys(<%- importedType %>));
     <%_ }); _%>
     const isSaving = ref(false);
-    const currentLanguage = ref('');
+    const currentLanguage = inject('currentLanguage', () => computed(() => navigator.language ?? '<%- nativeLanguage %>'), true);
 
     const route = useRoute();
     const router = useRouter();
@@ -212,13 +212,6 @@ _%>
     };
   },
   created(): void {
-    this.currentLanguage = this.$store.getters.currentLanguage;
-    this.$store.watch(
-      () => this.$store.getters.currentLanguage,
-      () => {
-        this.currentLanguage = this.$store.getters.currentLanguage;
-      }
-    );
     <%_ if (relationshipsContainManyToOne) { _%>
     <%_
       for (relationship of relationships) {

--- a/generators/vue/templates/src/main/webapp/app/entities/_entityFolder/_entityFile-update.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/entities/_entityFolder/_entityFile-update.component.ts.ejs
@@ -4,8 +4,9 @@ import { useI18n } from 'vue-i18n-bridge';
 <%_ } _%>
 import { useRoute, useRouter } from 'vue-router/composables';
 import { useVuelidate } from '@vuelidate/core'
+
 <%_ if (anyFieldIsBlobDerived) { _%>
-  import useDataUtils from '@/shared/data/data-utils.service';
+import useDataUtils from '@/shared/data/data-utils.service';
 <%_ } _%>
 <%_ if (anyFieldIsTimeDerived) { _%>
 import { useDateFormat } from '@/shared/composables';

--- a/generators/vue/templates/src/main/webapp/app/entities/entities-menu.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/entities/entities-menu.component.ts.ejs
@@ -4,6 +4,7 @@ import {
   inject,
   onMounted,
   watch,
+  ComputedRef,
 <%_ } _%>
 } from 'vue';
 <%_ if (enableTranslation) { _%>
@@ -21,10 +22,11 @@ export default defineComponent({
   <%_ if (applicationTypeMicroservice) { _%>
     const microfrontendI18n = inject('microfrontendI18n', true);
     const translationService = inject<TranslationService>('translationService');
+    const currentLanguage = inject<ComputedRef<string>>('currentLanguage');
 
     const loadLanguage = () => {
       if (microfrontendI18n) {
-        translationService.loadTranslations('<%= frontendAppName %>', '<%= endpointPrefix %>/', I18N_HASH);
+        translationService.loadTranslations(currentLanguage.value, '<%= frontendAppName %>', '<%= endpointPrefix %>/', I18N_HASH);
       }
     };
 

--- a/generators/vue/templates/src/main/webapp/app/locale/translation.service.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/locale/translation.service.ts.ejs
@@ -1,20 +1,18 @@
 import axios from 'axios';
 import VueI18n from 'vue-i18n';
-import { Store } from 'vuex';
 import dayjs from 'dayjs';
+import languages from '@/shared/config/languages';
 
 export default class TranslationService {
-  private store: Store<unknown>;
   private i18n: VueI18n;
+  private languages = languages();
 
-  constructor(store: Store<unknown>, i18n: VueI18n) {
-    this.store = store;
+  constructor(i18n: VueI18n) {
     this.i18n = i18n;
   }
 <%_ if (microfrontend) { _%>
 
-  public loadTranslations(appKey: string, urlPrefix: string, hash: string) {
-    const currentLanguage = this.store.getters.currentLanguage;
+  public loadTranslations(currentLanguage: string, appKey: string, urlPrefix: string, hash: string) {
     if (!this.i18n) return;
 
     axios.get(`${urlPrefix}i18n/${currentLanguage}.json?_=${hash}`).then((res: any) => {
@@ -25,26 +23,16 @@ export default class TranslationService {
   }
 <%_ } _%>
 
-  public refreshTranslation(newLanguage: string) {
-    let currentLanguage = this.store.getters.currentLanguage;
-    currentLanguage = newLanguage ? newLanguage : '<%= nativeLanguage %>';
-    if (this.i18n && !this.i18n.messages[currentLanguage]) {
-      this.i18n.setLocaleMessage(currentLanguage, {});
-      axios.get(`i18n/${currentLanguage}.json?_=${I18N_HASH}`).then((res: any) => {
-        if (res.data) {
-          this.i18n.setLocaleMessage(currentLanguage, res.data);
-          this.setLocale(currentLanguage);
-        }
-      });
-    } else if (this.i18n) {
-      this.setLocale(currentLanguage);
+  public async refreshTranslation(newLanguage: string) {
+    if (this.i18n && !this.i18n.messages[newLanguage]) {
+      const res = await axios.get(`i18n/${newLanguage}.json?_=${I18N_HASH}`);
+      this.i18n.setLocaleMessage(newLanguage, res.data);
     }
   }
 
-  private setLocale(lang: string) {
+  public setLocale(lang: string) {
     dayjs.locale(lang);
     this.i18n.locale = lang;
-    this.store.commit('currentLanguage', lang);
     axios.defaults.headers.common['Accept-Language'] = lang;
     document.querySelector('html').setAttribute('lang', lang);
 <%_ if (enableI18nRTL) { _%>
@@ -54,12 +42,19 @@ export default class TranslationService {
 <%_ if (enableI18nRTL) { _%>
 
     private isRTL(lang: string): boolean {
-      const languages = this.store.getters.languages;
-      return languages[lang] && languages[lang].rtl;
+      return this.languages[lang]?.rtl;
     }
 
     private updatePageDirection(currentLanguage: string): void {
       document.querySelector('html').setAttribute('dir', this.isRTL(currentLanguage) ? 'rtl' : 'ltr');
     }
 <%_ } _%>
+
+  public isLanguageSupported(lang: string) {
+    return Boolean(this.languages[lang]);
+  }
+
+  public getLocalStoreLanguage(): string | null {
+    return localStorage.getItem('currentLanguage');
+  }
 }

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -1,9 +1,10 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.common with an alias.
 import Vue, { provide, computed, watch<% if (enableTranslation) { %>, onMounted<% } %> } from 'vue';
-import { setupAxiosInterceptors } from '@/shared/config/axios-interceptor';
+import { createPinia, PiniaVuePlugin } from 'pinia'
 
-import { useStore } from '@/store';
+import { useStore<% if (enableTranslation) { %>, useTranslationStore<% } %> } from '@/store';
+import { setupAxiosInterceptors } from '@/shared/config/axios-interceptor';
 
 import App from './app.vue';
 import router<% if (applicationTypeGateway && microfrontend) { %>, { lazyRoutes }<% } %> from './router';
@@ -24,6 +25,9 @@ import { useTrackerService } from './admin/tracker/tracker.service';
 <%_ } _%>
 /* tslint:disable */
 
+Vue.use(PiniaVuePlugin)
+const pinia = createPinia()
+
 // jhipster-needle-add-entity-service-to-main-import - JHipster will import entities services here
 
 /* tslint:enable */
@@ -36,7 +40,6 @@ Vue.component('jhi-sort-indicator', JhiSortIndicatorComponent);
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(Vue);
 <%_ } _%>
-const store = useStore();
 
 new Vue({
   el: '#app',
@@ -51,15 +54,17 @@ new Vue({
   setup() {
     provide('loginService', new LoginService());
 <%_ } _%>
+    const store = useStore();
     const accountService = new AccountService(store);
 <%_ if (enableTranslation) { _%>
+    const translationStore = useTranslationStore();
     const translationService = new TranslationService(i18n);
 
-    const currentLanguage = computed(() => store.getters.currentLanguage);
+    const currentLanguage = computed(() => translationStore.currentLanguage);
     const changeLanguage = async (newLanguage: string) => {
       if (currentLanguage.value !== newLanguage) {
         await translationService.refreshTranslation(newLanguage);
-        store.commit('currentLanguage', newLanguage);
+        translationStore.setCurrentLanguage(newLanguage);
       }
     };
 
@@ -67,7 +72,7 @@ new Vue({
     provide('changeLanguage', changeLanguage);
 
     watch(
-      () => store.getters.account,
+      () => store.account,
       async value => {
         if (!translationService.getLocalStoreLanguage()) {
           await changeLanguage(value.langKey);
@@ -76,7 +81,7 @@ new Vue({
     );
 
     watch(
-      () => store.getters.currentLanguage,
+      () => translationStore.currentLanguage,
       value => {
         translationService.setLocale(value);
       }
@@ -85,14 +90,14 @@ new Vue({
     onMounted(async () => {
       const lang = [
       translationService.getLocalStoreLanguage(),
-        store.getters.account?.langKey,
+        store.account?.langKey,
         navigator.language,
         '<%- nativeLanguage %>'
       ].find(lang => lang && translationService.isLanguageSupported(lang));
       await changeLanguage(lang);
     });
 <%_ } else { _%>
-    provide('currentLanguage', computed(() => store.getters.account?.langKey ?? navigator.language ?? '<%- nativeLanguage %>'));
+    provide('currentLanguage', computed(() => store.account?.langKey ?? navigator.language ?? '<%- nativeLanguage %>'));
 <%_ } _%>
 
     router.beforeResolve(async (to, from, next) => {
@@ -101,7 +106,7 @@ new Vue({
       loginService.hideLogin();
 
 <%_ } _%>
-      if (!store.getters.authenticated) {
+      if (!store.authenticated) {
         await accountService.update();
       }
       if (to.meta?.authorities && to.meta.authorities.length > 0) {
@@ -122,7 +127,7 @@ new Vue({
         const status = error.status || error.response.status;
         if (status === 401) {
           // Store logged out state.
-          store.commit('logout');
+          store.logout();
           if (!url.endsWith('api/account') && !url.endsWith('api/<% if (authenticationTypeSession) { %>authentication<% } else { %>authenticate<% } %>')) {
             // Ask for a new authentication
 <%_ if (authenticationTypeOauth2) { _%>
@@ -140,8 +145,8 @@ new Vue({
       }
     );
 
-    provide('authenticated', computed(() => store.getters.authenticated));
-    provide('currentUsername', computed(() => store.getters.account?.login));
+    provide('authenticated', computed(() => store.authenticated));
+    provide('currentUsername', computed(() => store.account?.login));
 
 <%_ if (enableTranslation) { _%>
     provide('translationService', translationService);
@@ -156,5 +161,5 @@ new Vue({
     provide('microfrontendI18n', false);
 <%_ } _%>
   },
-  store,
+  pinia,
 });

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -1,6 +1,6 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.common with an alias.
-import Vue, { provide } from 'vue';
+import Vue, { provide, computed, watch<% if (enableTranslation) { %>, onMounted<% } %> } from 'vue';
 import { setupAxiosInterceptors } from '@/shared/config/axios-interceptor';
 
 import { useStore } from '@/store';
@@ -38,8 +38,7 @@ const i18n = initI18N(Vue);
 <%_ } _%>
 const store = useStore();
 
-/* tslint:disable */
-<% if (!authenticationTypeOauth2) { %>const vue = <% } %>new Vue({
+new Vue({
   el: '#app',
   components: { App },
   template: '<App/>',
@@ -52,10 +51,49 @@ const store = useStore();
   setup() {
     provide('loginService', new LoginService());
 <%_ } _%>
+    const accountService = new AccountService(store);
 <%_ if (enableTranslation) { _%>
-    const translationService = new TranslationService(store, i18n);
+    const translationService = new TranslationService(i18n);
+
+    const currentLanguage = computed(() => store.getters.currentLanguage);
+    const changeLanguage = async (newLanguage: string) => {
+      if (currentLanguage.value !== newLanguage) {
+        await translationService.refreshTranslation(newLanguage);
+        store.commit('currentLanguage', newLanguage);
+      }
+    };
+
+    provide('currentLanguage', currentLanguage);
+    provide('changeLanguage', changeLanguage);
+
+    watch(
+      () => store.getters.account,
+      async value => {
+        if (!translationService.getLocalStoreLanguage()) {
+          await changeLanguage(value.langKey);
+        }
+      }
+    );
+
+    watch(
+      () => store.getters.currentLanguage,
+      value => {
+        translationService.setLocale(value);
+      }
+    );
+
+    onMounted(async () => {
+      const lang = [
+      translationService.getLocalStoreLanguage(),
+        store.getters.account?.langKey,
+        navigator.language,
+        '<%- nativeLanguage %>'
+      ].find(lang => lang && translationService.isLanguageSupported(lang));
+      await changeLanguage(lang);
+    });
+<%_ } else { _%>
+    provide('currentLanguage', computed(() => store.getters.account?.langKey ?? navigator.language ?? '<%- nativeLanguage %>'));
 <%_ } _%>
-    const accountService = new AccountService(store<%_ if (enableTranslation) { _%>, translationService<%_ } _%>);
 
     router.beforeResolve(async (to, from, next) => {
 <%_ if (!authenticationTypeOauth2) { _%>
@@ -101,6 +139,9 @@ const store = useStore();
         return Promise.reject(error);
       }
     );
+
+    provide('authenticated', computed(() => store.getters.authenticated));
+    provide('currentUsername', computed(() => store.getters.account?.login));
 
 <%_ if (enableTranslation) { _%>
     provide('translationService', translationService);

--- a/generators/vue/templates/src/main/webapp/app/shared/config/languages.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/config/languages.ts.ejs
@@ -1,0 +1,23 @@
+<%#
+ Copyright 2013-2023 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+const languages = () => ({
+  // jhipster-needle-i18n-language-key-pipe - JHipster will add/remove languages in this object
+});
+
+export default languages;

--- a/generators/vue/templates/src/main/webapp/app/shared/config/store/account-store.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/config/store/account-store.ts.ejs
@@ -1,4 +1,4 @@
-import { Module } from 'vuex';
+import { defineStore } from 'pinia'
 
 export interface AccountStateStorable {
   logon: boolean;
@@ -18,38 +18,33 @@ export const defaultAccountState: AccountStateStorable = {
   activeProfiles: '',
 };
 
-export const accountStore: Module<AccountStateStorable, any> = {
-  state: { ...defaultAccountState },
+export const useAccountStore = defineStore('main', {
+  state: (): AccountStateStorable => ({ ...defaultAccountState }),
   getters: {
-    logon: state => state.logon,
     account: state => state.userIdentity,
-    authenticated: state => state.authenticated,
-    profilesLoaded: state => state.profilesLoaded,
-    activeProfiles: state => state.activeProfiles,
-    ribbonOnProfiles: state => state.ribbonOnProfiles,
   },
-  mutations: {
-    authenticate(state, promise) {
-      state.logon = promise;
+  actions: {
+    authenticate(promise) {
+      this.logon = promise;
     },
-    authenticated(state, identity) {
-      state.userIdentity = identity;
-      state.authenticated = true;
-      state.logon = null;
+    setAuthentication(identity) {
+      this.userIdentity = identity;
+      this.authenticated = true;
+      this.logon = null;
     },
-    logout(state) {
-      state.userIdentity = null;
-      state.authenticated = false;
-      state.logon = null;
+    logout() {
+      this.userIdentity = null;
+      this.authenticated = false;
+      this.logon = null;
     },
-    profilesLoaded(state) {
-      state.profilesLoaded = true;
+    setProfilesLoaded() {
+      this.profilesLoaded = true;
     },
-    setActiveProfiles(state, profile) {
-      state.activeProfiles = profile;
+    setActiveProfiles(profile) {
+      this.activeProfiles = profile;
     },
-    setRibbonOnProfiles(state, ribbon) {
-      state.ribbonOnProfiles = ribbon;
+    setRibbonOnProfiles(ribbon) {
+      this.ribbonOnProfiles = ribbon;
     },
   },
-};
+});

--- a/generators/vue/templates/src/main/webapp/app/shared/config/store/translation-store.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/config/store/translation-store.ts.ejs
@@ -1,11 +1,10 @@
 import { Module } from 'vuex';
+import languages from '@/shared/config/languages';
 
 export const translationStore: Module<any, any> = {
     state: {
-        currentLanguage: localStorage.getItem("currentLanguage") || '<%= nativeLanguage %>',
-        languages: {
-            // jhipster-needle-i18n-language-key-pipe - JHipster will add/remove languages in this object
-        }
+        currentLanguage: undefined,
+        languages: languages(),
     },
     getters: {
         currentLanguage: state => state.currentLanguage,

--- a/generators/vue/templates/src/main/webapp/app/shared/config/store/translation-store.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/config/store/translation-store.ts.ejs
@@ -1,19 +1,17 @@
-import { Module } from 'vuex';
-import languages from '@/shared/config/languages';
+import { defineStore } from 'pinia';
 
-export const translationStore: Module<any, any> = {
-    state: {
-        currentLanguage: undefined,
-        languages: languages(),
+interface TranslationState {
+  currentLanguage: string;
+}
+
+export const useTranslationStore = defineStore('translationStore', {
+  state: (): TranslationState => ({
+    currentLanguage: undefined,
+  }),
+  actions: {
+    setCurrentLanguage(newLanguage) {
+      this.currentLanguage = newLanguage;
+      localStorage.setItem('currentLanguage', newLanguage);
     },
-    getters: {
-        currentLanguage: state => state.currentLanguage,
-        languages: state => state.languages,
-    },
-    mutations: {
-        currentLanguage(state, newLanguage) {
-            state.currentLanguage = newLanguage;
-            localStorage.setItem("currentLanguage", newLanguage);
-        },
-    },
-};
+  },
+});

--- a/generators/vue/templates/src/main/webapp/app/store.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/store.ts.ejs
@@ -1,19 +1,9 @@
-import Vue from 'vue';
-import Vuex from 'vuex';
-import { accountStore } from '@/shared/config/store/account-store';
+import { useAccountStore as useStore } from '@/shared/config/store/account-store';
+export type AccountStore = ReturnType<typeof useStore>;
+export { useStore };
 <%_ if (enableTranslation) { _%>
-import { translationStore } from '@/shared/config/store/translation-store';
+
+import { useTranslationStore } from '@/shared/config/store/translation-store';
+export type TranslationStore = ReturnType<typeof useTranslationStore>;
+export { useTranslationStore };
 <%_ } _%>
-
-Vue.use(Vuex);
-
-const store = new Vuex.Store({
-  modules: {
-    accountStore,
-<%_ if (enableTranslation) { _%>
-      translationStore,
-<%_ } _%>
-  },
-});
-
-export const useStore = () => store;

--- a/generators/vue/templates/src/test/javascript/jest.conf.js.ejs
+++ b/generators/vue/templates/src/test/javascript/jest.conf.js.ejs
@@ -49,7 +49,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 80,
-      branches: 60,
+      branches: 50,
       functions: 70,
       lines: 80,
     },

--- a/generators/vue/templates/src/test/javascript/spec/app/account/account.service.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/account.service.spec.ts.ejs
@@ -1,18 +1,8 @@
-<%_ if (enableTranslation) { _%>
-import { createLocalVue } from '@vue/test-utils';
-<%_ } %>
 import axios from 'axios';
 import sinon from 'sinon';
 
 import { useStore } from '@/store';
 import AccountService from '@/account/account.service';
-<%_ if (enableTranslation) { _%>
-import TranslationService from '@/locale/translation.service';
-<%_ } %>
-
-<%_ if (enableTranslation) { _%>
-import { initI18N } from '@/shared/config/config'; 
-<%_ } %>
 import { defaultAccountState } from '@/shared/config/store/account-store';
 
 const resetStore = store => {
@@ -29,15 +19,9 @@ const axiosStub = {
   post: sinon.stub(axios, 'post'),
 };
 
-<%_ if (enableTranslation) { _%>
-const localVue = createLocalVue();
-<%_ } _%>
 const store = useStore();
 
 describe('Account Service test suite', () => {
-<%_ if (enableTranslation) { _%>
-  let i18n;
-<%_ } %>
   let accountService: AccountService;
 
   beforeEach(() => {
@@ -47,16 +31,13 @@ describe('Account Service test suite', () => {
 <%_ } %>
     axiosStub.get.reset();
     resetStore(store);
-<%_ if (enableTranslation) { _%>
-    i18n = initI18N(localVue);
-<%_ } %>
   });
 
   it('should init service and do not retrieve account', async () => {
     axiosStub.get.resolves({});
     axiosStub.get.withArgs('management/info').resolves({ status: 200, data: { 'display-ribbon-on-profiles': 'dev', activeProfiles: ['dev', 'test'] } });
 
-    accountService = new AccountService(store<%_ if (enableTranslation) { _%>, new TranslationService(store, i18n)<%_ } %>);
+    accountService = new AccountService(store);
     await accountService.update();
 
     expect(store.getters.logon).toBe(null);
@@ -70,7 +51,7 @@ describe('Account Service test suite', () => {
 
   it('should init service and retrieve profiles if already logged in before but no account found', async () => {
     axiosStub.get.resolves({});
-    accountService = new AccountService(store<%_ if (enableTranslation) { _%>, new TranslationService(store, i18n)<%_ } %>);
+    accountService = new AccountService(store);
     await accountService.update();
 
     expect(store.getters.logon).toBe(null);
@@ -82,7 +63,7 @@ describe('Account Service test suite', () => {
   it('should init service and retrieve profiles if already logged in before but exception occurred and should be logged out', async () => {
     axiosStub.get.resolves({});
     axiosStub.get.withArgs('api/account').rejects();
-    accountService = new AccountService(store<%_ if (enableTranslation) { _%>, new TranslationService(store, i18n)<%_ } %>);
+    accountService = new AccountService(store);
     await accountService.update();
 
     expect(accountService.authenticated).toBe(false);
@@ -92,7 +73,7 @@ describe('Account Service test suite', () => {
 
   it('should init service and check for authority after retrieving account but getAccount failed', async () => {
     axiosStub.get.rejects();
-    accountService = new AccountService(store<%_ if (enableTranslation) { _%>, new TranslationService(store, i18n)<%_ } %>);
+    accountService = new AccountService(store);
     await accountService.update();
 
     return accountService.hasAnyAuthorityAndCheckAuth('USER').then((value: boolean) => {
@@ -102,7 +83,7 @@ describe('Account Service test suite', () => {
 
   it('should init service and check for authority after retrieving account', async () => {
     axiosStub.get.resolves({ status: 200, data: { authorities: ['USER'], langKey: 'en' } });
-    accountService = new AccountService(store<%_ if (enableTranslation) { _%>, new TranslationService(store, i18n)<%_ } %>);
+    accountService = new AccountService(store);
     await accountService.update();
 
     return accountService.hasAnyAuthorityAndCheckAuth('USER').then((value: boolean) => {
@@ -112,7 +93,7 @@ describe('Account Service test suite', () => {
 
   it('should init service as not authentified and not return any authorities admin and not retrieve account', async () => {
     axiosStub.get.rejects();
-    accountService = new AccountService(store<%_ if (enableTranslation) { _%>, new TranslationService(store, i18n)<%_ } %>);
+    accountService = new AccountService(store);
     await accountService.update();
 
     return accountService.hasAnyAuthorityAndCheckAuth('ADMIN').then((value: boolean) => {
@@ -122,7 +103,7 @@ describe('Account Service test suite', () => {
 
   it('should init service as not authentified and return authority user', async () => {
     axiosStub.get.rejects();
-    accountService = new AccountService(store<%_ if (enableTranslation) { _%>, new TranslationService(store, i18n)<%_ } %>);
+    accountService = new AccountService(store);
     await accountService.update();
 
     return accountService.hasAnyAuthorityAndCheckAuth('USER').then((value: boolean) => {

--- a/generators/vue/templates/src/test/javascript/spec/app/account/account.service.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/account.service.spec.ts.ejs
@@ -1,17 +1,12 @@
 import axios from 'axios';
 import sinon from 'sinon';
 
-import { useStore } from '@/store';
+import { createTestingPinia } from '@pinia/testing';
 import AccountService from '@/account/account.service';
-import { defaultAccountState } from '@/shared/config/store/account-store';
+import { AccountStore, useStore } from '@/store';
 
-const resetStore = store => {
-  store.replaceState({
-    accountStore: { ...defaultAccountState },
-<%_ if (enableTranslation) { _%>
-    translationStore: { languages: {} },
-<%_ } %>
-  });
+const resetStore = (store: AccountStore) => {
+  store.$reset();
 };
 
 const axiosStub = {
@@ -19,6 +14,7 @@ const axiosStub = {
   post: sinon.stub(axios, 'post'),
 };
 
+createTestingPinia({ stubActions: false });
 const store = useStore();
 
 describe('Account Service test suite', () => {
@@ -40,13 +36,13 @@ describe('Account Service test suite', () => {
     accountService = new AccountService(store);
     await accountService.update();
 
-    expect(store.getters.logon).toBe(null);
+    expect(store.logon).toBe(null);
     expect(accountService.authenticated).toBe(false);
-    expect(store.getters.account).toBe(null);
+    expect(store.account).toBe(null);
     expect(axiosStub.get.calledWith('management/info')).toBeTruthy();
-    expect(store.getters.activeProfiles[0]).toBe('dev');
-    expect(store.getters.activeProfiles[1]).toBe('test');
-    expect(store.getters.ribbonOnProfiles).toBe('dev');
+    expect(store.activeProfiles[0]).toBe('dev');
+    expect(store.activeProfiles[1]).toBe('test');
+    expect(store.ribbonOnProfiles).toBe('dev');
   });
 
   it('should init service and retrieve profiles if already logged in before but no account found', async () => {
@@ -54,9 +50,9 @@ describe('Account Service test suite', () => {
     accountService = new AccountService(store);
     await accountService.update();
 
-    expect(store.getters.logon).toBe(null);
+    expect(store.logon).toBe(null);
     expect(accountService.authenticated).toBe(false);
-    expect(store.getters.account).toBe(null);
+    expect(store.account).toBe(null);
     expect(axiosStub.get.calledWith('management/info')).toBeTruthy();
   });
 
@@ -67,7 +63,7 @@ describe('Account Service test suite', () => {
     await accountService.update();
 
     expect(accountService.authenticated).toBe(false);
-    expect(store.getters.account).toBe(null);
+    expect(store.account).toBe(null);
     expect(axiosStub.get.calledWith('management/info')).toBeTruthy();
   });
 

--- a/generators/vue/templates/src/test/javascript/spec/app/account/change-password/change-password.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/change-password/change-password.component.spec.ts.ejs
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
@@ -36,7 +37,10 @@ describe('ChangePassword Component', () => {
 <%_ if (enableTranslation) { _%>
         i18n,
 <%_ } _%>
-        localVue
+        localVue,
+        provide: {
+          currentUsername: computed(() => 'username'),
+        },
       });
     changePassword = wrapper.vm;
   });

--- a/generators/vue/templates/src/test/javascript/spec/app/account/change-password/change-password.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/change-password/change-password.component.spec.ts.ejs
@@ -3,6 +3,8 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
 
+import { PiniaVuePlugin } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
 import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
@@ -17,7 +19,8 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
+const pinia = createTestingPinia();
+localVue.use(PiniaVuePlugin);
 
 const axiosStub = {
   get: sinon.stub(axios, 'get'),
@@ -33,7 +36,7 @@ describe('ChangePassword Component', () => {
 
     const wrapper = shallowMount<ChangePasswordComponentType>(ChangePassword,
       {
-        store,
+        pinia,
 <%_ if (enableTranslation) { _%>
         i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/account/login-form/login-form.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/login-form/login-form.component.spec.ts.ejs
@@ -4,9 +4,6 @@ import sinon from 'sinon';
 import VueRouter from 'vue-router';
 
 import AccountService from '@/account/account.service';
-<%_ if (enableTranslation) { _%>
-import TranslationService from '@/locale/translation.service';
-<%_ } _%>
 
 import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
@@ -63,7 +60,7 @@ describe('LoginForm Component', () => {
         localVue,
         router,
         provide: {
-          accountService: new AccountService(store<% if (enableTranslation) { %>, new TranslationService(store, i18n)<% } %>)
+          accountService: new AccountService(store)
         }
       });
     loginForm = wrapper.vm;

--- a/generators/vue/templates/src/test/javascript/spec/app/account/login-form/login-form.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/login-form/login-form.component.spec.ts.ejs
@@ -2,9 +2,10 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
 import VueRouter from 'vue-router';
+import { PiniaVuePlugin } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
 
 import AccountService from '@/account/account.service';
-
 import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
@@ -28,6 +29,8 @@ localVue.component('b-link', {});
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
+const pinia = createTestingPinia();
+localVue.use(PiniaVuePlugin);
 const store = useStore();
 
 const axiosStub = {
@@ -53,7 +56,7 @@ describe('LoginForm Component', () => {
 
     const wrapper = shallowMount<LoginFormComponentType>(LoginForm,
       {
-        store,
+        pinia,
         <%_ if (enableTranslation) { _%>
         i18n,
         <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
@@ -1,8 +1,8 @@
+import { computed } from 'vue';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
 
-import { useStore } from '@/store';
 import { EMAIL_ALREADY_USED_TYPE, LOGIN_ALREADY_USED_TYPE } from '@/constants';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
@@ -19,7 +19,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 
 const axiosStub = {
   get: sinon.stub(axios, 'get'),
@@ -43,13 +42,13 @@ describe('Register Component', () => {
     jest.spyOn(loginService, 'openLogin');
 
     const wrapper = shallowMount<RegisterComponentType>(Register, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
       localVue,
       provide: {
         loginService,
+        currentLanguage: computed(() => '<%= nativeLanguage %>'),
       },
     });
     register = wrapper.vm;

--- a/generators/vue/templates/src/test/javascript/spec/app/account/sessions/sessions.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/sessions/sessions.component.spec.ts.ejs
@@ -2,6 +2,8 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
 
+import { PiniaVuePlugin } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
 import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
@@ -20,6 +22,8 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
+const pinia = createTestingPinia({ stubActions: false });
+localVue.use(PiniaVuePlugin);
 const store = useStore();
 
 const axiosStub = {
@@ -35,16 +39,16 @@ describe('Sessions Component', () => {
     axiosStub.get.resolves({ data: [] });
     axiosStub.delete.reset();
 
-    store.commit('authenticated', {
-      login: 'username'
+    store.setAuthentication({
+      login: 'username',
     });
 
     const wrapper = shallowMount<SessionsComponentType>(Sessions, {
-      store,
+      pinia,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      localVue
+      localVue,
     });
     sessions = wrapper.vm;
   });

--- a/generators/vue/templates/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
+import { PiniaVuePlugin } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
 
 import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
@@ -17,6 +19,8 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
+const pinia = createTestingPinia({ stubActions: false });
+localVue.use(PiniaVuePlugin);
 const store = useStore();
 
 const axiosStub = {
@@ -36,10 +40,10 @@ describe('Settings Component', () => {
     axiosStub.get.resolves({});
     axiosStub.post.reset();
 
-    store.commit('authenticated', account);
+    store.setAuthentication(account);
     const wrapper = shallowMount<SettingsComponentType>(Settings,
       {
-        store,
+        pinia,
 <%_ if (enableTranslation) { _%>
         i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
@@ -2,7 +2,6 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -16,7 +15,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 
 const axiosStub = {
   get: sinon.stub(axios, 'get'),
@@ -31,7 +29,6 @@ describe('Configuration Component', () => {
       { beans: [{prefix: 'A'}, {prefix: 'B'}] }
     ], propertySources: [{ properties: { key1: {value: 'value'} }}] } });
     const wrapper = shallowMount<ConfigurationComponentType>(Configuration, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/gateway/gateway.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/gateway/gateway.component.spec.ts.ejs
@@ -1,7 +1,6 @@
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -16,7 +15,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
 
 describe('Gateway Component', () => {
@@ -27,7 +25,6 @@ describe('Gateway Component', () => {
     const gatewayService = new GatewayService();
     jest.spyOn(gatewayService, 'findAll').mockResolvedValue({ data: [] });
     wrapper = shallowMount<GatewayComponentType>(GatewayVue, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/health/health-modal.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/health/health-modal.component.spec.ts.ejs
@@ -1,6 +1,5 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -13,7 +12,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', {});
 const healthService = { getBaseName: jest.fn(), getSubSystemName: jest.fn() };
 

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
@@ -3,7 +3,6 @@ import axios from 'axios';
 import sinon from 'sinon';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -19,7 +18,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
 localVue.component('health-modal', HealthModal);
 localVue.directive('b-modal', {});
@@ -34,7 +32,6 @@ describe('Health Component', () => {
   beforeEach(() => {
     axiosStub.get.resolves({});
     const wrapper = shallowMount<HealthComponentType>(Health, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
@@ -5,7 +5,6 @@ import Logs from '@/admin/logs/logs.vue';
 import type LogsComponent from '@/admin/logs/logs.component';
 import LogsService from '@/admin/logs/logs.service';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -17,7 +16,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 
 const axiosStub = {
   get: sinon.stub(axios, 'get'),
@@ -30,7 +28,6 @@ describe('Logs Component', () => {
   beforeEach(() => {
     axiosStub.get.resolves({});
     const wrapper = shallowMount<LogsComponentType>(Logs, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/metrics/metrics-modal.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/metrics/metrics-modal.component.spec.ts.ejs
@@ -1,6 +1,5 @@
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -14,7 +13,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 
 describe('Metrics Component', () => {
   let metricsModal: MetricsModalComponentType;
@@ -22,7 +20,6 @@ describe('Metrics Component', () => {
 
   beforeEach(() => {
     wrapper = shallowMount<MetricsModalComponentType>(MetricsModal, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/metrics/metrics.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/metrics/metrics.component.spec.ts.ejs
@@ -3,7 +3,6 @@ import axios from 'axios';
 import sinon from 'sinon';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -19,7 +18,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
 localVue.component('metrics-modal', MetricsModal);
 localVue.directive('b-modal', {});
@@ -238,7 +236,6 @@ describe('Metrics Component', () => {
   beforeEach(() => {
     axiosStub.get.resolves({ data: { timers: [], gauges: []} });
     const wrapper = shallowMount<MetricsComponentType>(Metrics, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/tracker/tracker.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/tracker/tracker.component.spec.ts.ejs
@@ -3,8 +3,8 @@ import axios from 'axios';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import * as sinon from 'sinon';
 import { Subject, Subscription } from 'rxjs';
+import VueRouter from 'vue-router';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -15,11 +15,11 @@ import TrackerService from '@/admin/tracker/tracker.service';
 type <%=jhiPrefixCapitalized%>TrackerComponentType = Vue & InstanceType<typeof <%=jhiPrefixCapitalized%>TrackerComponent>;
 
 const localVue = createLocalVue();
+localVue.use(VueRouter);
 
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
 
 const axiosStub = {
@@ -34,6 +34,7 @@ describe('<%=jhiPrefixCapitalized%>Tracker', () => {
   let subscription: Subscription;
   let subscriptionSpy;
   let trackerServiceStub: any;
+  let router: VueRouter;
 
   beforeEach(() => {
     axiosStub.get.resolves({ data: {} });
@@ -44,13 +45,14 @@ describe('<%=jhiPrefixCapitalized%>Tracker', () => {
       subscriptionSpy = sinon.spy(subscription, 'unsubscribe');
       return subscription;
     });
+    router = new VueRouter();
 
     wrapper = shallowMount<<%=jhiPrefixCapitalized%>TrackerComponentType>(<%=jhiPrefixCapitalized%>Tracker, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
       localVue,
+      router,
       provide: {
         trackerService: trackerServiceStub,
       },

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/tracker/tracker.service.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/tracker/tracker.service.spec.ts.ejs
@@ -1,34 +1,30 @@
-import { createLocalVue } from '@vue/test-utils';
+import { ref, Ref } from 'vue';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import * as sinon from 'sinon';
 import VueRouter from 'vue-router';
 import { Subject } from 'rxjs';
 
-import { useStore } from '@/store';
-import TrackerService from '@/admin/tracker/tracker.service';
+import TrackerService, { useTrackerService } from '@/admin/tracker/tracker.service';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
-import { defaultAccountState } from '@/shared/config/store/account-store';
 
 const localVue = createLocalVue();
-const store = useStore();
+localVue.use(VueRouter);
 
 describe('Tracker Service', () => {
   let trackerService: TrackerService;
   let routerStub: any;
+  let TrackerApp: any;
+  let authenticated: Ref<boolean>;
 
   let mockStomp: any;
 
   beforeEach(() => {
-    store.replaceState({
-      ...store.state,
-      accountStore: { ...defaultAccountState },
-    });
-    routerStub = sinon.createStubInstance<VueRouter>(VueRouter);
+    routerStub = new VueRouter();
     sinon.stub(routerStub, 'currentRoute').get(() => ({ fullPath: '/' }));
     routerStub.afterEach = sinon.spy();
-
-    trackerService = new TrackerService(routerStub, store);
+    authenticated = ref(false);
 
     const watch$ = new Subject<any>();
 
@@ -38,20 +34,30 @@ describe('Tracker Service', () => {
       configure: sinon.stub(),
       activate: sinon.stub(),
       deactivate: sinon.stub(),
-      connected$: new Subject<any>(),
+      connectionState$: new Subject<any>(),
     };
 
-    trackerService.stomp = mockStomp;
-    trackerService['buildUrl'] = () => '';
+    TrackerApp = {
+      name: 'TrackerApp',
+      template: `
+        <div></div>
+      `,
+      setup() {
+        trackerService = useTrackerService({ stomp: mockStomp });
+        trackerService['buildUrl'] = () => '';
+      },
+    };
   });
 
   it('Should subscribe router activity', async () => {
+    shallowMount(TrackerApp, { localVue, router: routerStub, provide: { authenticated } });
     expect(routerStub.afterEach.calledOnce).toBeTruthy();
   });
 
   it('Should call activate on authenticated', async () => {
     // WHEN
-    store.commit('authenticated', {});
+    authenticated.value = true;
+    shallowMount(TrackerApp, { localVue, router: routerStub, provide: { authenticated } });
     await localVue.nextTick();
 
     // THEN
@@ -61,9 +67,11 @@ describe('Tracker Service', () => {
   it('Should send activity on connected', async () => {
     // GIVEN
     sinon.stub(routerStub, 'currentRoute').get(() => ({ fullPath: '/admin' }));
+    shallowMount(TrackerApp, { localVue, router: routerStub, provide: { authenticated } });
 
     // WHEN
-    mockStomp.connected$.next({});
+    mockStomp.connectionState$.next(1);
+    await localVue.nextTick();
 
     // THEN
     expect(mockStomp.publish.callCount).toBe(1);
@@ -74,11 +82,12 @@ describe('Tracker Service', () => {
 
   it('Should disconnect on logout', async () => {
     // GIVEN
-    store.commit('authenticated', {});
+    authenticated.value = true;
+    shallowMount(TrackerApp, { localVue, router: routerStub, provide: { authenticated } });
     await localVue.nextTick();
 
     // WHEN
-    store.commit('logout');
+    authenticated.value = false;
     await localVue.nextTick();
 
     // THEN

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
@@ -8,7 +8,6 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VueRouter from 'vue-router';
 import { ToastPlugin } from 'bootstrap-vue';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -24,7 +23,6 @@ localVue.use(ToastPlugin);
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
 
 describe('UserManagementEdit Component', () => {
@@ -46,7 +44,6 @@ describe('UserManagementEdit Component', () => {
       ],
     });
     mountOptions = {
-      store,
       router,
 <%_ if (enableTranslation) { _%>
       i18n,

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
@@ -8,7 +8,6 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ToastPlugin } from 'bootstrap-vue';
 import VueRouter from 'vue-router';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -24,7 +23,6 @@ localVue.use(ToastPlugin);
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
 localVue.component('b-badge', {});
 localVue.component('router-link', {});
@@ -61,7 +59,6 @@ describe('UserManagementView Component', () => {
       router.push('/' + <%- tsKeyId %>);
 
       const wrapper = shallowMount<UserManagementViewComponentType>(UserManagementView, {
-        store,
         localVue,
         router,
 <%_ if (enableTranslation) { _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -1,13 +1,13 @@
 <%_
 const tsKeyId = this.generateTestEntityId(user.primaryKey.type);
 _%>
+import { ref } from 'vue';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ToastPlugin } from 'bootstrap-vue';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -22,7 +22,6 @@ localVue.use(ToastPlugin);
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
 localVue.component('router-link', {});
 localVue.component('jhi-sort-indicator', {});
@@ -37,20 +36,12 @@ const axiosStub = {
 describe('UserManagement Component', () => {
   let userManagement: UserManagementComponentType;
 
-  const account = {
-    firstName: 'John',
-    lastName: 'Doe',
-    email: 'john.doe@jhipster.org'
-  };
-
   beforeEach(() => {
     axiosStub.put.reset();
     axiosStub.get.reset();
     axiosStub.get.resolves({ headers: {} });
 
-    store.commit('authenticated', account);
     const wrapper = shallowMount<UserManagementComponentType>(UserManagement, {
-      store,
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
@@ -58,7 +49,10 @@ describe('UserManagement Component', () => {
       stubs: {
         bPagination: true,
         jhiItemCount: true,
-        bModal: true
+        bModal: true,
+      },
+      provide: {
+        currentUsername: ref(''),
       },
     });
     userManagement = wrapper.vm;

--- a/generators/vue/templates/src/test/javascript/spec/app/core/error/error.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/core/error/error.component.spec.ts.ejs
@@ -1,10 +1,10 @@
+import { Ref, ref } from 'vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 
 import Error from '@/core/error/error.vue';
 import type ErrorComponent from '@/core/error/error.component';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -17,15 +17,16 @@ localVue.use(VueRouter);
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 const customErrorMsg = 'An error occurred.';
 
 describe('Error component', () => {
   let error: ErrorComponentType;
   let loginService: LoginService;
   let router: VueRouter;
+  let authenticated: Ref<boolean>;
 
   beforeEach(() => {
+    authenticated = ref(false);
     router = new VueRouter({
       routes: [
         {
@@ -63,11 +64,11 @@ describe('Error component', () => {
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      store,
       router,
       localVue,
       provide: {
         loginService,
+        authenticated,
       },
     });
     error = wrapper.vm;
@@ -88,11 +89,11 @@ describe('Error component', () => {
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      store,
       router,
       localVue,
       provide: {
         loginService,
+        authenticated,
       },
     });
     error = wrapper.vm;
@@ -113,11 +114,11 @@ describe('Error component', () => {
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      store,
       router,
       localVue,
       provide: {
         loginService,
+        authenticated,
       },
     });
     error = wrapper.vm;
@@ -142,11 +143,11 @@ describe('Error component', () => {
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      store,
       router,
       localVue,
       provide: {
         loginService,
+        authenticated,
       },
     });
     error = wrapper.vm;

--- a/generators/vue/templates/src/test/javascript/spec/app/core/home/home.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/core/home/home.component.spec.ts.ejs
@@ -1,8 +1,8 @@
+import { ref } from 'vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Home from '@/core/home/home.vue';
 import type HomeComponent from '@/core/home/home.component';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -10,7 +10,6 @@ import { initI18N } from '@/shared/config/config';
 type HomeComponentType = Vue & InstanceType<typeof HomeComponent>;
 
 const localVue = createLocalVue();
-const store = useStore();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
@@ -18,6 +17,8 @@ localVue.component('router-link', {});
 
 describe('Home', () => {
   let home: HomeComponentType;
+  let authenticated;
+  let currentUsername;
 <%_ if (authenticationTypeJwt) { _%>
   const loginService = { openLogin: jest.fn() };
 <%_ } else if (authenticationTypeSession) { _%>
@@ -27,15 +28,18 @@ describe('Home', () => {
 <%_ } _%>
 
   beforeEach(() => {
+    authenticated = ref(false);
+    currentUsername = ref('');
     const wrapper = shallowMount<HomeComponentType>(Home, {
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      store,
       localVue,
       provide: {
         loginService,
-      }
+        authenticated,
+        currentUsername,
+      },
     });
     home = wrapper.vm;
   });
@@ -46,7 +50,8 @@ describe('Home', () => {
   });
 
   it('should have user data set after authentication', () => {
-    store.commit('authenticated', {login: 'test'});
+    authenticated.value = true;
+    currentUsername.value = 'test';
 
     expect(home.authenticated).toBeTruthy();
     expect(home.username).toBe('test');

--- a/generators/vue/templates/src/test/javascript/spec/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import JhiNavbar from '@/core/jhi-navbar/jhi-navbar.vue';
 import type JhiNavbarComponent from '@/core/jhi-navbar/jhi-navbar.component';
@@ -34,7 +35,7 @@ describe('JhiNavbar', () => {
   let router: VueRouter;
   const accountService = { hasAnyAuthorityAndCheckAuth: jest.fn().mockImplementation(() => Promise.resolve(true)) };
 <%_ if (enableTranslation) { _%>
-  const translationService = { refreshTranslation: jest.fn() };
+  const changeLanguage = jest.fn();
 <%_ } _%>
 
   beforeEach(() => {
@@ -58,19 +59,15 @@ describe('JhiNavbar', () => {
       localVue,
       provide: {
         loginService,
+        currentLanguage: computed(() => 'foo'),
 <%_ if (enableTranslation) { _%>
-        translationService,
+        changeLanguage,
 <%_ } _%>
         accountService,
       },
     });
     jhiNavbar = wrapper.vm;
   });
-<%_ if (enableTranslation) { _%>
-  it('should refresh translations', () => {
-    expect(translationService.refreshTranslation).toHaveBeenCalled();
-  });
-<%_ } _%>
 
   it('should not have user data set', () => {
     expect(jhiNavbar.authenticated).toBeFalsy();
@@ -138,14 +135,12 @@ describe('JhiNavbar', () => {
   it('should call translationService when changing language', () => {
     jhiNavbar.changeLanguage('fr');
 
-    expect(translationService.refreshTranslation).toHaveBeenCalled();
+    expect(changeLanguage).toHaveBeenCalled();
   });
 
   it('should check for correct language', () => {
-    store.commit('currentLanguage', 'fr');
-
     expect(jhiNavbar.isActiveLanguage('en')).toBeFalsy();
-    expect(jhiNavbar.isActiveLanguage('fr')).toBeTruthy();
+    expect(jhiNavbar.isActiveLanguage('foo')).toBeTruthy();
   });
 <%_ } _%>
 });

--- a/generators/vue/templates/src/test/javascript/spec/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -3,6 +3,8 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import JhiNavbar from '@/core/jhi-navbar/jhi-navbar.vue';
 import type JhiNavbarComponent from '@/core/jhi-navbar/jhi-navbar.component';
 import VueRouter from 'vue-router';
+import { createTestingPinia } from '@pinia/testing';
+import { PiniaVuePlugin } from 'pinia';
 
 import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
@@ -14,10 +16,12 @@ import LoginService from '@/account/login.service';
 type JhiNavbarComponentType = Vue & InstanceType<typeof JhiNavbarComponent>;
 
 const localVue = createLocalVue();
+localVue.use(PiniaVuePlugin);
+const pinia = createTestingPinia({ stubActions: false });
+const store = useStore();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', {});
 localVue.component('b-navbar', {});
 localVue.component('b-navbar-nav', {});
@@ -54,7 +58,7 @@ describe('JhiNavbar', () => {
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      store,
+      pinia,
       router,
       localVue,
       provide: {
@@ -76,13 +80,13 @@ describe('JhiNavbar', () => {
   });
 
   it('should have user data set after authentication', () => {
-    store.commit('authenticated', { login: 'test' });
+    store.setAuthentication({ login: 'test' });
 
     expect(jhiNavbar.authenticated).toBeTruthy();
   });
 
   it('should have profile info set after info retrieved', () => {
-    store.commit('setActiveProfiles', ['prod', 'api-docs']);
+    store.setActiveProfiles(['prod', 'api-docs']);
 
     expect(jhiNavbar.openAPIEnabled).toBeTruthy();
     expect(jhiNavbar.inProduction).toBeTruthy();
@@ -104,7 +108,7 @@ describe('JhiNavbar', () => {
   });
 
   it('logout should clear credentials', async () => {
-    store.commit('authenticated', { login: 'test' });
+    store.setAuthentication({ login: 'test' });
 <%_ if (authenticationTypeOauth2) { _%>
     const logoutUrl = '/to-match';
     (loginService.logout as any).mockReturnValue(Promise.resolve({ data: { logoutUrl } }));

--- a/generators/vue/templates/src/test/javascript/spec/app/core/ribbon/ribbon.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/core/ribbon/ribbon.component.spec.ts.ejs
@@ -2,7 +2,9 @@ import { createLocalVue, shallowMount } from "@vue/test-utils";
 import Ribbon from '@/core/ribbon/ribbon.vue';
 import type RibbonComponent from '@/core/ribbon/ribbon.component';
 
-import { useStore } from '@/store';
+import { PiniaVuePlugin } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { AccountStore, useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -10,7 +12,8 @@ import { initI18N } from '@/shared/config/config';
 type RibbonComponentType = Vue & InstanceType<typeof RibbonComponent>;
 
 const localVue = createLocalVue();
-const store = useStore();
+const pinia = createTestingPinia({ stubActions: false });
+localVue.use(PiniaVuePlugin);
 
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
@@ -18,39 +21,37 @@ const i18n = initI18N(localVue);
 
 describe('Ribbon', () => {
   let ribbon: RibbonComponentType;
+  let store: AccountStore;
 
-  const wrap = async (managementInfo?: any) => {
+  beforeEach(async () => {
     const wrapper = shallowMount<RibbonComponentType>(Ribbon, {
 <%_ if (enableTranslation) { _%>
       i18n,
 <%_ } _%>
-      store,
+      pinia,
       localVue
     });
     ribbon = wrapper.vm;
     await ribbon.$nextTick();
-  }
-
-  beforeEach(() => {
-    store.commit('setRibbonOnProfiles', null);
+    store = useStore();
+    store.setRibbonOnProfiles(null);
   });
 
-  it('should not have ribbonEnabled when no data', async () => {
-    await wrap();
+  it('should not have ribbonEnabled when no data', () => {
     expect(ribbon.ribbonEnabled).toBeFalsy();
   });
 
   it('should have ribbonEnabled set to value in store', async () => {
     const profile = 'dev';
-    store.commit('setActiveProfiles', ['foo', profile, 'bar']);
-    store.commit('setRibbonOnProfiles', profile);
+    store.setActiveProfiles(['foo', profile, 'bar']);
+    store.setRibbonOnProfiles(profile);
     expect(ribbon.ribbonEnabled).toBeTruthy();
   });
 
   it('should not have ribbonEnabled when profile not activated', async () => {
     const profile = 'dev';
-    store.commit('setActiveProfiles', ['foo', 'bar']);
-    store.commit('setRibbonOnProfiles', profile);
+    store.setActiveProfiles(['foo', 'bar']);
+    store.setRibbonOnProfiles(profile);
     expect(ribbon.ribbonEnabled).toBeFalsy();
   });
 });

--- a/generators/vue/templates/src/test/javascript/spec/app/entities/_entityFolder/_entityFile-details.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/entities/_entityFolder/_entityFile-details.component.spec.ts.ejs
@@ -25,7 +25,6 @@ import sinon, { SinonStubbedInstance } from 'sinon';
 import { ToastPlugin } from 'bootstrap-vue';
 import VueRouter from 'vue-router';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -42,7 +41,6 @@ localVue.use(VueRouter);
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', {});
 localVue.component('router-link', {});
 
@@ -65,7 +63,6 @@ describe('Component Tests', () => {
       });
 
       mountOptions = {
-        store,
 <%_ if (enableTranslation) { _%>
         i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/entities/_entityFolder/_entityFile-update.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/entities/_entityFolder/_entityFile-update.component.spec.ts.ejs
@@ -24,7 +24,6 @@ import Router from 'vue-router';
 import { ToastPlugin } from 'bootstrap-vue';
 import VueRouter from 'vue-router';
 
-import { useStore } from '@/store';
 <%_ if (anyFieldIsTimeDerived) { _%>
 import dayjs from 'dayjs';
 import { DATE_TIME_LONG_FORMAT } from '@/shared/composables/date-format';
@@ -57,7 +56,6 @@ const localVue = createLocalVue();
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 const router = new Router();
 localVue.use(Router);
 localVue.use(ToastPlugin);
@@ -88,7 +86,6 @@ describe('Component Tests', () => {
       });
 
       mountOptions = {
-        store,
 <%_ if (enableTranslation) { _%>
         i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/entities/_entityFolder/_entityFile.component.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/entities/_entityFolder/_entityFile.component.spec.ts.ejs
@@ -24,7 +24,6 @@ import { shallowMount, createLocalVue, ThisTypedShallowMountOptions } from '@vue
 import sinon, { SinonStubbedInstance } from 'sinon';
 import { ToastPlugin } from 'bootstrap-vue';
 
-import { useStore } from '@/store';
 <%_ if (enableTranslation) { _%>
 import { initI18N } from '@/shared/config/config';
 <%_ } _%>
@@ -40,7 +39,6 @@ localVue.use(ToastPlugin);
 <%_ if (enableTranslation) { _%>
 const i18n = initI18N(localVue);
 <%_ } _%>
-const store = useStore();
 localVue.component('font-awesome-icon', {});
 localVue.component('b-badge', {});
 <%_ if (!paginationNo) { _%>
@@ -68,7 +66,6 @@ describe('Component Tests', () => {
       <%= entityInstance %>ServiceStub.retrieve.resolves({ headers: {} });
 
       mountOptions = {
-        store,
 <%_ if (enableTranslation) { _%>
         i18n,
 <%_ } _%>

--- a/generators/vue/templates/src/test/javascript/spec/app/entities/entities-menu.spec.ts.ejs
+++ b/generators/vue/templates/src/test/javascript/spec/app/entities/entities-menu.spec.ts.ejs
@@ -1,3 +1,4 @@
+import { ref } from 'vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import EntitiesMenu from '@/entities/entities-menu.vue';
 import type EntitiesMenuComponent from '@/entities/entities-menu.component';
@@ -25,6 +26,7 @@ describe('EntitiesMenu', () => {
         provide: {
           translationService,
           microfrontendI18n: true,
+          currentLanguage: ref('<%- nativeLanguage %>'),
         },
       });
     });

--- a/generators/vue/templates/webpack/webpack.microfrontend.js.jhi.vue.ejs
+++ b/generators/vue/templates/webpack/webpack.microfrontend.js.jhi.vue.ejs
@@ -45,7 +45,7 @@ const { DefinePlugin } = require('webpack');
           'vue-i18n': { singleton: true, shareScope: 'default' },
           'vue-i18n-bridge': { singleton: true, shareScope: 'default' },
           'vue-router': { singleton: true, shareScope: 'default' },
-          vuex: { singleton: true, shareScope: 'default' },
+          pinia: { singleton: true, shareScope: 'default' },
           '@/shared/security/authority': {
             singleton: true,
             shareScope: 'default',


### PR DESCRIPTION
- pinia is now the recommended store and supports vue 2 and vue 3.
- provide authentication status, currentUsername and currentLanguage as a reactive field globally instead of using the store at each component.
- provide changeLanguage as function globally instead of mixed store/service methods.
- languages is static don't need to be put into a store.
- remove unnecessary store from tests.

Related to https://github.com/jhipster/generator-jhipster/issues/12558.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
