### PR TITLE
Background Color Correction

### DIFF
--- a/generators/angular/templates/src/main/webapp/content/scss/_bootstrap-variables.scss.ejs
+++ b/generators/angular/templates/src/main/webapp/content/scss/_bootstrap-variables.scss.ejs
@@ -53,7 +53,7 @@ $border-radius-sm: 0.1rem;
 // Body:
 // Settings for the `<body>` element.
 
-$body-bg: #e4e5e6;
+$body-bg: #ffffff;
 
 // Typography:
 // Font, line-height, and color for body text, headings, and more.

--- a/generators/react/templates/src/main/webapp/app/_bootstrap-variables.scss.ejs
+++ b/generators/react/templates/src/main/webapp/app/_bootstrap-variables.scss.ejs
@@ -44,5 +44,5 @@ $border-radius-sm:       .1rem;
 // Body:
 // Settings for the `<body>` element.
 
-$body-bg:                   #e4e5e6;
+$body-bg:                   #ffffff;
 <%_ } _%>


### PR DESCRIPTION
fix #22406 

I have fixed the background color for both Angular and React by setting it to white. No adjustment was needed for Vue, as it was already set to white (it uses a different style from the others).

With this change, the default theme now closely resembles that of JHipster 7.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
