### PR TITLE
drop vue dependency workarounds

### DIFF
--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -117,9 +117,6 @@
     "webpack-merge": "<%= nodeDependencies['webpack-merge'] %>",
     "workbox-webpack-plugin": "<%= nodeDependencies['workbox-webpack-plugin'] %>"
   },
-  "overrides": {
-    "eslint-plugin-prettier": "$eslint-plugin-prettier"
-  },
   "engines": {
     "node": ">=<%= nodeVersion %>",
     "npm": ">= 6.14.4"

--- a/generators/workspaces/generator.mjs
+++ b/generators/workspaces/generator.mjs
@@ -197,20 +197,6 @@ export default class WorkspacesGenerator extends BaseGenerator {
             },
           });
         }
-        if (applications.some(app => app.clientFrameworkVue)) {
-          this.packageJson.merge({
-            devDependencies: {
-              '@vue/eslint-config-prettier': '7.1.0',
-            },
-            // https://github.com/vuejs/vue-jest/issues/480#issuecomment-1330479635
-            overrides: {
-              '@babel/core': '7.17.9',
-              '@babel/generator': '7.17.9',
-              'istanbul-lib-instrument': '5.2.0',
-              'eslint-plugin-prettier': '5.0.0',
-            },
-          });
-        }
       },
     };
   }


### PR DESCRIPTION
Drop prettier and jest workarounds.
Prettier 3.0 is supported now and we have switched to vitest.

Fixes https://github.com/jhipster/generator-jhipster/issues/22877.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
