### PR TITLE
Add username to PostgreSQL healthcheck

### DIFF
--- a/generators/docker-compose/__snapshots__/docker-compose.spec.mts.snap
+++ b/generators/docker-compose/__snapshots__/docker-compose.spec.mts.snap
@@ -543,7 +543,7 @@ jhipster:
     healthcheck:
       test:
         - CMD-SHELL
-        - pg_isready
+        - pg_isready -U $\${POSTGRES_USER}
       interval: 5s
       timeout: 5s
       retries: 10
@@ -873,7 +873,7 @@ jhipster:
     healthcheck:
       test:
         - CMD-SHELL
-        - pg_isready
+        - pg_isready -U $\${POSTGRES_USER}
       interval: 5s
       timeout: 5s
       retries: 10
@@ -1221,7 +1221,7 @@ jhipster:
     healthcheck:
       test:
         - CMD-SHELL
-        - pg_isready
+        - pg_isready -U $\${POSTGRES_USER}
       interval: 5s
       timeout: 5s
       retries: 10
@@ -1493,7 +1493,7 @@ jhipster:
     healthcheck:
       test:
         - CMD-SHELL
-        - pg_isready
+        - pg_isready -U $\${POSTGRES_USER}
       interval: 5s
       timeout: 5s
       retries: 10

--- a/generators/docker/templates/src/main/docker/postgresql.yml.ejs
+++ b/generators/docker/templates/src/main/docker/postgresql.yml.ejs
@@ -28,7 +28,7 @@ services:
       - POSTGRES_PASSWORD=
       - POSTGRES_HOST_AUTH_METHOD=trust
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready']
+      test: ['CMD-SHELL', 'pg_isready -U $${POSTGRES_USER}']
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
This makes the following fatal warning go away.

```
gateway-postgresql-1            | 2023-05-15 16:02:46.432 UTC [106] FATAL:  role "root" does not exist
```

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
