### PR TITLE
Sonar: Remove this use of 'setCookieName'; it is deprecated

### DIFF
--- a/generators/server/templates/src/main/java/package/config/LocaleConfiguration_imperative.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/LocaleConfiguration_imperative.java.ejs
@@ -31,9 +31,7 @@ public class LocaleConfiguration implements WebMvcConfigurer {
 
     @Bean
     public LocaleResolver localeResolver() {
-        AngularCookieLocaleResolver cookieLocaleResolver = new AngularCookieLocaleResolver();
-        cookieLocaleResolver.setCookieName("NG_TRANSLATE_LANG_KEY");
-        return cookieLocaleResolver;
+        return new AngularCookieLocaleResolver("NG_TRANSLATE_LANG_KEY");
     }
 
     @Override


### PR DESCRIPTION
With https://github.com/jhipster/jhipster-bom/releases/tag/8.0.0-beta.3 we can finish https://github.com/jhipster/generator-jhipster/issues/23141
Fix: https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jhipster-sample-application&open=AYT5NKCfoub84d7atcQh

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
