### PR TITLE
Fix unauthorized error handling

### DIFF
--- a/generators/react/templates/src/main/webapp/app/config/notification-middleware.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/config/notification-middleware.spec.ts.ejs
@@ -118,11 +118,9 @@ describe('Notification Middleware', () => {
     error: {
       isAxiosError: true,
       response: {
-        data: {
-          title: 'Unauthorized',
-          status: 401,
-          path: '/api/authenticate',
-          message: 'error.http.401',
+        data: '',
+        config: {
+          url: 'api/authenticate'
         },
         status: 401,
       },

--- a/generators/react/templates/src/main/webapp/app/config/notification-middleware.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/config/notification-middleware.ts.ejs
@@ -22,6 +22,7 @@ import { translate } from 'react-jhipster';
 <%_ } _%>
 import { toast } from 'react-toastify';
 import { isFulfilledAction, isRejectedAction } from 'app/shared/reducers/reducer.utils';
+import { AxiosError, AxiosHeaderValue } from 'axios';
 
 const addErrorAlert = (message, key?, data?) => {
 <%_ if (enableTranslation) { _%>
@@ -64,13 +65,14 @@ export default () => next => action => {
 
 
   if (isRejectedAction(action) && error && error.isAxiosError) {
-    if (error.response) {
-      const response = error.response;
-      const data = response.data;
+    const axiosError = error as AxiosError;
+    if (axiosError.response) {
+      const response = axiosError.response;
+      const data = response.data as any;
       if (
         !(
           response.status === 401 &&
-          (error.message === '' || (data && data.path && (data.path.includes('/api/account') || data.path.includes('/api/authenticate'))))
+          (axiosError.message === '' || response.config.url === 'api/account' || response.config.url === 'api/authenticate')
         )
       ) {
         switch (response.status) {
@@ -83,11 +85,11 @@ export default () => next => action => {
             let errorHeader: string | null = null;
             let entityKey: string | null = null;
             response?.headers &&
-              Object.entries<string>(response.headers).forEach(([k, v]) => {
+              Object.entries<AxiosHeaderValue>(response.headers).forEach(([k, v]) => {
               if (k.toLowerCase().endsWith('app-error')) {
-                errorHeader = v;
+                errorHeader = v as string;
               } else if (k.toLowerCase().endsWith('app-params')) {
-                entityKey = v;
+                entityKey = v as string;
               }
             });
             if (errorHeader) {
@@ -127,7 +129,7 @@ export default () => next => action => {
             }
         }
       }
-    } else if (error.config && error.config.url === 'api/account' && error.config.method === 'get') {
+    } else if (axiosError.config && axiosError.config.url === 'api/account' && axiosError.config.method === 'get') {
       /* eslint-disable no-console */
       console.log('Authentication Error: Trying to access url api/account with GET.');
     } else {


### PR DESCRIPTION
Resolves #22483

- Using the URL defined in `AxiosError` instead of `data`, which was becoming empty.
- Adjusted the expected action value in Jest to reflect the current situation.
- Implemented the use of `AxiosError` type after `isAxiosError` check (I initially wanted to also define a type for `data`. This remains an issue to be addressed in the future).

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->