### PR TITLE
Drop vue dependencies

### DIFF
--- a/generators/vue/templates/package.json
+++ b/generators/vue/templates/package.json
@@ -35,7 +35,6 @@
     "css-loader": "6.7.3",
     "css-minimizer-webpack-plugin": "5.0.0",
     "folder-hash": "4.0.4",
-    "fork-ts-checker-webpack-plugin": "7.3.0",
     "html-webpack-plugin": "5.5.1",
     "jest": "29.5.0",
     "jest-environment-jsdom": "29.5.0",

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -68,7 +68,6 @@
     "copy-webpack-plugin": "<%= nodeDependencies['copy-webpack-plugin'] %>",
     "css-loader": "<%= nodeDependencies['css-loader'] %>",
     "css-minimizer-webpack-plugin": "<%= nodeDependencies['css-minimizer-webpack-plugin'] %>",
-    "fork-ts-checker-webpack-plugin": "<%= nodeDependencies['fork-ts-checker-webpack-plugin'] %>",
 <%_ if (!skipJhipsterDependencies) { _%>
     "generator-jhipster": "<%= jhipsterVersion %>",
   <%_ blueprints.forEach(blueprint => { _%>

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -112,7 +112,6 @@
     "typescript": "<%= nodeDependencies['typescript'] %>",
     "@vue/vue2-jest": "<%= nodeDependencies['@vue/vue2-jest'] %>",
     "vue-loader": "<%= nodeDependencies['vue-loader'] %>",
-    "vue-template-compiler": "<%= nodeDependencies['vue'] %>",
     "webpack": "<%= nodeDependencies['webpack'] %>",
     "webpack-bundle-analyzer": "<%= nodeDependencies['webpack-bundle-analyzer'] %>",
     "webpack-cli": "<%= nodeDependencies['webpack-cli'] %>",

--- a/generators/vue/templates/webpack/webpack.prod.js.ejs
+++ b/generators/vue/templates/webpack/webpack.prod.js.ejs
@@ -22,7 +22,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const { styleLoaders } = require('./vue.utils');
 const config = require('./config');
@@ -98,22 +97,6 @@ const webpackConfig = {
       filename: 'content/[name].[contenthash].css',
       chunkFilename: 'content/[id].css'
     }),
-    // keep module.id stable when vendor modules does not change
-    new ForkTsCheckerWebpackPlugin(
-      {
-        typescript: {
-          vue: {
-            enabled: true,
-            compiler: 'vue-template-compiler',
-          },
-          diagnosticOptions: {
-            semantic: true,
-            syntactic: true,
-          },
-        },
-        formatter: 'codeframe',
-      }
-    ),
     new WorkboxPlugin.GenerateSW({
       clientsClaim: true,
       skipWaiting: true,


### PR DESCRIPTION
- vue-template-compiler is not required since vue 2.7.
- latest fork-ts-checker-webpack-plugin doesn't support vue and vue 3 has no support at any version.

Related to https://github.com/jhipster/generator-jhipster/issues/12558
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
