### PR TITLE
WIP: Revisit - Update password reset page to use only react-form capabilities

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
@@ -41,7 +41,7 @@
             name="email"
             placeholder="{{ 'global.form.email.placeholder' | translate }}"
             formControlName="email"
-            data-cy="emailResetPassword"
+            data-cy="email"
             #email
           />
 

--- a/generators/angular/templates/src/main/webapp/app/account/settings/settings.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/settings/settings.component.html.ejs
@@ -39,7 +39,7 @@
             name="firstName"
             placeholder="{{ 'settings.form.firstname.placeholder' | translate }}"
             formControlName="firstName"
-            data-cy="firstname"
+            data-cy="firstName"
           />
 
           <div
@@ -83,7 +83,7 @@
             name="lastName"
             placeholder="{{ 'settings.form.lastname.placeholder' | translate }}"
             formControlName="lastName"
-            data-cy="lastname"
+            data-cy="lastName"
           />
 
           <div

--- a/generators/cypress/templates/src/test/javascript/cypress/support/commands.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/support/commands.ts.ejs
@@ -77,7 +77,7 @@ export const confirmPasswordSelector = '[data-cy="confirmPassword"]';
 export const submitPasswordSelector = '[data-cy="submit"]';
 
 // Reset Password
-export const emailResetPasswordSelector = '[data-cy="emailResetPassword"]';
+export const emailResetPasswordSelector = '[data-cy="email"]';
 export const submitInitResetPasswordSelector = '[data-cy="submit"]';
 <%_ } _%>
 

--- a/generators/cypress/templates/src/test/javascript/cypress/support/commands.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/support/commands.ts.ejs
@@ -64,8 +64,8 @@ export const secondPasswordRegisterSelector = '[data-cy="secondPassword"]';
 export const submitRegisterSelector = '[data-cy="submit"]';
 
 // Settings
-export const firstNameSettingsSelector = '[data-cy="firstname"]';
-export const lastNameSettingsSelector = '[data-cy="lastname"]';
+export const firstNameSettingsSelector = '[data-cy="firstName"]';
+export const lastNameSettingsSelector = '[data-cy="lastName"]';
 export const emailSettingsSelector = '[data-cy="email"]';
 export const languageSettingsSelector = '[data-cy="langKey"]';
 export const submitSettingsSelector = '[data-cy="submit"]';

--- a/generators/react/templates/package.json.ejs
+++ b/generators/react/templates/package.json.ejs
@@ -41,7 +41,7 @@
     "react": "<%= nodeDependencies['react'] %>",
     "react-dom": "<%= nodeDependencies['react-dom'] %>",
     "react-hook-form": "<%= nodeDependencies['react-hook-form'] %>",
-    "react-jhipster": "<%= nodeDependencies['react-jhipster'] %>",
+    "react-jhipster": "github:Tcharl/react-jhipster#namedJsxElements",
     "react-loadable": "<%= nodeDependencies['react-loadable'] %>",
     "react-redux": "<%= nodeDependencies['react-redux'] %>",
     "react-redux-loading-bar": "<%= nodeDependencies['react-redux-loading-bar'] %>",
@@ -132,6 +132,7 @@
     "ts-loader": "<%= nodeDependencies['ts-loader'] %>",
 <%_ if (cypressTests) { _%>
     "cypress": "<%= nodeDependencies['cypress'] %>",
+    "cypress-intellij-reporter": "^0.0.7",
 <%_ } _%>
     "typescript": "<%= nodeDependencies['typescript'] %>",
     "webpack": "<%= nodeDependencies['webpack'] %>",

--- a/generators/react/templates/package.json.ejs
+++ b/generators/react/templates/package.json.ejs
@@ -41,7 +41,7 @@
     "react": "<%= nodeDependencies['react'] %>",
     "react-dom": "<%= nodeDependencies['react-dom'] %>",
     "react-hook-form": "<%= nodeDependencies['react-hook-form'] %>",
-    "react-jhipster": "github:Tcharl/react-jhipster#namedJsxElements",
+    "react-jhipster": "github:hide212131/react-jhipster#namedJsxElements",
     "react-loadable": "<%= nodeDependencies['react-loadable'] %>",
     "react-redux": "<%= nodeDependencies['react-redux'] %>",
     "react-redux-loading-bar": "<%= nodeDependencies['react-redux-loading-bar'] %>",

