### PR TITLE
prevent leakage of user information via api

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -41,6 +41,9 @@ import org.springframework.web.ErrorResponseException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 <%_ if (reactive) { _%>
+<%_ if (!skipUserManagement) { _%>
+import org.springframework.security.core.AuthenticationException;
+<%_ } _%>
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.http.MediaType;
@@ -146,12 +149,25 @@ _%>
 
     private ProblemDetailWithCause getProblemDetailWithCause(Throwable ex) {
 <%_ if (!skipUserManagement) { _%>
-        if(ex instanceof <%= packageName %>.service.EmailAlreadyUsedException)
-            return new EmailAlreadyUsedException().getProblemDetailWithCause();
-        if(ex instanceof <%= packageName %>.service.UsernameAlreadyUsedException )
-            return new LoginAlreadyUsedException().getProblemDetailWithCause();
+        if(ex instanceof <%= packageName %>.service.EmailAlreadyUsedException ||
+            ex instanceof <%= packageName %>.service.UsernameAlreadyUsedException) {
+                // return 201 - CREATED on purpose to not reveal information to potential attackers
+                // see https://github.com/jhipster/generator-jhipster/issues/21731
+                return ProblemDetailWithCauseBuilder.instance()
+                    .withStatus(201).build();
+            }
         if(ex instanceof <%= packageName %>.service.InvalidPasswordException )
             return (ProblemDetailWithCause) new InvalidPasswordException().getBody();
+
+        <%_ if (reactive) { _%>
+        if (ex instanceof AuthenticationException) {
+            // Ensure no information about existing users is revealed via failed authentication attempts
+            return ProblemDetailWithCauseBuilder.instance()
+                .withStatus(toStatus(ex).value())
+                .withTitle("Unauthorized")
+                .withDetail("Invalid credentials").build();
+        }
+        <%_ } _%>
 <%_ } _%>
         if(ex instanceof ErrorResponseException exp && exp.getBody() instanceof ProblemDetailWithCause)
             return (ProblemDetailWithCause) exp.getBody();

--- a/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
@@ -529,14 +529,14 @@ class AccountResourceIT {
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(TestUtil.convertObjectToJsonBytes(secondUser))
             .exchange()
-            .expectStatus().isBadRequest();
+            .expectStatus().isCreated();
 <%_ } else { _%>
         restAccountMockMvc.perform(
             post("/api/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtil.convertObjectToJsonBytes(secondUser))<% if (authenticationUsesCsrf) { %>
                 .with(csrf())<% } %>)
-            .andExpect(status().is4xxClientError());
+            .andExpect(status().isCreated());
 <%_ } _%>
     }
 
@@ -655,14 +655,14 @@ class AccountResourceIT {
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(TestUtil.convertObjectToJsonBytes(secondUser))
             .exchange()
-            .expectStatus().is4xxClientError();
+            .expectStatus().isCreated();
 <%_ } else { _%>
         restAccountMockMvc.perform(
             post("/api/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtil.convertObjectToJsonBytes(secondUser))<% if (authenticationUsesCsrf) { %>
                 .with(csrf())<% } %>)
-            .andExpect(status().is4xxClientError());
+            .andExpect(status().isCreated());
 <%_ } _%>
     }
 

--- a/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIT_reactive.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIT_reactive.java.ejs
@@ -19,6 +19,8 @@
 package <%= packageName %>.web.rest.errors;
 
 import <%= packageName %>.IntegrationTest;
+import org.hamcrest.core.AnyOf;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -120,7 +122,8 @@ class ExceptionTranslatorIT {
             .expectBody()
             .jsonPath("$.message").isEqualTo("error.http.401")
             .jsonPath("$.path").isEqualTo("/api/exception-translator-test/unauthorized")
-            .jsonPath("$.detail").isEqualTo("test authentication failed!");
+            .jsonPath("$.detail")
+            .value(AnyOf.anyOf(IsEqual.equalTo("test authentication failed!"), IsEqual.equalTo("Invalid credentials")));
     }
 
     @Test


### PR DESCRIPTION
This PR does two things:

For imperative and reactive during registration we do not expose an error (e.g. username already exists) via the api. Therefore for the caller successful registration and failed registration look the same, so there is no way (except some sophisticated things like measuring response times) to gain knowledge about existing users and emails.

Second thing is only for reactive as for imperative spring security already took care of it. 
In case authentication fails we do not expose the exact error to the caller/the api (e.g. invalid password) as this would also reveal that the login was correct. The generic error now only states `Invalid credentials` which is the same for non reactive apps.

closes #21731

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
