### PR TITLE
Fix gateway users cache

### DIFF
--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
@@ -123,6 +123,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
   <%_ } _%>
 
 import java.util.HashSet;
@@ -394,11 +395,10 @@ public class SecurityConfiguration {
                 if (jwt.hasClaim("given_name") && jwt.hasClaim("family_name")) {
                     return Mono.just(jwt);
                 }
-                // Retrieve user info from OAuth provider if not already loaded
-                return users.get(jwt.getSubject(), s -> {
-                    WebClient webClient = WebClient.create();
-
-                    return webClient
+                // Get user info from `users` cache if present
+                return Optional.ofNullable(users.getIfPresent(jwt.getSubject()))
+                    // Retrieve user info from OAuth provider if not already loaded
+                    .orElseGet(() -> WebClient.create()
                         .get()
                         .uri(userInfoUri)
                         .headers(headers -> headers.setBearerAuth(token))
@@ -428,8 +428,10 @@ public class SecurityConfiguration {
                                 })
                                 .claims(claims -> claims.putAll(jwt.getClaims()))
                                 .build()
-                        );
-                });
+                        )
+                        // Put user info into the `users` cache
+                        .doOnNext(newJwt -> users.put(jwt.getSubject(), Mono.just(newJwt)))
+                    );
             }
         };
     }


### PR DESCRIPTION
cache simple Mono of JWT instead the whole pipe, because previously OAuth2 /userinfo calls were performed each time cached Monos were accessed

Fix #20063

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
