### PR TITLE
remove consul from openapi lookup

### DIFF
--- a/generators/client/templates/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/src/main/webapp/swagger-ui/index.html.ejs
@@ -78,7 +78,7 @@
 
         try {
           const response = await axios.get('/management/health/discoveryComposite', axiosConfig);
-          const services = response.data?.components?.discoveryClient?.details?.services;
+          const services = response.data?.components?.discoveryClient?.details?.services<% if (serviceDiscoveryConsul) { %>.filter(service => service !== 'consul')<% } %>;
           console.log(`Services`, services);
 
           if (services && services.length > 0) {


### PR DESCRIPTION
Swagger implementation probes every service for an openapi endpoint.
The stack trace is shown because consul doesn't have the endpoint.
Since consul is known to doesn't have the openapi endpoint, this pr removes it.

Fixes https://github.com/jhipster/generator-jhipster/issues/22654.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
