### PR TITLE
React template: Add missing link for login in the register page

### DIFF
--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -20,6 +20,7 @@ import React, { useState, useEffect } from 'react';
 import { Translate, translate, ValidatedField, ValidatedForm, isEmail } from 'react-jhipster';
 import { Row, Col, Alert, Button } from 'reactstrap';
 import { toast } from 'react-toastify';
+import { Link } from 'react-router-dom';
 
 <%_ if (authenticationTypeOauth2) { _%>
 import { getLoginUrl } from 'app/shared/util/url-utils';

--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -21,6 +21,9 @@ import { Translate, translate, ValidatedField, ValidatedForm, isEmail } from 're
 import { Row, Col, Alert, Button } from 'reactstrap';
 import { toast } from 'react-toastify';
 
+<%_ if (authenticationTypeOauth2) { _%>
+import { getLoginUrl } from 'app/shared/util/url-utils';
+<%_ } _%>
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { handleRegister, reset } from './register.reducer';
@@ -136,9 +139,15 @@ export const RegisterPage = () => {
           <p>&nbsp;</p>
           <Alert color="warning">
             <span>
-              <Translate contentKey="global.messages.info.authenticated.prefix">If you want to </Translate>
+              <Translate contentKey="global.messages.info.authenticated.prefix">If you want to</Translate>{' '}
             </span>
-            <a className="alert-link"><Translate contentKey="global.messages.info.authenticated.link"> sign in</Translate></a>
+<%_ if (authenticationTypeOauth2) { _%>
+            <a href={getLoginUrl()} className="alert-link">
+              <Translate contentKey="global.messages.info.authenticated.link">sign in</Translate>
+            </a>
+<%_ } else { _%>
+            <Link to="/login" className="alert-link"><Translate contentKey="global.messages.info.authenticated.link">sign in</Translate></Link>
+<%_ } _%>
             <span>
               <Translate contentKey="global.messages.info.authenticated.suffix">
                 , you can try the default accounts:


### PR DESCRIPTION
Fixed the login link in the account page which was broken before

Before update:

https://github.com/jhipster/generator-jhipster/assets/30769960/bfcfbcea-1a06-462c-9cc4-215193ba0364


After update:

https://github.com/jhipster/generator-jhipster/assets/30769960/056535cb-02a4-4f3f-9305-95b4a7206927

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
