### PR TITLE
allow view/edit in new tabs from list view

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.html.ejs
@@ -180,16 +180,14 @@ _%>
     <%_ } _%>
 <%_ } _%>
                             <a [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'view']"
-                                    class="btn btn-info btn-sm"
-                                    data-cy="entityDetailsButton">
+                               class="btn btn-info btn-sm" data-cy="entityDetailsButton">
                                 <fa-icon icon="eye"></fa-icon>
                                 <span class="d-none d-md-inline" <%= jhiPrefix %>Translate="entity.action.view">__jhiTransformTranslate__('entity.action.view')</span>
                             </a>
 <%_ if (!readOnly) { _%>
 
                             <a [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'edit']"
-                                    class="btn btn-primary btn-sm"
-                                    data-cy="entityEditButton">
+                               class="btn btn-primary btn-sm" data-cy="entityEditButton">
                                 <fa-icon icon="pencil-alt"></fa-icon>
                                 <span class="d-none d-md-inline" <%= jhiPrefix %>Translate="entity.action.edit">__jhiTransformTranslate__('entity.action.edit')</span>
                             </a>

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.html.ejs
@@ -179,8 +179,7 @@ _%>
                             </button>
     <%_ } _%>
 <%_ } _%>
-                            <a
-                                    [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'view']"
+                            <a [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'view']"
                                     class="btn btn-info btn-sm"
                                     data-cy="entityDetailsButton">
                                 <fa-icon icon="eye"></fa-icon>
@@ -188,8 +187,7 @@ _%>
                             </a>
 <%_ if (!readOnly) { _%>
 
-                            <a
-                                    [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'edit']"
+                            <a [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'edit']"
                                     class="btn btn-primary btn-sm"
                                     data-cy="entityEditButton">
                                 <fa-icon icon="pencil-alt"></fa-icon>

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.html.ejs
@@ -179,22 +179,22 @@ _%>
                             </button>
     <%_ } _%>
 <%_ } _%>
-                            <button type="submit"
+                            <a
                                     [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'view']"
                                     class="btn btn-info btn-sm"
                                     data-cy="entityDetailsButton">
                                 <fa-icon icon="eye"></fa-icon>
                                 <span class="d-none d-md-inline" <%= jhiPrefix %>Translate="entity.action.view">__jhiTransformTranslate__('entity.action.view')</span>
-                            </button>
+                            </a>
 <%_ if (!readOnly) { _%>
 
-                            <button type="submit"
+                            <a
                                     [routerLink]="['/<%= entityPage %>', <%= entityInstance %>.<%= primaryKey.name %>, 'edit']"
                                     class="btn btn-primary btn-sm"
                                     data-cy="entityEditButton">
                                 <fa-icon icon="pencil-alt"></fa-icon>
                                 <span class="d-none d-md-inline" <%= jhiPrefix %>Translate="entity.action.edit">__jhiTransformTranslate__('entity.action.edit')</span>
-                            </button>
+                            </a>
 
                             <button type="submit" (click)="delete(<%= entityInstance %>)"
                                     class="btn btn-danger btn-sm"

--- a/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_.tsx.ejs
@@ -491,7 +491,7 @@ _%>
                           <Button tag={Link} to={`/<%= entityPage %>/${<%= entityInstance %>.<%= primaryKey.name %>}/edit<%_ if (paginationPagination) { _%>?page=${paginationState.activePage}&sort=${paginationState.sort},${paginationState.order}<%_ } _%>`} color="primary" size="sm" data-cy="entityEditButton">
                             <FontAwesomeIcon icon="pencil-alt" /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
                           </Button>
-                          <Button to={`/<%= entityPage %>/${<%= entityInstance %>.<%= primaryKey.name %>}/delete<%_ if (paginationPagination) { _%>?page=${paginationState.activePage}&sort=${paginationState.sort},${paginationState.order}<%_ } _%>`} color="danger" size="sm" data-cy="entityDeleteButton">
+                          <Button onClick={() => location.href=`/<%= entityPage %>/${<%= entityInstance %>.<%= primaryKey.name %>}/delete<%_ if (paginationPagination) { _%>?page=${paginationState.activePage}&sort=${paginationState.sort},${paginationState.order}<%_ } _%>`} color="danger" size="sm" data-cy="entityDeleteButton">
                             <FontAwesomeIcon icon="trash" /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.delete">Delete</Translate></span>
                           </Button>
 <%_ } _%>

