### PR TITLE
drop spotless npmw integration

### DIFF
--- a/generators/server/templates/npmw
+++ b/generators/server/templates/npmw
@@ -5,7 +5,6 @@ basedir=`dirname "$0"`
 if [ -f "$basedir/mvnw" ]; then
   bindir="$basedir/target/node"
   repodir="$basedir/target/node/node_modules"
-  spotlessApplyCommand="$basedir/mvnw process-sources"
   installCommand="$basedir/mvnw -Pwebapp frontend:install-node-and-npm@install-node-and-npm"
 
   PATH="$basedir/$builddir/:$PATH"
@@ -14,7 +13,6 @@ if [ -f "$basedir/mvnw" ]; then
 elif [ -f "$basedir/gradlew" ]; then
   bindir="$basedir/build/node/bin"
   repodir="$basedir/build/node/lib/node_modules"
-  spotlessApplyCommand="$basedir/gradlew spotlessApply"
   installCommand="$basedir/gradlew npmSetup"
 else
   echo "Using npm installed globally"
@@ -23,10 +21,6 @@ fi
 
 NPM_EXE="$repodir/npm/bin/npm-cli.js"
 NODE_EXE="$bindir/node"
-
-if [ ! -z "$spotlessApplyCommand" ]; then
-  $spotlessApplyCommand || true
-fi
 
 if [ ! -x "$NPM_EXE" ] || [ ! -x "$NODE_EXE" ]; then
   $installCommand || true

--- a/generators/server/templates/npmw.cmd
+++ b/generators/server/templates/npmw.cmd
@@ -8,18 +8,12 @@ if exist "%NPMW_DIR%mvnw.cmd" (
   set NODE_EXE=^"^"
   set NODE_PATH=%NPMW_DIR%target\node\
   set NPM_EXE=^"%NPMW_DIR%target\node\npm.cmd^"
-  set SPOTLESS_APPLY_COMMAND=^"%NPMW_DIR%mvnw.cmd^" process-sources
   set INSTALL_NPM_COMMAND=^"%NPMW_DIR%mvnw.cmd^" -Pwebapp frontend:install-node-and-npm@install-node-and-npm
 ) else (
   set NODE_EXE=^"%NPMW_DIR%build\node\bin\node.exe^"
   set NODE_PATH=%NPMW_DIR%build\node\bin\
   set NPM_EXE=^"%NPMW_DIR%build\node\lib\node_modules\npm\bin\npm-cli.js^"
-  set SPOTLESS_APPLY_COMMAND=^"%NPMW_DIR%gradlew.bat^" spotlessApply
   set INSTALL_NPM_COMMAND=^"%NPMW_DIR%gradlew.bat^" npmSetup
-)
-
-if exist %SPOTLESS_APPLY_COMMAND% (
-  call %SPOTLESS_APPLY_COMMAND%
 )
 
 if not exist %NPM_EXE% (


### PR DESCRIPTION
See https://github.com/jhipster/generator-jhipster/pull/22744#issuecomment-1620475540.

Running as a command like I've said in https://github.com/jhipster/generator-jhipster/pull/22744#issuecomment-1620475540 will cause conflicts running `jhipster --defaults` twice. Second execution will compare source without spotless against source with spotless, spotless execution will happen after compare and commit.

Unfortunately the only way to fully integrate spotless is by integration it into mem-fs using transforms.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
