### PR TITLE
add String.valueof() for correct log message

### DIFF
--- a/generators/server/templates/src/main/java/package/aop/logging/LoggingAspect.java.ejs
+++ b/generators/server/templates/src/main/java/package/aop/logging/LoggingAspect.java.ejs
@@ -99,7 +99,7 @@ public class LoggingAspect {
                 .error(
                     "Exception in {}() with cause = {}",
                     joinPoint.getSignature().getName(),
-                    String.valueOf(e.getCause() != null ? e.getCause() : "NULL")
+                    e.getCause() != null ? String.valueOf(e.getCause()) : "NULL"
                 );
         }
     }

--- a/generators/server/templates/src/main/java/package/aop/logging/LoggingAspect.java.ejs
+++ b/generators/server/templates/src/main/java/package/aop/logging/LoggingAspect.java.ejs
@@ -99,7 +99,7 @@ public class LoggingAspect {
                 .error(
                     "Exception in {}() with cause = {}",
                     joinPoint.getSignature().getName(),
-                    e.getCause() != null ? e.getCause() : "NULL"
+                    String.valueOf(e.getCause() != null ? e.getCause() : "NULL")
                 );
         }
     }


### PR DESCRIPTION
Fix #21304

`logger.error()` may not work rightly with logback, because the cause is a exception.
Maybe use `String.valueof()` to wrap the cause.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
