### PR TITLE
Fix typos

### DIFF
--- a/generators/server/templates/src/test/java/package/web/rest/TestUtil.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/TestUtil.java.ejs
@@ -239,16 +239,16 @@ public final class TestUtil {
 <%_ if (databaseTypeSql) { _%>
 
     /**
-     * Makes a an executes a query to the EntityManager finding all stored objects.
+     * Executes a query on the EntityManager finding all stored objects.
      * @param <T> The type of objects to be searched
      * @param em The instance of the EntityManager
-     * @param clss The class type to be searched
+     * @param clazz The class type to be searched
      * @return A list of all found objects
      */
-    public static <T> List<T> findAll(EntityManager em, Class<T> clss) {
+    public static <T> List<T> findAll(EntityManager em, Class<T> clazz) {
         CriteriaBuilder cb = em.getCriteriaBuilder();
-        CriteriaQuery<T> cq = cb.createQuery(clss);
-        Root<T> rootEntry = cq.from(clss);
+        CriteriaQuery<T> cq = cb.createQuery(clazz);
+        Root<T> rootEntry = cq.from(clazz);
         CriteriaQuery<T> all = cq.select(rootEntry);
         TypedQuery<T> allQuery = em.createQuery(all);
         return allQuery.getResultList();


### PR DESCRIPTION
- Use *clazz* instead of *clss* for method parameter of type `Class<T> clazz` --- just like in `TestUtil#equalsVerifier`
- Fix typo in Javadoc