--- a/generators/react/templates/src/main/webapp/app/entities/_entityFolder/_entityFile-update.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/_entityFolder/_entityFile-update.tsx.ejs
@@ -288,11 +288,11 @@ _%>
           />
   <%_ } else if (field.fieldTypeBinary) { _%>
     <%_ if (!field.blobContentTypeText) {  _%>
-            <%_ if (field.blobContentTypeImage) {_%>
+      <%_ if (field.blobContentTypeImage) {_%>
             isImage accept="image/*"
-            <%_ } else { _%>
+      <%_ } else { _%>
             openActionLabel={translate('entity.action.open')}
-            <%_ } _%>
+      <%_ } _%>
             <%- include('react_validators'); %>
           />
     <%_ } else { _%>

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
@@ -17,21 +17,21 @@
  limitations under the License.
 -%>
 import React, { useState, useEffect } from 'react';
-import { Col, Row, Button } from 'reactstrap';
-import { Translate, translate, ValidatedField, ValidatedForm } from 'react-jhipster';
-import { useSearchParams } from 'react-router-dom';
+import { Col, Row, Button, Form } from 'reactstrap';
+import { Translate, translate, ValidatedTextInput } from 'react-jhipster';
 import { toast } from 'react-toastify';
-
+import { useSearchParams } from 'react-router-dom';
 import { handlePasswordResetFinish, reset } from '../password-reset.reducer';
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 import { useAppDispatch, useAppSelector } from 'app/config/store';
+import { useForm } from 'react-hook-form';
 
 export const PasswordResetFinishPage = () => {
   const dispatch = useAppDispatch();
 
   const [searchParams] = useSearchParams();
   const key = searchParams.get('key');
-
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
   const [password, setPassword] = useState('');
 
   useEffect(
@@ -40,48 +40,6 @@ export const PasswordResetFinishPage = () => {
     },
     []
   );
-
-  const handleValidSubmit = ({ newPassword }) => dispatch(handlePasswordResetFinish({ key, newPassword }));
-
-  const updatePassword = event => setPassword(event.target.value);
-
-  const getResetForm = () => {
-    return (
-      <ValidatedForm onSubmit={handleValidSubmit}>
-        <ValidatedField
-          name="newPassword"
-          label={translate('global.form.newpassword.label')}
-          placeholder={translate('global.form.newpassword.placeholder')}
-          type="password"
-          validate={{
-            required: { value: true, message: translate('global.messages.validate.newpassword.required') },
-            minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
-            maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') },
-          }}
-          onChange={updatePassword}
-          data-cy="resetPassword"
-        />
-        <PasswordStrengthBar password={password} />
-        <ValidatedField
-          name="confirmPassword"
-          label={translate('global.form.confirmpassword.label')}
-          placeholder={translate('global.form.confirmpassword.placeholder')}
-          type="password"
-          validate={{
-            required: { value: true, message: translate('global.messages.validate.confirmpassword.required') },
-            minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
-            maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
-            validate: v => v === password || translate('global.messages.error.dontmatch'),
-          }}
-          data-cy="confirmResetPassword"
-        />
-        <Button color="success" type="submit" data-cy="submit">
-          <Translate contentKey="reset.finish.form.button">Validate new password</Translate>
-        </Button>
-      </ValidatedForm>
-    );
-  };
-
   const successMessage = useAppSelector(state => state.passwordReset.successMessage);
 
   useEffect(() => {
@@ -93,6 +51,59 @@ export const PasswordResetFinishPage = () => {
 <%_ } _%>
     }
   }, [successMessage]);
+
+  const handleValidSubmit = data => {
+    dispatch(handlePasswordResetFinish({ key: data.key, newPassword: data.newPassword }));
+  }
+
+  const updatePassword = event => {
+    setPassword(event.target.value);
+    setValue('newPassword', event.target.value, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+  }
+
+  const getResetForm = () => {
+    return (
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      <Form onSubmit={ handleSubmit(handleValidSubmit) }>
+        <ValidatedTextInput
+          register={ register }
+          touchedFields={ touchedFields }
+          errors={ errors }
+          setValue={ setValue }
+          name="newPassword"
+          validation={ {
+            required: translate('global.messages.validate.newpassword.required') ,
+            minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
+            maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') },
+          } }
+          labelPlaceholderKey="global.form.newpassword.label"
+          inputPlaceholderKey="global.form.newpassword.placeholder"
+          type="password"
+          updateValueOverrideMethod={ updatePassword }
+        />
+        <PasswordStrengthBar password={password} />
+        <ValidatedTextInput
+          register={ register }
+          touchedFields={ touchedFields }
+          errors={ errors }
+          setValue={ setValue }
+          name="confirmPassword"
+          validation={ {
+            required: translate('global.messages.validate.confirmpassword.required'),
+            minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
+            maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
+            validate: v => v === password || translate('global.messages.error.dontmatch'),
+          } }
+          labelPlaceholderKey="global.form.confirmpassword.label"
+          inputPlaceholderKey="global.form.confirmpassword.placeholder"
+          type="password"
+        />
+        <Button color="success" type="submit" data-cy="submit">
+          <Translate contentKey="reset.finish.form.button">Validate new password</Translate>
+        </Button>
+      </Form>
+    );
+  };
 
   return (
     <div>

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
@@ -71,11 +71,11 @@ export const PasswordResetFinishPage = () => {
           errors={ errors }
           setValue={ setValue }
           name="newPassword"
-          validate={ {
+          validate={{
             required: translate('global.messages.validate.newpassword.required') ,
             minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
             maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') },
-          } }
+          }}
           labelPlaceholderKey="global.form.newpassword.label"
           inputPlaceholderKey="global.form.newpassword.placeholder"
           type="password"
@@ -88,12 +88,12 @@ export const PasswordResetFinishPage = () => {
           errors={ errors }
           setValue={ setValue }
           name="confirmPassword"
-          validate={ {
+          validate={{
             required: translate('global.messages.validate.confirmpassword.required'),
             minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
             maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
             validate: v => v === password || translate('global.messages.error.dontmatch'),
-          } }
+          }}
           labelPlaceholderKey="global.form.confirmpassword.label"
           inputPlaceholderKey="global.form.confirmpassword.placeholder"
           type="password"

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
@@ -71,7 +71,7 @@ export const PasswordResetFinishPage = () => {
           errors={ errors }
           setValue={ setValue }
           name="newPassword"
-          validation={ {
+          validate={ {
             required: translate('global.messages.validate.newpassword.required') ,
             minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
             maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') },
@@ -88,7 +88,7 @@ export const PasswordResetFinishPage = () => {
           errors={ errors }
           setValue={ setValue }
           name="confirmPassword"
-          validation={ {
+          validate={ {
             required: translate('global.messages.validate.confirmpassword.required'),
             minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
             maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
@@ -70,7 +70,7 @@ export const PasswordResetFinishPage = () => {
           touchedFields={ touchedFields }
           errors={ errors }
           setValue={ setValue }
-          name="newPassword"
+          nameIdCy="newPassword"
           validate={{
             required: translate('global.messages.validate.newpassword.required') ,
             minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
@@ -87,7 +87,7 @@ export const PasswordResetFinishPage = () => {
           touchedFields={ touchedFields }
           errors={ errors }
           setValue={ setValue }
-          name="confirmPassword"
+          nameIdCy="confirmPassword"
           validate={{
             required: translate('global.messages.validate.confirmpassword.required'),
             minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
@@ -31,7 +31,7 @@ export const PasswordResetFinishPage = () => {
 
   const [searchParams] = useSearchParams();
   const key = searchParams.get('key');
-  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm({ mode: 'onTouched'});
   const [password, setPassword] = useState('');
 
   useEffect(

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
@@ -17,15 +17,17 @@
  limitations under the License.
 -%>
 import React, { useEffect } from 'react';
-import { Translate, translate, ValidatedField, ValidatedForm, isEmail } from 'react-jhipster';
-import { Button, Alert, Col, Row } from 'reactstrap';
+import { Translate, translate, ValidatedTextInput, isEmail } from 'react-jhipster';
+import { Button, Alert, Col, Row, Form } from 'reactstrap';
 import { toast } from 'react-toastify';
 
 import { handlePasswordResetInit, reset } from '../password-reset.reducer';
 import { useAppDispatch, useAppSelector } from 'app/config/store';
+import { useForm } from 'react-hook-form';
 
 export const PasswordResetInit = () => {
   const dispatch = useAppDispatch();
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
 
   useEffect(
     () => () => {
@@ -34,9 +36,9 @@ export const PasswordResetInit = () => {
     []
   );
 
-  const handleValidSubmit = ({ email }) => {
-    dispatch(handlePasswordResetInit(email));
-  };
+  const handleValidSubmit = data => {
+    dispatch(handlePasswordResetInit(data.email));
+  }
 
   const successMessage = useAppSelector(state => state.passwordReset.successMessage);
 
@@ -50,38 +52,44 @@ export const PasswordResetInit = () => {
     }
   }, [successMessage]);
 
-    return (
-      <div>
-        <Row className="justify-content-center">
-          <Col md="8">
-            <h1><Translate contentKey="reset.request.title">Reset your password</Translate></h1>
-            <Alert color="warning">
-              <p><Translate contentKey="reset.request.messages.info">Enter the email address you used to register</Translate></p>
-            </Alert>
-            <ValidatedForm onSubmit={handleValidSubmit}>
-              <ValidatedField
-                name="email"
-                label={translate('global.form.email.label')}
-                placeholder={translate('global.form.email.placeholder')}
-                type="email"
-                validate={{
-                  required: { value: true, message: translate('global.messages.validate.email.required') },
-                  minLength: { value: 5, message: translate('global.messages.validate.email.minlength') },
-                  maxLength: { value: 254, message: translate('global.messages.validate.email.maxlength') },
-                  validate: v => isEmail(v) || translate('global.messages.validate.email.invalid'),
-                }}
-                data-cy="emailResetPassword"
-              />
-              <Button color="primary" type="submit" data-cy="submit">
-                <Translate contentKey="reset.request.form.button">
-                  Reset password
-                </Translate>
-              </Button>
-            </ValidatedForm>
-          </Col>
-        </Row>
-      </div>
-    );
-}
+  return (
+    <div>
+      <Row className="justify-content-center">
+        <Col md="8">
+          <h1>
+            <Translate contentKey="reset.request.title">Reset your password</Translate>
+          </h1>
+          <Alert color="warning">
+            <p>
+              <Translate contentKey="reset.request.messages.info">Enter the email address you used to register</Translate>
+            </p>
+          </Alert>
+          {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+          <Form onSubmit={ handleSubmit(handleValidSubmit) }>
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              name="email"
+              validation={ {
+                required: translate('global.messages.validate.email.required'),
+                minLength: { value: 5, message: translate('global.messages.validate.email.minlength') },
+                maxLength: { value: 254, message: translate('global.messages.validate.email.maxlength') },
+                validate: v => isEmail(v) || translate('global.messages.validate.email.invalid'),
+              }}
+              labelPlaceholderKey="global.form.email.label"
+              inputPlaceholderKey="global.form.email.placeholder"
+              type="email"
+            />
+            <Button color="primary" type="submit" data-cy="submit">
+              <Translate contentKey="reset.request.form.button">Reset password</Translate>
+            </Button>
+          </Form>
+        </Col>
+      </Row>
+    </div>
+  );
+};
 
 export default PasswordResetInit;

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
@@ -71,7 +71,7 @@ export const PasswordResetInit = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="email"
+              nameIdCy="email"
               validate={ {
                 required: translate('global.messages.validate.email.required'),
                 minLength: { value: 5, message: translate('global.messages.validate.email.minlength') },

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
@@ -72,7 +72,7 @@ export const PasswordResetInit = () => {
               errors={ errors }
               setValue={ setValue }
               name="email"
-              validation={ {
+              validate={ {
                 required: translate('global.messages.validate.email.required'),
                 minLength: { value: 5, message: translate('global.messages.validate.email.minlength') },
                 maxLength: { value: 254, message: translate('global.messages.validate.email.maxlength') },

--- a/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
@@ -27,7 +27,7 @@ import { useForm } from 'react-hook-form';
 
 export const PasswordResetInit = () => {
   const dispatch = useAppDispatch();
-  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm({ mode: 'onTouched'});
 
   useEffect(
     () => () => {

--- a/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -18,7 +18,7 @@
 -%>
 import React, { useState, useEffect } from 'react';
 import { Translate, translate, ValidatedTextInput } from 'react-jhipster';
-import { Button, Col, Form, FormFeedback, FormGroup, Input, Label, Row } from 'reactstrap';
+import { Button, Col, Form, Row } from 'reactstrap';
 import { toast } from 'react-toastify';
 
 import { useAppDispatch, useAppSelector } from 'app/config/store';

--- a/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -81,7 +81,7 @@ export const PasswordPage = () => {
               errors={ errors }
               setValue={ setValue }
               name="currentPassword"
-              validation={ { required: translate('global.messages.validate.newpassword.required') } }
+              validate={{ required: translate('global.messages.validate.newpassword.required') }}
               labelPlaceholderKey="global.form.currentpassword.label"
               inputPlaceholderKey="global.form.currentpassword.placeholder"
               type="password"
@@ -92,11 +92,11 @@ export const PasswordPage = () => {
               errors={ errors }
               setValue={ setValue }
               name="newPassword"
-              validation={ {
+              validate={{
                 required: translate('global.messages.validate.newpassword.required'),
                 minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
                 maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') }
-              } }
+              }}
               labelPlaceholderKey="global.form.newpassword.label"
               inputPlaceholderKey="global.form.newpassword.placeholder"
               type="password"
@@ -109,12 +109,12 @@ export const PasswordPage = () => {
               errors={ errors }
               setValue={ setValue }
               name="confirmPassword"
-              validation={ {
+              validate={{
                 required: translate('global.messages.validate.confirmpassword.required'),
                 minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
                 maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
                 validate: v => v === newPassword || translate('global.messages.error.dontmatch'),
-              } }
+              }}
               labelPlaceholderKey="global.form.confirmpassword.label"
               inputPlaceholderKey="global.form.confirmpassword.placeholder"
               type="password"

--- a/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -80,7 +80,7 @@ export const PasswordPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="currentPassword"
+              nameIdCy="currentPassword"
               validate={{ required: translate('global.messages.validate.newpassword.required') }}
               labelPlaceholderKey="global.form.currentpassword.label"
               inputPlaceholderKey="global.form.currentpassword.placeholder"
@@ -91,7 +91,7 @@ export const PasswordPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="newPassword"
+              nameIdCy="newPassword"
               validate={{
                 required: translate('global.messages.validate.newpassword.required'),
                 minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
@@ -108,7 +108,7 @@ export const PasswordPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="confirmPassword"
+              nameIdCy="confirmPassword"
               validate={{
                 required: translate('global.messages.validate.confirmpassword.required'),
                 minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },

--- a/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -17,19 +17,22 @@
  limitations under the License.
 -%>
 import React, { useState, useEffect } from 'react';
-import { Translate, translate, ValidatedField, ValidatedForm } from 'react-jhipster';
-import { Row, Col, Button } from 'reactstrap';
+import { Translate, translate } from 'react-jhipster';
+import { Button, Col, Form, FormFeedback, FormGroup, Input, Label, Row } from 'reactstrap';
 import { toast } from 'react-toastify';
 
 import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { getSession } from 'app/shared/reducers/authentication';
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 import { savePassword, reset } from './password.reducer';
+import { useForm } from 'react-hook-form';
 
 export const PasswordPage = () => {
-  const [password, setPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
   const dispatch = useAppDispatch();
-
+  const { register, handleSubmit, setValue, formState: { errors }} = useForm({
+    mode: 'onTouched'
+  });
   useEffect(() => {
     dispatch(reset());
     dispatch(getSession());
@@ -38,11 +41,9 @@ export const PasswordPage = () => {
     };
   }, []);
 
-  const handleValidSubmit = ({ currentPassword, newPassword }) => {
-    dispatch(savePassword({ currentPassword, newPassword }));
+  const handleValidSubmit = data => {
+    dispatch(savePassword({ currentPassword: data.currentPassword, newPassword: data.newPassword }));
   };
-
-  const updatePassword = event => setPassword(event.target.value);
 
   const account = useAppSelector(state => state.authentication.account);
   const successMessage = useAppSelector(state => state.password.successMessage);
@@ -63,6 +64,10 @@ export const PasswordPage = () => {
     dispatch(reset());
   }, [successMessage, errorMessage]);
 
+  const updateCurrentPassword = event => { setValue('currentPassword', event.target.value); };
+  const updateNewPassword = event => { setNewPassword(event.target.value); setValue('newPassword', event.target.value); };
+  const updateConfirmPassword = event => { setValue('confirmPassword', event.target.value); };
+
   return (
     <div>
       <Row className="justify-content-center">
@@ -72,48 +77,71 @@ export const PasswordPage = () => {
               Password for {account.login}
             </Translate>
           </h2>
-          <ValidatedForm id="password-form" onSubmit={handleValidSubmit}>
-            <ValidatedField
-              name="currentPassword"
-              label={translate('global.form.currentpassword.label')}
-              placeholder={translate('global.form.currentpassword.placeholder')}
-              type="password"
-              validate={{
-                required: { value: true, message: translate('global.messages.validate.newpassword.required') },
-              }}
-              data-cy="currentPassword"
-            />
-            <ValidatedField
-              name="newPassword"
-              label={translate('global.form.newpassword.label')}
-              placeholder={translate('global.form.newpassword.placeholder')}
-              type="password"
-              validate={{
-                required: { value: true, message: translate('global.messages.validate.newpassword.required') },
-                minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
-                maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') },
-              }}
-              onChange={updatePassword}
-              data-cy="newPassword"
-            />
-            <PasswordStrengthBar password={password} />
-            <ValidatedField
-              name="confirmPassword"
-              label={translate('global.form.confirmpassword.label')}
-              placeholder={translate('global.form.confirmpassword.placeholder')}
-              type="password"
-              validate={{
-                required: { value: true, message: translate('global.messages.validate.confirmpassword.required') },
-                minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
-                maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
-                validate: v => v === password || translate('global.messages.error.dontmatch'),
-              }}
-              data-cy="confirmPassword"
-            />
+          {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+          <Form id="password-form" onSubmit={ handleSubmit(handleValidSubmit) }>
+            <FormGroup>
+              <Label id="currentPasswordLabel" for="currentPassword">
+                {translate('global.form.currentpassword.label')}
+              </Label>
+              <Input
+                id="currentPassword"
+                name="currentPassword"
+                placeholder={ translate('global.form.currentpassword.placeholder') }
+                type="password"
+                {...register('currentPassword', { required: translate('global.messages.validate.newpassword.required') })}
+                data-cy="currentPassword"
+                valid={!errors.currentPassword}
+                invalid={!!errors.currentPassword}
+                onChange={updateCurrentPassword}
+              />
+              <FormFeedback hidden={!errors.currentPassword}>{errors.currentPassword?.message}</FormFeedback>
+            </FormGroup>
+            <FormGroup>
+              <Label id="newPasswordLabel" for="newPassword">
+                {translate('global.form.newpassword.label')}
+              </Label>
+              <Input
+                name="newPassword"
+                placeholder={translate('global.form.newpassword.placeholder')}
+                type="password"
+                {...register('newPassword', {
+                  required: translate('global.messages.validate.newpassword.required'),
+                  minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
+                  maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') }
+                })}
+                data-cy="newPassword"
+                valid={!errors.newPassword}
+                invalid={!!errors.newPassword}
+                onChange={updateNewPassword}
+              />
+              <FormFeedback hidden={!errors.newPassword}>{errors.newPassword?.message}</FormFeedback>
+              <PasswordStrengthBar password={newPassword} />
+            </FormGroup>
+            <FormGroup>
+              <Label id="confirmPasswordLabel" for="confirmPassword">
+                {translate('global.form.confirmpassword.label')}
+              </Label>
+              <Input
+                name="confirmPassword"
+                placeholder={translate('global.form.confirmpassword.placeholder')}
+                type="password"
+                {...register('confirmPassword', {
+                  required: translate('global.messages.validate.confirmpassword.required'),
+                  minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
+                  maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
+                  validate: v => v === newPassword || translate('global.messages.error.dontmatch'),
+                })}
+                data-cy="confirmPassword"
+                valid={!errors.confirmPassword}
+                invalid={!!errors.confirmPassword}
+                onChange={updateConfirmPassword}
+              />
+              <FormFeedback hidden={!errors.confirmPassword}>{errors.confirmPassword?.message}</FormFeedback>
+            </FormGroup>
             <Button color="success" type="submit" data-cy="submit">
               <Translate contentKey="password.form.button">Save</Translate>
             </Button>
-          </ValidatedForm>
+          </Form>
         </Col>
       </Row>
     </div>

--- a/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import React, { useState, useEffect } from 'react';
-import { Translate, translate } from 'react-jhipster';
+import { Translate, translate, ValidatedTextInput } from 'react-jhipster';
 import { Button, Col, Form, FormFeedback, FormGroup, Input, Label, Row } from 'reactstrap';
 import { toast } from 'react-toastify';
 
@@ -30,9 +30,7 @@ import { useForm } from 'react-hook-form';
 export const PasswordPage = () => {
   const [newPassword, setNewPassword] = useState('');
   const dispatch = useAppDispatch();
-  const { register, handleSubmit, setValue, formState: { errors }} = useForm({
-    mode: 'onTouched'
-  });
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
   useEffect(() => {
     dispatch(reset());
     dispatch(getSession());
@@ -64,9 +62,7 @@ export const PasswordPage = () => {
     dispatch(reset());
   }, [successMessage, errorMessage]);
 
-  const updateCurrentPassword = event => { setValue('currentPassword', event.target.value); };
-  const updateNewPassword = event => { setNewPassword(event.target.value); setValue('newPassword', event.target.value); };
-  const updateConfirmPassword = event => { setValue('confirmPassword', event.target.value); };
+  const updateNewPassword = event => { setNewPassword(event.target.value); setValue('newPassword', event.target.value, { shouldValidate: true, shouldDirty: true, shouldTouch: true }); };
 
   return (
     <div>
@@ -79,65 +75,50 @@ export const PasswordPage = () => {
           </h2>
           {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
           <Form id="password-form" onSubmit={ handleSubmit(handleValidSubmit) }>
-            <FormGroup>
-              <Label id="currentPasswordLabel" for="currentPassword">
-                {translate('global.form.currentpassword.label')}
-              </Label>
-              <Input
-                id="currentPassword"
-                name="currentPassword"
-                placeholder={ translate('global.form.currentpassword.placeholder') }
-                type="password"
-                {...register('currentPassword', { required: translate('global.messages.validate.newpassword.required') })}
-                data-cy="currentPassword"
-                valid={!errors.currentPassword}
-                invalid={!!errors.currentPassword}
-                onChange={updateCurrentPassword}
-              />
-              <FormFeedback hidden={!errors.currentPassword}>{errors.currentPassword?.message}</FormFeedback>
-            </FormGroup>
-            <FormGroup>
-              <Label id="newPasswordLabel" for="newPassword">
-                {translate('global.form.newpassword.label')}
-              </Label>
-              <Input
-                name="newPassword"
-                placeholder={translate('global.form.newpassword.placeholder')}
-                type="password"
-                {...register('newPassword', {
-                  required: translate('global.messages.validate.newpassword.required'),
-                  minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
-                  maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') }
-                })}
-                data-cy="newPassword"
-                valid={!errors.newPassword}
-                invalid={!!errors.newPassword}
-                onChange={updateNewPassword}
-              />
-              <FormFeedback hidden={!errors.newPassword}>{errors.newPassword?.message}</FormFeedback>
-              <PasswordStrengthBar password={newPassword} />
-            </FormGroup>
-            <FormGroup>
-              <Label id="confirmPasswordLabel" for="confirmPassword">
-                {translate('global.form.confirmpassword.label')}
-              </Label>
-              <Input
-                name="confirmPassword"
-                placeholder={translate('global.form.confirmpassword.placeholder')}
-                type="password"
-                {...register('confirmPassword', {
-                  required: translate('global.messages.validate.confirmpassword.required'),
-                  minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
-                  maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
-                  validate: v => v === newPassword || translate('global.messages.error.dontmatch'),
-                })}
-                data-cy="confirmPassword"
-                valid={!errors.confirmPassword}
-                invalid={!!errors.confirmPassword}
-                onChange={updateConfirmPassword}
-              />
-              <FormFeedback hidden={!errors.confirmPassword}>{errors.confirmPassword?.message}</FormFeedback>
-            </FormGroup>
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              name="currentPassword"
+              validation={ { required: translate('global.messages.validate.newpassword.required') } }
+              labelPlaceholderKey="global.form.currentpassword.label"
+              inputPlaceholderKey="global.form.currentpassword.placeholder"
+              type="password"
+            />
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              name="newPassword"
+              validation={ {
+                required: translate('global.messages.validate.newpassword.required'),
+                minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
+                maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') }
+              } }
+              labelPlaceholderKey="global.form.newpassword.label"
+              inputPlaceholderKey="global.form.newpassword.placeholder"
+              type="password"
+              updateValueOverrideMethod={ updateNewPassword }
+            />
+            <PasswordStrengthBar password={newPassword} />
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              name="confirmPassword"
+              validation={ {
+                required: translate('global.messages.validate.confirmpassword.required'),
+                minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
+                maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
+                validate: v => v === newPassword || translate('global.messages.error.dontmatch'),
+              } }
+              labelPlaceholderKey="global.form.confirmpassword.label"
+              inputPlaceholderKey="global.form.confirmpassword.placeholder"
+              type="password"
+            />
             <Button color="success" type="submit" data-cy="submit">
               <Translate contentKey="password.form.button">Save</Translate>
             </Button>

--- a/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -30,7 +30,7 @@ import { useForm } from 'react-hook-form';
 export const PasswordPage = () => {
   const [newPassword, setNewPassword] = useState('');
   const dispatch = useAppDispatch();
-  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm({ mode: 'onTouched'});
   useEffect(() => {
     dispatch(reset());
     dispatch(getSession());

--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -17,15 +17,18 @@
  limitations under the License.
 -%>
 import React, { useState, useEffect } from 'react';
-import { Translate, translate, ValidatedField, ValidatedForm, isEmail } from 'react-jhipster';
-import { Row, Col, Alert, Button } from 'reactstrap';
+import { Translate, translate, ValidatedTextInput, isEmail } from 'react-jhipster';
+import { Row, Col, Alert, Button, Form } from 'reactstrap';
 import { toast } from 'react-toastify';
 
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { handleRegister, reset } from './register.reducer';
+import { useForm } from 'react-hook-form';
 
 export const RegisterPage = () => {
+
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
   const [password, setPassword] = useState('');
   const dispatch = useAppDispatch();
 
@@ -40,16 +43,15 @@ export const RegisterPage = () => {
   const currentLocale = useAppSelector(state => state.locale.currentLocale);
 <%_ } _%>
 
-  const handleValidSubmit = ({ username, email, firstPassword }) => {
+  const handleValidSubmit = data => {
 <%_ if (enableTranslation) { _%>
-    dispatch(handleRegister({ login: username, email, password: firstPassword, langKey: currentLocale }));
+    dispatch(handleRegister({ login: data.username, email: data.email, password: data.firstPassword, langKey: currentLocale }));
 <%_ } else { _%>
-    dispatch(handleRegister({ login: username, email, password: firstPassword, langKey: 'en' }));
+    dispatch(handleRegister({ login: data.username, email: data.email, password: data.firstPassword, langKey: 'en' }));
 <%_ } _%>
   };
 
-  const updatePassword = event => setPassword(event.target.value);
-
+  const updatePassword = event => { setPassword(event.target.value); setValue('firstPassword', event.target.value, { shouldValidate: true, shouldDirty: true, shouldTouch: true }); };
   const successMessage = useAppSelector(state => state.register.successMessage);
 
   useEffect(() => {
@@ -73,13 +75,16 @@ export const RegisterPage = () => {
       </Row>
       <Row className="justify-content-center">
         <Col md="8">
-          <ValidatedForm id="register-form" onSubmit={handleValidSubmit}>
-            <ValidatedField
+          {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+          <Form id="register-form" onSubmit={ handleSubmit(handleValidSubmit) }>
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
               name="username"
-              label={translate('global.form.username.label')}
-              placeholder={translate('global.form.username.placeholder')}
               validate={{
-                required: { value: true, message: translate('register.messages.validate.login.required') },
+                required: 'register.messages.validate.login.required',
                 pattern: {
                   value: /^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$|^[_.@A-Za-z0-9-]+$/,
                   message: translate('register.messages.validate.login.pattern'),
@@ -87,39 +92,48 @@ export const RegisterPage = () => {
                 minLength: { value: 1, message: translate('register.messages.validate.login.minlength') },
                 maxLength: { value: 50, message: translate('register.messages.validate.login.maxlength') },
               }}
-              data-cy="username"
+              labelPlaceholderKey="global.form.username.label"
+              inputPlaceholderKey="global.form.username.placeholder"
             />
-            <ValidatedField
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
               name="email"
-              label={translate('global.form.email.label')}
-              placeholder={translate('global.form.email.placeholder')}
               type="email"
               validate={{
-                required: { value: true, message: translate('global.messages.validate.email.required') },
+                required: translate('global.messages.validate.email.required'),
                 minLength: { value: 5, message: translate('global.messages.validate.email.minlength') },
                 maxLength: { value: 254, message: translate('global.messages.validate.email.maxlength') },
                 validate: v => isEmail(v) || translate('global.messages.validate.email.invalid'),
               }}
-              data-cy="email"
+              labelPlaceholderKey="global.form.email.label"
+              inputPlaceholderKey="global.form.email.placeholder"
             />
-            <ValidatedField
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
               name="firstPassword"
-              label={translate('global.form.newpassword.label')}
-              placeholder={translate('global.form.newpassword.placeholder')}
               type="password"
-              onChange={updatePassword}
               validate={{
-                required: { value: true, message: translate('global.messages.validate.newpassword.required') },
+                required: translate('global.messages.validate.newpassword.required'),
                 minLength: { value: 4, message: translate('global.messages.validate.newpassword.minlength') },
-                maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') },
+                maxLength: { value: 50, message: translate('global.messages.validate.newpassword.maxlength') }
               }}
-              data-cy="firstPassword"
+              labelPlaceholderKey="global.form.newpassword.label"
+              inputPlaceholderKey="global.form.newpassword.placeholder"
+              updateValueOverrideMethod={ updatePassword }
             />
             <PasswordStrengthBar password={password} />
-            <ValidatedField
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
               name="secondPassword"
-              label={translate('global.form.confirmpassword.label')}
-              placeholder={translate('global.form.confirmpassword.placeholder')}
               type="password"
               validate={{
                 required: { value: true, message: translate('global.messages.validate.confirmpassword.required') },
@@ -127,12 +141,13 @@ export const RegisterPage = () => {
                 maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
                 validate: v => v === password || translate('global.messages.error.dontmatch'),
               }}
-              data-cy="secondPassword"
+              labelPlaceholderKey="global.form.confirmpassword.label"
+              inputPlaceholderKey="global.form.confirmpassword.placeholder"
             />
             <Button id="register-submit" color="primary" type="submit" data-cy="submit">
               <Translate contentKey="register.form.button">Register</Translate>
             </Button>
-          </ValidatedForm>
+          </Form>
           <p>&nbsp;</p>
           <Alert color="warning">
             <span>

--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -82,7 +82,7 @@ export const RegisterPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="username"
+              nameIdCy="username"
               validate={{
                 required: translate('register.messages.validate.login.required'),
                 pattern: {
@@ -100,7 +100,7 @@ export const RegisterPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="email"
+              nameIdCy="email"
               type="email"
               validate={{
                 required: translate('global.messages.validate.email.required'),
@@ -116,7 +116,7 @@ export const RegisterPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="firstPassword"
+              nameIdCy="firstPassword"
               type="password"
               validate={{
                 required: translate('global.messages.validate.newpassword.required'),
@@ -133,7 +133,7 @@ export const RegisterPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="secondPassword"
+              nameIdCy="secondPassword"
               type="password"
               validate={{
                 required: translate('global.messages.validate.confirmpassword.required'),

--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -84,7 +84,7 @@ export const RegisterPage = () => {
               setValue={ setValue }
               name="username"
               validate={{
-                required: 'register.messages.validate.login.required',
+                required: translate('register.messages.validate.login.required'),
                 pattern: {
                   value: /^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$|^[_.@A-Za-z0-9-]+$/,
                   message: translate('register.messages.validate.login.pattern'),
@@ -136,7 +136,7 @@ export const RegisterPage = () => {
               name="secondPassword"
               type="password"
               validate={{
-                required: { value: true, message: translate('global.messages.validate.confirmpassword.required') },
+                required: translate('global.messages.validate.confirmpassword.required'),
                 minLength: { value: 4, message: translate('global.messages.validate.confirmpassword.minlength') },
                 maxLength: { value: 50, message: translate('global.messages.validate.confirmpassword.maxlength') },
                 validate: v => v === password || translate('global.messages.error.dontmatch'),

--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -28,7 +28,7 @@ import { useForm } from 'react-hook-form';
 
 export const RegisterPage = () => {
 
-  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm();
+  const { register, handleSubmit, setValue, formState: { errors, touchedFields }} = useForm({ mode: 'onTouched'});
   const [password, setPassword] = useState('');
   const dispatch = useAppDispatch();
 

--- a/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -17,8 +17,8 @@
  limitations under the License.
 -%>
 import React, { useEffect } from 'react';
-import { Button, Col, Row } from 'reactstrap';
-import { Translate, translate, ValidatedField, ValidatedForm, isEmail } from 'react-jhipster';
+import { Button, Col, Row, Form, Input } from 'reactstrap';
+import { Translate, translate, ValidatedTextInput, isEmail } from 'react-jhipster';
 import { toast } from 'react-toastify';
 
 <%_ if (enableTranslation) { _%>
@@ -27,11 +27,18 @@ import { locales, languages } from 'app/config/translation';
 import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { getSession } from 'app/shared/reducers/authentication';
 import { saveAccountSettings, reset } from './settings.reducer';
+import { useForm } from 'react-hook-form';
 
 export const SettingsPage = () => {
   const dispatch = useAppDispatch();
   const account = useAppSelector(state => state.authentication.account);
   const successMessage = useAppSelector(state => state.settings.successMessage);
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, touchedFields },
+  } = useForm();
 
   useEffect(() => {
     dispatch(getSession());
@@ -68,46 +75,55 @@ export const SettingsPage = () => {
               User settings for {account.login}
             </Translate>
           </h2>
-          <ValidatedForm id="settings-form" onSubmit={handleValidSubmit} defaultValues={account}>
-            <ValidatedField
+          {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+          <Form id="settings-form" onSubmit={handleSubmit(handleValidSubmit)} defaultValues={account}>
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
               name="firstName"
-              label={translate('settings.form.firstname')}
-              id="firstName"
-              placeholder={translate('settings.form.firstname.placeholder')}
               validate={{
-                required: { value: true, message: translate('settings.messages.validate.firstname.required') },
+                required: translate('settings.messages.validate.firstname.required'),
                 minLength: { value: 1, message: translate('settings.messages.validate.firstname.minlength') },
                 maxLength: { value: 50, message: translate('settings.messages.validate.firstname.maxlength') },
               }}
-              data-cy="firstname"
+              labelPlaceholderKey="settings.form.firstname"
+              inputPlaceholderKey="settings.form.firstname.placeholder"
             />
-            <ValidatedField
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
               name="lastName"
-              label={translate('settings.form.lastname')}
-              id="lastName"
-              placeholder={translate('settings.form.lastname.placeholder')}
               validate={{
-                required: { value: true, message: translate('settings.messages.validate.lastname.required') },
+                required: translate('settings.messages.validate.lastname.required'),
                 minLength: { value: 1, message: translate('settings.messages.validate.lastname.minlength') },
                 maxLength: { value: 50, message: translate('settings.messages.validate.lastname.maxlength') },
               }}
-              data-cy="lastname"
+              labelPlaceholderKey="settings.form.lastname"
+              inputPlaceholderKey="settings.form.lastname.placeholder"
             />
-            <ValidatedField
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
               name="email"
-              label={translate('global.form.email.label')}
-              placeholder={translate('global.form.email.placeholder')}
               type="email"
               validate={{
-                required: { value: true, message: translate('global.messages.validate.email.required') },
+                required: translate('global.messages.validate.email.required'),
                 minLength: { value: 5, message: translate('global.messages.validate.email.minlength') },
                 maxLength: { value: 254, message: translate('global.messages.validate.email.maxlength') },
                 validate: v => isEmail(v) || translate('global.messages.validate.email.invalid'),
               }}
-              data-cy="email"
+              labelPlaceholderKey="global.form.email.label"
+              inputPlaceholderKey="global.form.email.placeholder"
             />
+
 <%_ if (enableTranslation) { _%>
-            <ValidatedField
+            <Input
               type="select"
               id="langKey"
               name="langKey"
@@ -119,12 +135,12 @@ export const SettingsPage = () => {
                   {languages[locale].name}
                 </option>
               ))}
-            </ValidatedField>
+            </Input>
 <%_ } _%>
             <Button color="primary" type="submit" data-cy="submit">
               <Translate contentKey="settings.form.button">Save</Translate>
             </Button>
-          </ValidatedForm>
+          </Form>
         </Col>
       </Row>
     </div>

--- a/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -27,7 +27,7 @@ import { locales, languages } from 'app/config/translation';
 import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { getSession } from 'app/shared/reducers/authentication';
 import { saveAccountSettings, reset } from './settings.reducer';
-import { useForm } from 'react-hook-form';
+import { DefaultValues, FieldValues, useForm } from 'react-hook-form';
 
 export const SettingsPage = () => {
   const dispatch = useAppDispatch();
@@ -38,7 +38,16 @@ export const SettingsPage = () => {
     handleSubmit,
     setValue,
     formState: { errors, touchedFields },
-  } = useForm();
+  } = useForm({
+      defaultValues: {
+        firstName: account?.firstName,
+        lastName: account?.lastName,
+        email: account?.email,
+<%_ if (enableTranslation) { _%>
+        langKey: account?.langKey,
+<%_ } _%>
+      } as DefaultValues<FieldValues>
+  });
 
   useEffect(() => {
     dispatch(getSession());
@@ -76,13 +85,13 @@ export const SettingsPage = () => {
             </Translate>
           </h2>
           {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
-          <Form id="settings-form" onSubmit={handleSubmit(handleValidSubmit)} defaultValues={account}>
+          <Form id="settings-form" onSubmit={handleSubmit(handleValidSubmit)}>
             <ValidatedTextInput
               register={ register }
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="firstName"
+              nameIdCy="firstName"
               validate={{
                 required: translate('settings.messages.validate.firstname.required'),
                 minLength: { value: 1, message: translate('settings.messages.validate.firstname.minlength') },
@@ -96,7 +105,7 @@ export const SettingsPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="lastName"
+              nameIdCy="lastName"
               validate={{
                 required: translate('settings.messages.validate.lastname.required'),
                 minLength: { value: 1, message: translate('settings.messages.validate.lastname.minlength') },
@@ -110,7 +119,7 @@ export const SettingsPage = () => {
               touchedFields={ touchedFields }
               errors={ errors }
               setValue={ setValue }
-              name="email"
+              nameIdCy="email"
               type="email"
               validate={{
                 required: translate('global.messages.validate.email.required'),

--- a/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -39,6 +39,7 @@ export const SettingsPage = () => {
     setValue,
     formState: { errors, touchedFields },
   } = useForm({
+      mode: 'onTouched',
       defaultValues: {
         firstName: account?.firstName,
         lastName: account?.lastName,

--- a/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -38,17 +38,19 @@ export const SettingsPage = () => {
     handleSubmit,
     setValue,
     formState: { errors, touchedFields },
-  } = useForm({
-      mode: 'onTouched',
-      defaultValues: {
-        firstName: account?.firstName,
-        lastName: account?.lastName,
-        email: account?.email,
+    reset: resetAsyncForm
+  } = useForm({ mode: 'onTouched' });
+
+  useEffect(() => {
+    resetAsyncForm({
+      firstName: account?.firstName,
+      lastName: account?.lastName,
+      email: account?.email,
 <%_ if (enableTranslation) { _%>
-        langKey: account?.langKey,
+      langKey: account?.langKey,
 <%_ } _%>
-      } as DefaultValues<FieldValues>
-  });
+    } as FieldValues);
+  }, [account]);
 
   useEffect(() => {
     dispatch(getSession());

--- a/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -19,7 +19,7 @@
 import React, { useEffect } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Button, Row, Col, Form, Input } from 'reactstrap';
-import { Translate, translate, ValidatedTextInput, isEmail } from 'react-jhipster';
+import { Translate, translate, ValidatedTextInput, isEmail, registerReactstrap } from 'react-jhipster';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FieldValues, useForm } from 'react-hook-form';
 
@@ -193,12 +193,12 @@ export const UserManagementUpdate = () => {
               type="checkbox"
               name="activated"
               check
-              {...register('activated')}
+              {...registerReactstrap(register, 'activated')}
               disabled={!user.id}
-              label={translate('userManagement.activated')}
             />          
+            {translate('userManagement.activated')}
 <%_ if (enableTranslation) { _%>
-          <Input type="select" name="langKey" label={translate('userManagement.langKey')}>
+          <Input type="select" name="langKey" label={translate('userManagement.langKey')} {...registerReactstrap(register, 'langKey')}>
             {locales.map(locale => (
               <option value={locale} key={locale}>
                 {languages[locale].name}
@@ -206,7 +206,7 @@ export const UserManagementUpdate = () => {
             ))}
           </Input>
 <%_ } _%>
-          <Input type="select" name="authorities" multiple label={translate('userManagement.profiles')}>
+          <Input type="select" name="authorities" multiple label={translate('userManagement.profiles')} {...registerReactstrap(register, 'authorities')}>
             {authorities.map(role => (
               <option value={role} key={role}>
                 {role}

--- a/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -16,11 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { Button, Row, Col, FormText } from 'reactstrap';
-import { Translate, translate, ValidatedField, ValidatedForm, isEmail } from 'react-jhipster';
+import { Button, Row, Col, Form, Input } from 'reactstrap';
+import { Translate, translate, ValidatedTextInput, isEmail } from 'react-jhipster';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { DefaultValues, FieldValues, useForm } from 'react-hook-form';
 
 <%_ if (enableTranslation) { _%>
 import { locales, languages } from 'app/config/translation';
@@ -66,6 +67,23 @@ export const UserManagementUpdate = () => {
   const loading = useAppSelector(state => state.userManagement.loading);
   const updating = useAppSelector(state => state.userManagement.updating);
   const authorities = useAppSelector(state => state.userManagement.authorities);
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, touchedFields },
+  } = useForm({
+        defaultValues: {
+          id: user?.id,
+          login: user?.login,
+          firstName: user?.firstName,
+          lastName: user?.lastName,
+          email: user?.email,
+          activated: user?.activated,
+          langKey: user?.langKey,
+          authorities: user?.authorities,
+        } as DefaultValues<FieldValues>
+    });
 
   return (
     <div>
@@ -79,108 +97,119 @@ export const UserManagementUpdate = () => {
       <Row className="justify-content-center">
         <Col md="8">
         { loading ? <p>Loading...</p>
-        : <ValidatedForm onSubmit={saveUser} defaultValues={user}>
+          /* eslint-disable-next-line @typescript-eslint/no-misused-promises */
+        : <Form onSubmit={handleSubmit(saveUser)}>
           {user.id ? (
-            <ValidatedField
-              type="text"
-              name="id"
-              required
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              nameIdCy="id"
+              validate={{
+                required: true,
+              }}
               readOnly
-              label={translate('global.field.id')}
-              validate={{ required: true }}
+              labelPlaceholderKey="global.field.id"
             />
-          ) : null}
-          <ValidatedField
-            type="text"
-            name="login"
-            label={translate('userManagement.login')}
-            validate={{
-              required: {
-                value: true,
-                message: translate('register.messages.validate.login.required'),
-              },
-              pattern: {
-                value: /<%- webappLoginRegExp %>/,
-                message: translate('register.messages.validate.login.pattern'),
-              },
-              minLength: {
-                value: 1,
-                message: translate('register.messages.validate.login.minlength'),
-              },
-              maxLength: {
-                value: 50,
-                message: translate('register.messages.validate.login.maxlength'),
-              },
-            }}
-          />
-          <ValidatedField
-            type="text"
-            name="firstName"
-            label={translate('userManagement.firstName')}
-            validate={{
-              maxLength: {
-                value: 50,
-                message: translate('entity.validation.maxlength', { max: 50 }),
-              },
-            }}
-          />
-          <ValidatedField
-            type="text"
-            name="lastName"
-            label={translate('userManagement.lastName')}
-            validate={{
-              maxLength: {
-                value: 50,
-                message: translate('entity.validation.maxlength', { max: 50 }),
-              },
-            }}
-          />
-          <FormText>This field cannot be longer than 50 characters.</FormText>
-          <ValidatedField
-            name="email"
-            label={translate('global.form.email.label')}
-            placeholder={translate('global.form.email.placeholder')}
-            type="email"
-            validate={{
-              required: {
-                value: true,
-                message: translate('global.messages.validate.email.required'),
-              },
-              minLength: {
-                value: 5,
-                message: translate('global.messages.validate.email.minlength'),
-              },
-              maxLength: {
-                value: 254,
-                message: translate('global.messages.validate.email.maxlength'),
-              },
-              validate: v => isEmail(v) || translate('global.messages.validate.email.invalid'),
-            }}
-          />
-          <ValidatedField
-            type="checkbox"
-            name="activated"
-            check
-            value={true}
-            disabled={!user.id}
-            label={translate('userManagement.activated')}
-          />
+              ) : null}
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              nameIdCy="login"
+              validate={{
+                required: translate('register.messages.validate.login.required'),
+                pattern: {
+                  value: /<%- webappLoginRegExp %>/,
+                  message: translate('register.messages.validate.login.pattern'),
+                },
+                minLength: {
+                  value: 1,
+                  message: translate('register.messages.validate.login.minlength'),
+                },
+                maxLength: {
+                  value: 50,
+                  message: translate('register.messages.validate.login.maxlength'),
+                },
+              }}
+              labelPlaceholderKey="userManagement.login"
+            />
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              nameIdCy="firstName"
+              validate={{
+                maxLength: {
+                  value: 50,
+                  message: translate('entity.validation.maxlength', { max: 50 }),
+                },
+              }}
+              labelPlaceholderKey="userManagement.firstName"
+            />
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              nameIdCy="lastName"
+              validate={{
+                maxLength: {
+                  value: 50,
+                  message: translate('entity.validation.maxlength', { max: 50 }),
+                },
+              }}
+              labelPlaceholderKey="userManagement.lastName"
+            />
+            <ValidatedTextInput
+              register={ register }
+              touchedFields={ touchedFields }
+              errors={ errors }
+              setValue={ setValue }
+              nameIdCy="email"
+              type="email"
+              validate={{
+                required: translate('global.messages.validate.email.required'),
+                minLength: {
+                  value: 5,
+                  message: translate('global.messages.validate.email.minlength'),
+                },
+                maxLength: {
+                  value: 254,
+                  message: translate('global.messages.validate.email.maxlength'),
+                },
+                validate: v => isEmail(v) || translate('global.messages.validate.email.invalid'),
+              }}
+              labelPlaceholderKey="global.form.email.label"
+              inputPlaceholderKey="global.form.email.placeholder"
+            />
+            <Input
+              type="checkbox"
+              name="activated"
+              check
+              {...register('activated')}
+              disabled={!user.id}
+              label={translate('userManagement.activated')}
+            />          
 <%_ if (enableTranslation) { _%>
-          <ValidatedField type="select" name="langKey" label={translate('userManagement.langKey')}>
+          <Input type="select" name="langKey" label={translate('userManagement.langKey')}>
             {locales.map(locale => (
               <option value={locale} key={locale}>
                 {languages[locale].name}
               </option>
             ))}
-          </ValidatedField>
+          </Input>
 <%_ } _%>
-          <ValidatedField type="select" name="authorities" multiple label={translate('userManagement.profiles')}>
+          <Input type="select" name="authorities" multiple label={translate('userManagement.profiles')}>
             {authorities.map(role => (
               <option value={role} key={role}>
                 {role}
               </option>
             ))}
-          </ValidatedField>
+          </Input>
           <Button tag={Link} to="/admin/user-management" replace color="info">
             <FontAwesomeIcon icon="arrow-left" />&nbsp;
             <span className="d-none d-md-inline">
@@ -192,7 +221,7 @@ export const UserManagementUpdate = () => {
             <FontAwesomeIcon icon="save" />&nbsp;
             <Translate contentKey="entity.action.save">Save</Translate>
           </Button>
-        </ValidatedForm>
+        </Form>
         }
         </Col>
       </Row>

--- a/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -73,6 +73,7 @@ export const UserManagementUpdate = () => {
     setValue,
     formState: { errors, touchedFields },
   } = useForm({
+        mode: 'onTouched',
         defaultValues: {
           id: user?.id,
           login: user?.login,

--- a/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -21,7 +21,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Button, Row, Col, Form, Input } from 'reactstrap';
 import { Translate, translate, ValidatedTextInput, isEmail } from 'react-jhipster';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { DefaultValues, FieldValues, useForm } from 'react-hook-form';
+import { FieldValues, useForm } from 'react-hook-form';
 
 <%_ if (enableTranslation) { _%>
 import { locales, languages } from 'app/config/translation';
@@ -72,19 +72,21 @@ export const UserManagementUpdate = () => {
     handleSubmit,
     setValue,
     formState: { errors, touchedFields },
-  } = useForm({
-        mode: 'onTouched',
-        defaultValues: {
-          id: user?.id,
-          login: user?.login,
-          firstName: user?.firstName,
-          lastName: user?.lastName,
-          email: user?.email,
-          activated: user?.activated,
-          langKey: user?.langKey,
-          authorities: user?.authorities,
-        } as DefaultValues<FieldValues>
-    });
+    reset: resetAsyncForm
+  } = useForm({ mode: 'onTouched'});
+
+  useEffect(() => {
+    resetAsyncForm({
+      id: user?.id,
+      login: user?.login,
+      firstName: user?.firstName,
+      lastName: user?.lastName,
+      email: user?.email,
+      activated: user?.activated,
+      langKey: user?.langKey,
+      authorities: user?.authorities,
+    } as FieldValues);
+  }, [user]);
 
   return (
     <div>

--- a/generators/vue/templates/src/main/webapp/app/account/reset-password/init/reset-password-init.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/reset-password/init/reset-password-init.vue.ejs
@@ -20,7 +20,7 @@
                         <input type="email" class="form-control" id="email" name="email"
                             v-bind:placeholder="t$('global.form[\'email.placeholder\']')"
                             :class="{ valid: !v$.resetAccount.email.$invalid, invalid: v$.resetAccount.email.$invalid }"
-                            v-model="v$.resetAccount.email.$model" minlength="5" maxlength="254" email required data-cy="emailResetPassword" />
+                            v-model="v$.resetAccount.email.$model" minlength="5" maxlength="254" email required data-cy="email" />
                         <div v-if="v$.resetAccount.email.$anyDirty && v$.resetAccount.email.$invalid">
                             <small class="form-text text-danger" v-if="!v$.resetAccount.email.required"
                                 v-text="t$('global.messages.validate.email.required')">

--- a/generators/vue/templates/src/main/webapp/app/account/settings/settings.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/settings/settings.vue.ejs
@@ -27,7 +27,7 @@
             <input type="text" class="form-control" id="firstName" name="firstName"
               v-bind:placeholder="t$('settings.form[\'firstname.placeholder\']')"
               :class="{ valid: !v$.settingsAccount.firstName.$invalid, invalid: v$.settingsAccount.firstName.$invalid }"
-              v-model="v$.settingsAccount.firstName.$model" minlength="1" maxlength="50" required data-cy="firstname" />
+              v-model="v$.settingsAccount.firstName.$model" minlength="1" maxlength="50" required data-cy="firstName" />
             <div v-if="v$.settingsAccount.firstName.$anyDirty && v$.settingsAccount.firstName.$invalid">
               <small class="form-text text-danger" v-if="!v$.settingsAccount.firstName.required"
                 v-text="t$('settings.messages.validate.firstname.required')">
@@ -48,7 +48,7 @@
             <input type="text" class="form-control" id="lastName" name="lastName"
               v-bind:placeholder="t$('settings.form[\'lastname.placeholder\']')"
               :class="{ valid: !v$.settingsAccount.lastName.$invalid, invalid: v$.settingsAccount.lastName.$invalid }"
-              v-model="v$.settingsAccount.lastName.$model" minlength="1" maxlength="50" required data-cy="lastname" />
+              v-model="v$.settingsAccount.lastName.$model" minlength="1" maxlength="50" required data-cy="lastName" />
             <div v-if="v$.settingsAccount.lastName.$anyDirty && v$.settingsAccount.lastName.$invalid">
               <small class="form-text text-danger" v-if="!v$.settingsAccount.lastName.required"
                 v-text="t$('settings.messages.validate.lastname.required')">


### PR DESCRIPTION
A PR to continue the discussion from https://github.com/jhipster/generator-jhipster/pull/19560

> Updates standard forms to use wrapped leaf element instead of a form wrapper.
> - let the user mix his own components with JH wrapped elements
> - compatible with latest react version (which forbids the use of useState and useEffect within a lib from what I've tested)
> - use something that he better knows to use
> - No need to maintain the react-jhipster forms code which is a bit... difficult to understand

I've made changes to the codes by @Tcharl to incorporate the following features:
- Rebased on the latest main branch.
- Updated to the newest reactstrap (v9.2).
- Fixed several issues.
- Modified checkbox and select functionalities to pass the e2e tests.

Currently, all tests pass when running `npm run e2e`.

Refer to the following information:
- Related to [react-jhipster](https://github.com/hide212131/react-jhipster/tree/namedJsxElements)
  - Added [ValidatedTextInput](https://github.com/hide212131/react-jhipster/blob/namedJsxElements/src/form/validated-text-input.tsx) to react-jhipster.
- [Sample app generated](https://github.com/hide212131/jhipster-sample-app/tree/remove_vadidated_forms). 
  - [The code diffs when using `ValidatedTextInput`](https://github.com/hide212131/jhipster-sample-app/commit/79af12a759f78c5ae60d426d323fe7ee78deeb91).
