### PR TITLE
Fix generation of incorrect code for enums where key equals value.

### DIFF
--- a/generators/server/templates/entity/src/main/java/package/domain/enumeration/Enum.java.ejs
+++ b/generators/server/templates/entity/src/main/java/package/domain/enumeration/Enum.java.ejs
@@ -28,7 +28,12 @@ package <%= entityAbsolutePackage %>.domain.enumeration;
 public enum <%= enumName %> {
 <%_ if (withoutCustomValues) { _%>
 <%= enumValues.map(enumValue => `${enumValue.comment && `\n${enumValue.comment}\n` || ''}    ${enumValue.name}`).join(', ') %>
-<%_ } else {
+<%_ } else {  
+  // The following code redefines the variable state to be 'without CustomValue' when name equals value.
+  withoutCustomValues = enumValues.every(({name, value}) => name === value);  
+  withCustomValues = enumValues.every(({name, value}) => name !== value);  
+  withSomeCustomValues = !withoutCustomValues && !withCustomValues;
+
   enumValues.forEach((enumWithCustomValue, index) => {
     if (enumWithCustomValue.comment){  _%>
 <%= enumWithCustomValue.comment %>
@@ -39,12 +44,12 @@ public enum <%= enumName %> {
     <%= enumWithCustomValue.name %>("<%= enumWithCustomValue.value %>")<% if (index < enumValues.length - 1) { %>,<% } else { %>;<% } %>
     <%_ }
   }); _%>
-
+  <%_ if (!withoutCustomValues) { _%>
     private<% if (withCustomValues) { %> final<% } %> String value;
 
-  <%_ if (withSomeCustomValues) { _%>
+    <%_ if (withSomeCustomValues) { _%>
     <%= enumName %>() {}
-  <%_ } _%>
+    <%_ } _%>
 
     <%= enumName %>(String value) {
         this.value = value;
@@ -53,5 +58,6 @@ public enum <%= enumName %> {
     public String getValue() {
         return value;
     }
+  <%_ } _%>  
 <%_ } _%>
 }

--- a/test-integration/samples/.jhipster/FieldTestEnumWithValue.json
+++ b/test-integration/samples/.jhipster/FieldTestEnumWithValue.json
@@ -8,7 +8,9 @@
   "fields": [
     { "fieldName": "myFieldA", "fieldType": "MyEnumA", "fieldValues": "AAA,BBB" },
     { "fieldName": "myFieldB", "fieldType": "MyEnumB", "fieldValues": "AAA (aaa_aaa),BBB" },
-    { "fieldName": "myFieldC", "fieldType": "MyEnumC", "fieldValues": "AAA (aaa_aaa),BBB (b and b)" }
+    { "fieldName": "myFieldC", "fieldType": "MyEnumC", "fieldValues": "AAA (aaa_aaa),BBB (b and b)" },
+    { "fieldName": "myFieldD", "fieldType": "MyEnumD", "fieldValues": "AAA (AAA),BBB (BBB)" },
+    { "fieldName": "myFieldE", "fieldType": "MyEnumE", "fieldValues": "AAA (aaa_aaa),BBB (BBB)" }
   ],
   "fluentMethods": true,
   "jpaMetamodelFiltering": false,


### PR DESCRIPTION
In sections where incorrect code was being generated, the process has been redefined to include the 'without CustomValue' state when the key equals the value. The area of correction is confined to the Java enum declaration. 
(More significant modifications such as a complete redefinition of 'without CustomValue' would impact the client side. If that's deemed necessary, I'm willing to implement it.)

Related tests have been added.

I have checked the differences in the generated code for 'ng-default', 'react-default', and 'vue-default' in jhipster-samples, and confirmed that the changes are as intended.

Resolves #22192

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
