### PR TITLE
Changed usePreparedStatements to false for Liquibase to work properly

### DIFF
--- a/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/initial_schema_sql.xml.ejs
+++ b/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/initial_schema_sql.xml.ejs
@@ -138,7 +138,7 @@ _%>
                   file="config/liquibase/data/authority.csv"
                   separator=";"
                   tableName="<%= jhiTablePrefix %>_authority"
-                  usePreparedStatements="true">
+                  usePreparedStatements="false">
             <column name="name" type="string"/>
         </loadData>
   <%_ } _%>
@@ -147,7 +147,7 @@ _%>
                   file="config/liquibase/data/user.csv"
                   separator=";"
                   tableName="<%= user.entityTableName %>"
-                  usePreparedStatements="true">
+                  usePreparedStatements="false">
     <%_ if (prodDatabaseTypePostgres) { _%>
             <column name="id" type="<%= idField.loadColumnType %>"/>
     <%_ } _%>
@@ -158,7 +158,7 @@ _%>
                   file="config/liquibase/data/user_authority.csv"
                   separator=";"
                   tableName="<%= jhiTablePrefix %>_user_authority"
-                  usePreparedStatements="true">
+                  usePreparedStatements="false">
             <column name="user_id" type="<%= idField.loadColumnType %>"/>
         </loadData>
   <%_ } _%>


### PR DESCRIPTION
Liqiubase migration could not be done when the project was created with the Sql option. In the initial_schema_sql.xml file, the usePreparedStatements settings were changed to false because this error was encountered when true.

**_Note: Tested with Postgresql database only._**