### PR TITLE
Sonar: 'dayjs/esm/locale/en' import is duplicated

### DIFF
--- a/generators/client/support/update-languages.mts
+++ b/generators/client/support/update-languages.mts
@@ -37,7 +37,8 @@ export function updateLanguagesInDayjsConfigurationTask(
   const { languagesDefinition = [] } = application;
   const { ignoreNeedlesError: ignoreNonExisting } = control;
 
-  const newContent = languagesDefinition.reduce(
+  const uniqueDayjsLocales = [...new Map(languagesDefinition.map(v => [v.dayjsLocale, v])).values()];
+  const newContent = uniqueDayjsLocales.reduce(
     (content, language) => `${content}import 'dayjs/${commonjs ? '' : 'esm/'}locale/${language.dayjsLocale}'\n`,
     '// jhipster-needle-i18n-language-dayjs-imports - JHipster will import languages from dayjs here\n',
   );


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jhipster-sample-application&open=AYYImbn4jT0F0g-yuSk2

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
