### PR TITLE
Rework composeWith api

### DIFF
--- a/generators/app/generator.mjs
+++ b/generators/app/generator.mjs
@@ -364,7 +364,7 @@ export default class JHipsterAppGenerator extends BaseApplicationGenerator {
         await this.composeWithJHipster(GENERATOR_COMMON);
         if (enableTranslation) {
           await this.composeWithJHipster(GENERATOR_LANGUAGES, {
-            regenerate: true,
+            generatorOptions: { regenerate: true },
           });
         }
         if (!skipServer) {
@@ -389,9 +389,12 @@ export default class JHipsterAppGenerator extends BaseApplicationGenerator {
         if (!this.jhipsterConfig.pages || this.jhipsterConfig.pages.length === 0) return;
         await Promise.all(
           this.jhipsterConfig.pages.map(page => {
-            return this.composeWithJHipster(page.generator || GENERATOR_PAGE, [page.name], {
-              skipInstall: true,
-              page,
+            return this.composeWithJHipster(page.generator || GENERATOR_PAGE, {
+              generatorArgs: [page.name],
+              generatorOptions: {
+                skipInstall: true,
+                page,
+              },
             });
           })
         );

--- a/generators/base/generator-base-todo.mts
+++ b/generators/base/generator-base-todo.mts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 import assert from 'assert';
-import path, { isAbsolute } from 'path';
+import path from 'path';
 import _ from 'lodash';
 import chalk from 'chalk';
-import fs, { existsSync } from 'fs';
+import fs from 'fs';
 import { exec } from 'child_process';
 import os from 'os';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import YeomanGenerator, { type Storage } from 'yeoman-generator';
 import { formatDateForChangelog, normalizePathEnd, createJHipster7Context, upperFirstCamelCase } from './support/index.mjs';
@@ -213,61 +213,6 @@ export default abstract class JHipsterBaseGenerator extends YeomanGenerator<JHip
   rewriteFile(filePath, needle, content) {
     const rewriteFileModel = this.needleApi.base.generateFileModel(filePath, needle, content);
     return this.needleApi.base.addBlockContentToFile(rewriteFileModel);
-  }
-
-  /**
-   * Compose with a jhipster generator using default jhipster config.
-   * @param {string} generator - jhipster generator.
-   * @param {object} args - args to pass
-   * @param {object} [options] - options to pass
-   * @param {object} [composeOptions] - compose options
-   * @return {object} the composed generator
-   */
-  async composeWithJHipster(generator: string, args?: any, options?: any, { immediately = false } = {}) {
-    assert(typeof generator === 'string', 'generator should to be a string');
-    if (!isAbsolute(generator)) {
-      const namespace = generator.includes(':') ? generator : `jhipster:${generator}`;
-      if (!Array.isArray(args)) {
-        options = args;
-        args = [];
-      }
-
-      if ((this as any).env.get(namespace)) {
-        generator = namespace;
-      } else {
-        // Keep test compatibily were jhipster lookup does not run.
-        const found = ['/index.js', '/index.cjs', '/index.mjs', '/index.ts', '/index.cts', '/index.mts'].find(extension => {
-          const pathToLook = join(__dirname, `../${generator}${extension}`);
-          return existsSync(pathToLook) ? pathToLook : undefined;
-        });
-        if (!found) {
-          throw new Error(`Generator ${generator} was not found`);
-        }
-        generator = join(__dirname, `../${generator}${found}`);
-      }
-    }
-
-    return this.env.composeWith(generator, {
-      generatorArgs: args,
-      generatorOptions: {
-        ...this.options,
-        destinationRoot: (this as any)._destinationRoot,
-        configOptions: this.configOptions,
-        ...options,
-      },
-      schedule: !immediately,
-    });
-  }
-
-  /**
-   * Compose with a jhipster generator using default jhipster config, but queue it immediately.
-   * @param {String} generator - jhipster generator.
-   * @param {String[]} [args] - arguments to pass
-   * @param {Object} [options] - options to pass
-   * @return {Promise<any>} the composed generator
-   */
-  dependsOnJHipster(generator: string, args?: string[], options?: any) {
-    return (this as any).composeWithJHipster(generator, args, options, { immediately: true });
   }
 
   /**

--- a/generators/client/needle-client.spec.mts
+++ b/generators/client/needle-client.spec.mts
@@ -7,9 +7,7 @@ const mockBlueprintSubGen: any = class extends ClientGenerator {
   constructor(args, opts, features) {
     super(args, opts, features);
 
-    const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
-
-    if (!jhContext) {
+    if (!this.jhipsterContext) {
       throw new Error('This is a JHipster blueprint and should be used only like jhipster --blueprints myblueprint');
     }
 

--- a/generators/entities/generator.mjs
+++ b/generators/entities/generator.mjs
@@ -113,7 +113,7 @@ export default class EntitiesGenerator extends BaseApplicationGenerator {
   get composing() {
     return {
       async composeApp() {
-        await this.composeWithJHipster(GENERATOR_APP, { skipPriorities: ['writing', 'postWriting'] });
+        await this.composeWithJHipster(GENERATOR_APP, { generatorOptions: { skipPriorities: ['writing', 'postWriting'] } });
       },
     };
   }

--- a/generators/entity/generator.mjs
+++ b/generators/entity/generator.mjs
@@ -131,9 +131,11 @@ export default class EntityGenerator extends BaseApplicationGenerator {
 
     if (!this.fromBlueprint) {
       await this.composeWithBlueprints(GENERATOR_ENTITY, {
-        entityExisted,
-        configExisted,
-        arguments: [name],
+        generatorOptions: {
+          entityExisted,
+          configExisted,
+          arguments: [name],
+        },
       });
     }
 
@@ -297,12 +299,14 @@ export default class EntityGenerator extends BaseApplicationGenerator {
       async composeEntities() {
         // We need to compose with others entities to update relationships.
         await this.composeWithJHipster(GENERATOR_ENTITIES, {
-          entities: this.options.singleEntity ? [this.context.name] : undefined,
-          regenerate: true,
-          writeEveryEntity: false,
-          composedEntities: [this.context.name],
-          skipDbChangelog: this.options.skipDbChangelog,
-          skipInstall: this.options.skipInstall,
+          generatorOptions: {
+            entities: this.options.singleEntity ? [this.context.name] : undefined,
+            regenerate: true,
+            writeEveryEntity: false,
+            composedEntities: [this.context.name],
+            skipDbChangelog: this.options.skipDbChangelog,
+            skipInstall: this.options.skipInstall,
+          },
         });
       },
     };

--- a/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
+++ b/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
@@ -47,7 +47,7 @@ export default class extends <%= generatorClass %>Generator {
     if (this.options.help) return;
   <%_ if (!customGenerator) { _%>
 
-    if (!this.options.jhipsterContext) {
+    if (!this.jhipsterContext) {
       throw new Error(`This is a JHipster blueprint and should be used only like ${chalk.yellow('jhipster --blueprints <%= application.baseName %>')}`);
     }
     <%_ if (sbs) { _%>

--- a/generators/jdl/generator.mts
+++ b/generators/jdl/generator.mts
@@ -201,32 +201,38 @@ export default class JdlGenerator extends BaseGenerator {
           return;
         }
 
-        const generationOptions: any = { reproducible: this.reproducible, force: this.force };
+        const generatorOptions: any = { reproducible: this.reproducible, force: this.force };
 
         if (this.ignoreApplication || this.applications.length === 0) {
           if (this.applications.length === 0) {
             const entities = this.exportedEntities;
             await this.composeWithJHipster(GENERATOR_ENTITIES, {
-              ...generationOptions,
-              entities: entities.map(entity => entity.name),
+              generatorOptions: {
+                ...generatorOptions,
+                entities: entities.map(entity => entity.name),
+              },
             });
           } else {
             for (const app of this.applications) {
               await this.composeWithJHipster(GENERATOR_ENTITIES, {
-                ...generationOptions,
-                entities: app.entities.map(entity => entity.name),
-                destinationRoot: app.folder ? this.destinationPath(app.folder) : undefined,
+                generatorOptions: {
+                  ...generatorOptions,
+                  entities: app.entities.map(entity => entity.name),
+                  destinationRoot: app.folder ? this.destinationPath(app.folder) : undefined,
+                },
               });
             }
           }
         } else if (this.applications.length === 1) {
           this.logger.debug('Generating 1 application');
-          await this.composeWithJHipster(GENERATOR_APP, generationOptions);
+          await this.composeWithJHipster(GENERATOR_APP, { generatorOptions });
         } else {
           this.logger.debug(`Generating ${this.applications.length}applications`);
           await this.composeWithJHipster(GENERATOR_WORKSPACES, {
-            workspacesFolders: this.applications.map(app => app.folder),
-            generateApplications: async () => this.runNonInteractive(this.applications, generationOptions),
+            generatorOptions: {
+              workspacesFolders: this.applications.map(app => app.folder),
+              generateApplications: async () => this.runNonInteractive(this.applications, generatorOptions),
+            } as any,
           });
         }
       },
@@ -247,9 +253,11 @@ export default class JdlGenerator extends BaseGenerator {
             this.logger.debug(`Generating deployment: ${JSON.stringify(deploymentConfig, null, 2)}`);
 
             await this.composeWithJHipster(deploymentType, {
-              destinationRoot: this.destinationPath(deploymentType),
-              force: true,
-              skipPrompts: true,
+              generatorOptions: {
+                destinationRoot: this.destinationPath(deploymentType),
+                force: true,
+                skipPrompts: true,
+              } as any,
             });
           }
         }

--- a/generators/languages/generator.mjs
+++ b/generators/languages/generator.mjs
@@ -99,8 +99,10 @@ export default class LanguagesGenerator extends BaseApplicationGenerator {
     if (!this.fromBlueprint) {
       this.supportedLanguages = supportedLanguages;
       const composedBlueprints = await this.composeWithBlueprints('languages', {
-        languages: this.languagesToApply,
-        arguments: this.options.languages,
+        generatorOptions: {
+          languages: this.languagesToApply,
+          arguments: this.options.languages,
+        },
       });
       for (const blueprint of composedBlueprints) {
         if (blueprint.supportedLanguages) {

--- a/generators/liquibase/generator.mts
+++ b/generators/liquibase/generator.mts
@@ -337,9 +337,10 @@ export default class LiquibaseGenerator extends BaseApplicationGenerator {
   _composeWithIncrementalChangelogProvider(entities: any[], databaseChangelog: any) {
     const skipWriting = entities!.length !== 0 && !entities!.includes(databaseChangelog.entityName);
     return this.composeWithJHipster(GENERATOR_LIQUIBASE_CHANGELOGS, {
-      databaseChangelog,
-      skipWriting,
-      configOptions: this.configOptions,
+      generatorOptions: {
+        databaseChangelog,
+        skipWriting,
+      } as any,
     });
   }
 

--- a/generators/spring-controller/generator.mjs
+++ b/generators/spring-controller/generator.mjs
@@ -63,7 +63,7 @@ export default class SpringControllerGenerator extends BaseGenerator {
 
   async beforeQueue() {
     if (!this.fromBlueprint) {
-      await this.composeWithBlueprints(GENERATOR_SPRING_CONTROLLER, { arguments: [this.name] });
+      await this.composeWithBlueprints(GENERATOR_SPRING_CONTROLLER, { generatorArgs: [this.name] });
     }
   }
 

--- a/generators/spring-service/generator.mjs
+++ b/generators/spring-service/generator.mjs
@@ -45,7 +45,7 @@ export default class SpringServiceGenerator extends BaseGenerator {
 
   async beforeQueue() {
     if (!this.fromBlueprint) {
-      await this.composeWithBlueprints(GENERATOR_SPRING_SERVICE, { arguments: [this.name] });
+      await this.composeWithBlueprints(GENERATOR_SPRING_SERVICE, { generatorArgs: [this.name] });
     }
   }
 

--- a/generators/workspaces/generator.mjs
+++ b/generators/workspaces/generator.mjs
@@ -105,7 +105,7 @@ export default class WorkspacesGenerator extends BaseGenerator {
           await this.generateApplications.call(this);
         } else {
           for (const appName of this.workspacesFolders) {
-            await this.composeWithJHipster(this.generateWith, { destinationRoot: this.destinationPath(appName) });
+            await this.composeWithJHipster(this.generateWith, { generatorOptions: { destinationRoot: this.destinationPath(appName) } });
           }
         }
       },

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -1,7 +1,0 @@
-import { CopyOptions } from 'mem-fs-editor';
-
-declare module 'mem-fs-editor' {
-  interface CopyOptions {
-    noGlob?: boolean;
-  }
-}

--- a/test/needle-api/needle-client-i18n.spec.mts
+++ b/test/needle-api/needle-client-i18n.spec.mts
@@ -11,9 +11,7 @@ const mockBlueprintSubGen: any = class extends LanguagesGenerator {
   constructor(args, opts, features) {
     super(args, opts, features);
 
-    const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
-
-    if (!jhContext) {
+    if (!this.jhipsterContext) {
       throw new Error('This is a JHipster blueprint and should be used only like jhipster --blueprints myblueprint');
     }
 

--- a/test/needle-api/needle-client-react-generator.spec.mts
+++ b/test/needle-api/needle-client-react-generator.spec.mts
@@ -12,9 +12,7 @@ const mockReactBlueprintSubGen: any = class extends ReactGenerator {
   constructor(args, opts, features) {
     super(args, opts, features);
 
-    const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
-
-    if (!jhContext) {
+    if (!this.jhipsterContext) {
       throw new Error('This is a JHipster blueprint and should be used only like jhipster --blueprints myblueprint');
     }
 

--- a/test/needle-api/needle-client-react.spec.mts
+++ b/test/needle-api/needle-client-react.spec.mts
@@ -12,9 +12,7 @@ const mockBlueprintSubGen: any = class extends ReactGenerator {
   constructor(args, opts, features) {
     super(args, opts, features);
 
-    const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
-
-    if (!jhContext) {
+    if (!this.jhipsterContext) {
       throw new Error('This is a JHipster blueprint and should be used only like jhipster --blueprints myblueprint');
     }
 

--- a/test/needle-api/needle-client-vue-generator.spec.mts
+++ b/test/needle-api/needle-client-vue-generator.spec.mts
@@ -12,8 +12,7 @@ const { VUE } = clientFrameworkTypes;
 const mockBlueprintSubGen: any = class extends VueGenerator {
   constructor(args, opts, features) {
     super(args, opts, features);
-    const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
-    if (!jhContext) {
+    if (!this.jhipsterContext) {
       throw new Error("This is a JHipster blueprint and should be used only like 'jhipster --blueprints myblueprint')}");
     }
     this.sbsBlueprint = true;

--- a/test/needle-api/needle-client-webpack.spec.mts
+++ b/test/needle-api/needle-client-webpack.spec.mts
@@ -13,9 +13,7 @@ const mockBlueprintSubGen: any = class extends ClientGenerator {
   constructor(args, opts, features) {
     super(args, opts, features);
 
-    const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
-
-    if (!jhContext) {
+    if (!this.jhipsterContext) {
       throw new Error('This is a JHipster blueprint and should be used only like jhipster --blueprints myblueprint');
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": ["cli/**/*", "generators/**/*", "jdl/**/*", "lib/**/*"],
   "exclude": ["**/*.spec.*", "**/__*/**", "**/node_modules", "**/.*/"],
-  "files": ["lib/global.d.ts"],
   "compilerOptions": {
     /* Language and Environment */
     "target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,


### PR DESCRIPTION
`composeWith` has too many optional parameters. Convert to a single `options`.

Closes https://github.com/jhipster/generator-jhipster/issues/21959
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
