### PR TITLE
Fix typo in the alert message for "reset password"

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/bn/reset.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/reset.json.ejs
@@ -25,7 +25,7 @@
             },
             "messages": {
                 "info": "Enter the email address you used to register",
-                "success": "Check your emails for details on how to reset your password."
+                "success": "Check your email for details on how to reset your password."
             }
         },
         "finish": {

--- a/generators/languages/templates/src/main/webapp/i18n/da/reset.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/da/reset.json.ejs
@@ -25,7 +25,7 @@
             },
             "messages": {
                 "info": "Enter the email address you used to register",
-                "success": "Check your emails for details on how to reset your password."
+                "success": "Check your email for details on how to reset your password."
             }
         },
         "finish": {

--- a/generators/languages/templates/src/main/webapp/i18n/en/reset.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/en/reset.json.ejs
@@ -25,7 +25,7 @@
             },
             "messages": {
                 "info": "Enter the email address you used to register",
-                "success": "Check your emails for details on how to reset your password."
+                "success": "Check your email for details on how to reset your password."
             }
         },
         "finish": {

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
@@ -63,7 +63,7 @@ export const PasswordResetSlice = createSlice({
         <%_ if (enableTranslation) { _%>
         successMessage: 'reset.request.messages.success',
         <%_ } else { _%>
-        successMessage: 'Check your emails for details on how to reset your password.'
+        successMessage: 'Check your email for details on how to reset your password.'
         <%_ } _%>
       }))
       .addCase(handlePasswordResetFinish.fulfilled, () => ({

--- a/generators/vue/templates/src/main/webapp/app/account/reset-password/init/reset-password-init.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/reset-password/init/reset-password-init.vue.ejs
@@ -9,7 +9,7 @@
                 </div>
 
                 <div class="alert alert-success" v-if="success">
-                    <p v-text="t$('reset.request.messages.success')">Check your emails for details on how to reset your
+                    <p v-text="t$('reset.request.messages.success')">Check your email for details on how to reset your
                         password.</p>
                 </div>
 


### PR DESCRIPTION
<!--
PR description.
-->
I have changed "emails" to "email" in the existing alert message for reset password: "Check your emails for details on how to reset your password."
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
