### PR TITLE
Sonar: Remove this use of 'getMarker'; it is deprecated

### DIFF
--- a/generators/server/templates/src/main/java/package/config/CRLFLogConverter.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CRLFLogConverter.java.ejs
@@ -5,6 +5,7 @@ import ch.qos.logback.core.pattern.CompositeConverter;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Marker;
@@ -46,7 +47,8 @@ public class CRLFLogConverter extends CompositeConverter<ILoggingEvent> {
     @Override
     protected String transform(ILoggingEvent event, String in) {
         AnsiElement element = ELEMENTS.get(getFirstOption());
-        if ((event.getMarker() != null && event.getMarker().contains(CRLF_SAFE_MARKER)) || isLoggerSafe(event)) {
+        List<Marker> markers = event.getMarkerList();
+        if ((markers != null && !markers.isEmpty() && markers.get(0).contains(CRLF_SAFE_MARKER)) || isLoggerSafe(event)) {
             return in;
         }
         String replacement = element == null ? "_" : toAnsiString("_", element);


### PR DESCRIPTION
Related to #23141 
Fix:
- https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jhipster-sample-application&open=AYT5NKBUoub84d7atcQe
- https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jhipster-sample-application&open=AYT5NKBUoub84d7atcQf

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
