### PR TITLE
prevent spotless from trying to handle generated sources

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -65,6 +65,7 @@ apply from: "gradle/sonar.gradle"
 
 spotless {
     java {
+        target 'src/*/java/**/*.java'
         removeUnusedImports()
     }
 }


### PR DESCRIPTION
By default spotless also tries to keep generated sources spotless, thats why it failed. Configured spotless to just check real sources.

Side note, I am not sure, but  I supposed generating an app should execute spotless, but it looks like it was not executed on test classes. Running spotlessApply fixed all unused imports

closes #22840


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
