### PR TITLE
Move base-core implementation to base-core folder and export basic types.

### DIFF
--- a/generators/angular/types-export.d.ts
+++ b/generators/angular/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/app/types-export.d.ts
+++ b/generators/app/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/aws/types-export.d.ts
+++ b/generators/aws/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/azure-app-service/types-export.d.ts
+++ b/generators/azure-app-service/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/azure-spring-cloud/types-export.d.ts
+++ b/generators/azure-spring-cloud/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/base-application/generator.mts
+++ b/generators/base-application/generator.mts
@@ -324,7 +324,7 @@ export default class BaseApplicationGenerator<
   /**
    * @private
    */
-  getTaskFirstArgForPriority(priorityName) {
+  getTaskFirstArgForPriority(priorityName): any {
     if (
       ![
         LOADING,

--- a/generators/base-application/types-export.d.ts
+++ b/generators/base-application/types-export.d.ts
@@ -1,0 +1,4 @@
+import Generator from './index.mjs';
+
+// Remove generics support
+export type BaseApplicationGenerator = Generator;

--- a/generators/base-core/index.mts
+++ b/generators/base-core/index.mts
@@ -17,4 +17,4 @@
  * limitations under the License.
  */
 
-export { default } from '../base/generator-base.mjs';
+export { default } from './generator-base.mjs';

--- a/generators/base-core/types-export.d.ts
+++ b/generators/base-core/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from './index.mjs';

--- a/generators/base/generator-base-blueprint.mts
+++ b/generators/base/generator-base-blueprint.mts
@@ -24,12 +24,12 @@ import semver from 'semver';
 import type { ComposeOptions } from 'yeoman-generator';
 import { packageJson } from '../../lib/index.mjs';
 import { packageNameToNamespace } from './support/index.mjs';
-import JHipsterBaseGenerator from './generator-base.mjs';
+import JHipsterBaseGenerator from './generator-base-todo.mjs';
 import { mergeBlueprints, parseBluePrints, loadBlueprintsFromConfiguration, normalizeBlueprintName } from './internal/index.mjs';
 import { PRIORITY_NAMES } from './priorities.mjs';
 import { BaseGeneratorDefinition, GenericTaskGroup } from './tasks.mjs';
 import { JHipsterGeneratorFeatures, JHipsterGeneratorOptions } from './api.mjs';
-import CoreGenerator from './generator-base.mjs';
+import CoreGenerator from '../base-core/generator-base.mjs';
 
 /**
  * Base class that contains blueprints support.
@@ -50,6 +50,9 @@ export default class JHipsterBaseBlueprintGenerator<
     if (this.options.help) {
       return;
     }
+
+    this.loadRuntimeOptions();
+    this.loadStoredAppOptions();
 
     this.sbsBlueprint = this.features.sbsBlueprint ?? false;
     this.fromBlueprint = this.rootGeneratorName() !== 'generator-jhipster';

--- a/generators/base/generator-base-todo.mts
+++ b/generators/base/generator-base-todo.mts
@@ -23,10 +23,9 @@ import chalk from 'chalk';
 import fs from 'fs';
 import { exec } from 'child_process';
 import os from 'os';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import YeomanGenerator, { type Storage } from 'yeoman-generator';
-import { formatDateForChangelog, normalizePathEnd, createJHipster7Context, upperFirstCamelCase, Logger } from './support/index.mjs';
+import { type Storage } from 'yeoman-generator';
+import JHipsterBaseCoreGenerator from '../base-core/index.mjs';
+import { formatDateForChangelog, normalizePathEnd, createJHipster7Context, upperFirstCamelCase } from './support/index.mjs';
 import { packageJson } from '../../lib/index.mjs';
 import { detectLanguage, loadLanguagesConfig } from '../languages/support/index.mjs';
 import {
@@ -64,10 +63,6 @@ import {
 import { removeFieldsWithNullishValues, parseCreationTimestamp, getHipster } from './support/index.mjs';
 import { getDefaultAppName } from '../project-name/support/index.mjs';
 import { MESSAGE_BROKER_KAFKA, MESSAGE_BROKER_NO, MESSAGE_BROKER_PULSAR } from '../server/options/index.mjs';
-import type { JHipsterGeneratorFeatures, JHipsterGeneratorOptions } from './api.mjs';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 const { ANGULAR, REACT, VUE, NO: CLIENT_FRAMEWORK_NO } = clientFrameworkTypes;
 const GENERATOR_JHIPSTER = 'generator-jhipster';
@@ -92,13 +87,7 @@ const isWin32 = os.platform() === 'win32';
 /**
  * Class the contains the methods that should be refactored and converted to typescript.
  */
-export default abstract class JHipsterBaseGenerator extends YeomanGenerator<JHipsterGeneratorOptions, JHipsterGeneratorFeatures> {
-  abstract jhipsterConfig: any;
-  abstract needleApi: any;
-  abstract sharedData: any;
-  abstract configOptions: any;
-  declare log: Logger;
-
+export default abstract class JHipsterBaseGenerator extends JHipsterBaseCoreGenerator {
   /**
    * @private
    * Add a new element in the "global.json" translations.
@@ -499,7 +488,7 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
           }
           const basename = path.basename(sourceFileFrom);
           const seed = `${context.entityClass}-${basename}${context.fakerSeed ?? ''}`;
-          Object.values(this.sharedData.getApplication()?.sharedEntities ?? {}).forEach((entity: any) => {
+          Object.values((this.sharedData as any).getApplication()?.sharedEntities ?? {}).forEach((entity: any) => {
             entity.resetFakerSeed(seed);
           });
           // Async calls will make the render method to be scheduled, allowing the faker key to change in the meantime.

--- a/generators/base/support/needles.mts
+++ b/generators/base/support/needles.mts
@@ -19,7 +19,7 @@
 import assert from 'assert';
 import _ from 'lodash';
 import escapeStringRegexp from 'escape-string-regexp';
-import CoreGenerator from '../generator-base.mjs';
+import CoreGenerator from '../../base-core/generator-base.mjs';
 import { CascatedEditFileCallback, EditFileCallback } from '../api.mjs';
 import { joinCallbacks } from './write-files.mjs';
 

--- a/generators/base/types-export.d.ts
+++ b/generators/base/types-export.d.ts
@@ -1,0 +1,4 @@
+import Generator from './index.mjs';
+
+// Remove generics support
+export type BaseGenerator = Generator;

--- a/generators/bootstrap-application-base/types-export.d.ts
+++ b/generators/bootstrap-application-base/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/bootstrap-application-client/types-export.d.ts
+++ b/generators/bootstrap-application-client/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/bootstrap-application-server/types-export.d.ts
+++ b/generators/bootstrap-application-server/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/bootstrap-application/types-export.d.ts
+++ b/generators/bootstrap-application/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/bootstrap/types-export.d.ts
+++ b/generators/bootstrap/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/ci-cd/types-export.d.ts
+++ b/generators/ci-cd/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/client/needle-api/needle-client-webpack.mts
+++ b/generators/client/needle-api/needle-client-webpack.mts
@@ -24,10 +24,10 @@ const { ANGULAR } = clientFrameworkTypes;
 
 export default class extends needleClient {
   _getWebpackFile(clientFramework: string = this.clientFramework) {
-    return this.clientFramework === ANGULAR ? `${CLIENT_WEBPACK_DIR}/webpack.custom.js` : `${CLIENT_WEBPACK_DIR}/webpack.common.js`;
+    return clientFramework === ANGULAR ? `${CLIENT_WEBPACK_DIR}/webpack.custom.js` : `${CLIENT_WEBPACK_DIR}/webpack.common.js`;
   }
 
-  copyExternalAssets(source: string, target: string, clientFramework: string) {
+  copyExternalAssets(source: string, target: string, clientFramework?: string) {
     const errorMessage = 'Resource path not added to JHipster app.';
     let assetBlock = '';
     if (source && target) {

--- a/generators/client/types-export.d.ts
+++ b/generators/client/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/cloudfoundry/types-export.d.ts
+++ b/generators/cloudfoundry/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/common/types-export.d.ts
+++ b/generators/common/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/cucumber/types-export.d.ts
+++ b/generators/cucumber/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/cypress/types-export.d.ts
+++ b/generators/cypress/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/docker-compose/types-export.d.ts
+++ b/generators/docker-compose/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/docker/types-export.d.ts
+++ b/generators/docker/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/entities/types-export.d.ts
+++ b/generators/entities/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/entity/types-export.d.ts
+++ b/generators/entity/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/export-jdl/types-export.d.ts
+++ b/generators/export-jdl/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/gae/types-export.d.ts
+++ b/generators/gae/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/gatling/types-export.d.ts
+++ b/generators/gatling/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/generate-blueprint/__snapshots__/generator.spec.mjs.snap
+++ b/generators/generate-blueprint/__snapshots__/generator.spec.mjs.snap
@@ -755,6 +755,9 @@ exports[`generator - generate-blueprint with all option should match snapshot 1`
   "test/utils.mjs": {
     "stateCleared": "modified",
   },
+  "tsconfig.json": {
+    "stateCleared": "modified",
+  },
 }
 `;
 
@@ -782,6 +785,9 @@ exports[`generator - generate-blueprint with default config should write files a
     "stateCleared": "modified",
   },
   "test/utils.mjs": {
+    "stateCleared": "modified",
+  },
+  "tsconfig.json": {
     "stateCleared": "modified",
   },
 }

--- a/generators/generate-blueprint/files.mjs
+++ b/generators/generate-blueprint/files.mjs
@@ -28,6 +28,7 @@ export const files = {
         '.mocharc.cjs',
         'README.md',
         'test/utils.mjs',
+        'tsconfig.json',
         '.prettierignore.jhi.blueprint',
       ],
     },

--- a/generators/generate-blueprint/templates/tsconfig.json.ejs
+++ b/generators/generate-blueprint/templates/tsconfig.json.ejs
@@ -1,0 +1,31 @@
+/* tsconfig.json is provided for ui autocomplete support, jhipster types are experimental */
+{
+  "compilerOptions": {
+    /* Language and Environment */
+    "target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "lib": ["ES2022"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+    "types": [],
+
+    /* Modules */
+    "module": "node16" /* Specify what module code is generated. */,
+    "rootDir": "./" /* Specify the root folder within your source files. */,
+
+    /* JavaScript Support */
+    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
+
+    /* Emit */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+
+    /* Interop Constraints */
+    "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": false,
+
+    /* Completeness */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/generators/generate-blueprint/types-export.d.ts
+++ b/generators/generate-blueprint/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/git/types-export.d.ts
+++ b/generators/git/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/gradle/types-export.d.ts
+++ b/generators/gradle/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/heroku/types-export.d.ts
+++ b/generators/heroku/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/info/types-export.d.ts
+++ b/generators/info/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/init/types-export.d.ts
+++ b/generators/init/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/java/types-export.d.ts
+++ b/generators/java/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/jdl/types-export.d.ts
+++ b/generators/jdl/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/kubernetes-helm/types-export.d.ts
+++ b/generators/kubernetes-helm/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/kubernetes-knative/types-export.d.ts
+++ b/generators/kubernetes-knative/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/kubernetes/types-export.d.ts
+++ b/generators/kubernetes/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/languages/types-export.d.ts
+++ b/generators/languages/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/liquibase-changelogs/types-export.d.ts
+++ b/generators/liquibase-changelogs/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/liquibase/generator.mts
+++ b/generators/liquibase/generator.mts
@@ -19,7 +19,7 @@
 import fs from 'fs';
 
 import _ from 'lodash';
-import BaseApplicationGenerator, { type Entity } from '../base-application/index.mjs';
+import BaseApplicationGenerator from '../base-application/index.mjs';
 import { GENERATOR_LIQUIBASE, GENERATOR_LIQUIBASE_CHANGELOGS, GENERATOR_BOOTSTRAP_APPLICATION_SERVER } from '../generator-list.mjs';
 import { liquibaseFiles } from './files.mjs';
 import {
@@ -45,12 +45,6 @@ import {
   addLiquibaseConstraintsChangelogCallback,
   addLiquibaseIncrementalChangelogCallback,
 } from './internal/needles.mjs';
-
-export type LiquibaseEntity = Entity & {
-  anyRelationshipIsOwnerSide: boolean;
-  liquibaseFakeData: Record<string, any>[];
-  fakeDataCount: number;
-};
 
 const BASE_CHANGELOG = {
   addedFields: [],

--- a/generators/liquibase/support/post-prepare-entity.mts
+++ b/generators/liquibase/support/post-prepare-entity.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { fieldTypes } from '../../../jdl/jhipster/index.mjs';
-import { LiquibaseEntity } from '../generator.mjs';
+import { LiquibaseEntity } from '../types.mjs';
 import { GeneratorDefinition } from '../../base-application/generator.mjs';
 
 const { CommonDBTypes } = fieldTypes;

--- a/generators/liquibase/types-export.d.ts
+++ b/generators/liquibase/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/liquibase/types.d.mts
+++ b/generators/liquibase/types.d.mts
@@ -1,7 +1,15 @@
+import type { Entity } from '../base-application/index.mjs';
+
 export type LiquibaseChangelog = { changelogName: string };
 
 export type LiquibaseSourceType = {
   addLiquibaseChangelog?(changelog: LiquibaseChangelog): void;
   addLiquibaseIncrementalChangelog?(changelog: LiquibaseChangelog): void;
   addLiquibaseConstraintsChangelog?(changelog: LiquibaseChangelog): void;
+};
+
+export type LiquibaseEntity = Entity & {
+  anyRelationshipIsOwnerSide: boolean;
+  liquibaseFakeData: Record<string, any>[];
+  fakeDataCount: number;
 };

--- a/generators/maven/types-export.d.ts
+++ b/generators/maven/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/needle-base.mts
+++ b/generators/needle-base.mts
@@ -75,7 +75,7 @@ export default class {
    * @param rewriteFileModel
    * @param errorMessage
    */
-  addBlockContentToFile(rewriteFileModel: NeedleFileModel, errorMessage: string): void {
+  addBlockContentToFile(rewriteFileModel: NeedleFileModel, errorMessage?: string): void {
     const ignoreNonExisting = errorMessage ?? true;
     const { path: rewritePath, file } = rewriteFileModel;
     let fullPath;

--- a/generators/openapi-client/types-export.d.ts
+++ b/generators/openapi-client/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/openshift/types-export.d.ts
+++ b/generators/openshift/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/page/types-export.d.ts
+++ b/generators/page/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/project-name/types-export.d.ts
+++ b/generators/project-name/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/react/types-export.d.ts
+++ b/generators/react/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/server/types-export.d.ts
+++ b/generators/server/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-cache/types-export.d.ts
+++ b/generators/spring-cache/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-cloud-stream/types-export.d.ts
+++ b/generators/spring-cloud-stream/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-controller/types-export.d.ts
+++ b/generators/spring-controller/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-data-cassandra/types-export.d.ts
+++ b/generators/spring-data-cassandra/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-data-couchbase/types-export.d.ts
+++ b/generators/spring-data-couchbase/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-data-elasticsearch/types-export.d.ts
+++ b/generators/spring-data-elasticsearch/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-data-mongodb/types-export.d.ts
+++ b/generators/spring-data-mongodb/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-data-neo4j/types-export.d.ts
+++ b/generators/spring-data-neo4j/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-data-relational/types-export.d.ts
+++ b/generators/spring-data-relational/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-service/types-export.d.ts
+++ b/generators/spring-service/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/spring-websocket/types-export.d.ts
+++ b/generators/spring-websocket/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/upgrade/types-export.d.ts
+++ b/generators/upgrade/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/vue/types-export.d.ts
+++ b/generators/vue/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/generators/workspaces/types-export.d.ts
+++ b/generators/workspaces/types-export.d.ts
@@ -1,0 +1,1 @@
+export type { default } from '../base-application/types-export.mjs';

--- a/package.json
+++ b/package.json
@@ -40,9 +40,15 @@
     "./cli": "./dist/cli/index.mjs",
     "./package.json": "./package.json",
     "./generators": "./dist/generators/generator-list.mjs",
-    "./generators/*": "./dist/generators/*/index.mjs",
+    "./generators/*": {
+      "types": "./dist/types/generators/*/types-export.d.ts",
+      "default": "./dist/generators/*/index.mjs"
+    },
     "./jdl/": "./dist/jdl/",
-    "./generators/base/support": "./dist/generators/base/support/index.mjs"
+    "./generators/*/support": {
+      "types": "./dist/types/generators/*/support/index.d.mts",
+      "default": "./dist/generators/*/support/index.mjs"
+    }
   },
   "main": "dist/lib/index.mjs",
   "bin": {

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,5 +1,11 @@
 {
-  "include": ["./generators/base", "./generators/base-application"],
+  "include": [
+    "./generators/base",
+    "./generators/core",
+    "./generators/base-application",
+    "./generators/*/support",
+    "./generators/*/type-export.d.ts"
+  ],
   "exclude": ["**/*.spec.*", "**/__*/**"],
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
Types are far from been ready, but for ui autocomplete to work, we need to export types.
At most generators, basic generators are been re-exported, specific types are failing to build correctly.
- add tsconfig to generate-blueprint, ui autocomplete requires a tsconfig.json with node16 configuration.

Closes https://github.com/jhipster/generator-jhipster/issues/22586
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
