### PR TITLE
Sonar: Remove this unused 'xxxRepository' private field (not just for reactive)

### DIFF
--- a/generators/server/templates/entity/src/main/java/package/common/inject_template.ejs
+++ b/generators/server/templates/entity/src/main/java/package/common/inject_template.ejs
@@ -20,7 +20,7 @@
   const beans = [];
   if (viaService) {
     beans.push({class: `${entityClass}Service`, instance: `${entityInstance}Service`});
-    if (!(readOnly && reactive)) {
+    if (!readOnly) {
       beans.push({class: `${entityClass}Repository`, instance: `${entityInstance}Repository`});
     }
     if (queryService && !reactive) {


### PR DESCRIPTION
Related to #22945 
The variable id unused for reactive and non reactive project

https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jhipster-sample-application&open=AXgYXBxAM8GLQdCnBrhu

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