--- a/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_.tsx.ejs
@@ -491,7 +491,7 @@ _%>
                           <Button tag={Link} to={`/<%= entityPage %>/${<%= entityInstance %>.<%= primaryKey.name %>}/edit<%_ if (paginationPagination) { _%>?page=${paginationState.activePage}&sort=${paginationState.sort},${paginationState.order}<%_ } _%>`} color="primary" size="sm" data-cy="entityEditButton">
                             <FontAwesomeIcon icon="pencil-alt" /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
                           </Button>
-                          <Button tag={Link} to={`/<%= entityPage %>/${<%= entityInstance %>.<%= primaryKey.name %>}/delete<%_ if (paginationPagination) { _%>?page=${paginationState.activePage}&sort=${paginationState.sort},${paginationState.order}<%_ } _%>`} color="danger" size="sm" data-cy="entityDeleteButton">
+                          <Button to={`/<%= entityPage %>/${<%= entityInstance %>.<%= primaryKey.name %>}/delete<%_ if (paginationPagination) { _%>?page=${paginationState.activePage}&sort=${paginationState.sort},${paginationState.order}<%_ } _%>`} color="danger" size="sm" data-cy="entityDeleteButton">
                             <FontAwesomeIcon icon="trash" /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.delete">Delete</Translate></span>
                           </Button>
 <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_.vue.ejs
@@ -127,18 +127,30 @@
 <%_ } _%>
                     <td class="text-right">
                         <div class="btn-group">
+  <%_ if (authenticationTypeSession) { _%>
+                            <router-link :to="{name: '<%= entityAngularName %>View', params: {<%= entityInstance %>Id: <%= entityInstance %>.id}}" class="btn btn-info btn-sm details" data-cy="entityDetailsButton">
+  <%_ } else { _%>
                             <router-link :to="{name: '<%= entityAngularName %>View', params: {<%= entityInstance %>Id: <%= entityInstance %>.id}}" custom v-slot="{ navigate }">
                                 <button @click="navigate" class="btn btn-info btn-sm details" data-cy="entityDetailsButton">
+  <%_ } _%>
                                     <font-awesome-icon icon="eye"></font-awesome-icon>
                                     <span class="d-none d-md-inline" v-text="t$('entity.action.view')">View</span>
+  <%_ if (!authenticationTypeSession) { _%>
                                 </button>
+  <%_ } _%>
                             </router-link>
 <%_ if (!readOnly) { _%>
+  <%_ if (authenticationTypeSession) { _%>
+                            <router-link :to="{name: '<%= entityAngularName %>Edit', params: {<%= entityInstance %>Id: <%= entityInstance %>.id}}" class="btn btn-primary btn-sm edit" data-cy="entityEditButton">
+  <%_ } else { _%>
                             <router-link :to="{name: '<%= entityAngularName %>Edit', params: {<%= entityInstance %>Id: <%= entityInstance %>.id}}" custom v-slot="{ navigate }">
                                 <button @click="navigate" class="btn btn-primary btn-sm edit" data-cy="entityEditButton">
+  <%_ } _%>
                                     <font-awesome-icon icon="pencil-alt"></font-awesome-icon>
                                     <span class="d-none d-md-inline" v-text="t$('entity.action.edit')">Edit</span>
+  <%_ if (!authenticationTypeSession) { _%>
                                 </button>
+  <%_ } _%>
                             </router-link>
                             <b-button v-on:click="prepareRemove(<%= entityInstance %>)"
                                    variant="danger"


### PR DESCRIPTION
Fix #22801

It is interesting to note, that tabs were already supported by react, so there was nothing to do for react. With this PR the view and edit "buttons" for angular and vue (here only authentication type "session") work in the same way like react. Vue produces an error for links opened in new tabs when authentication type is not "session". Working with tabs works best in session mode, e.g. with JWT authentication a login for each tab is required. But even when a login is required, this PR makes it still easier to copy or share view/edit links.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
