### PR TITLE
Follow option imports at blueprints.

### DIFF
--- a/generators/base/api.d.mts
+++ b/generators/base/api.d.mts
@@ -62,9 +62,22 @@ export type JHipsterGeneratorOptions = BaseOptions & {
 
 export type JHipsterGeneratorFeatures = BaseFeatures & {
   priorityArgs?: boolean;
+  /**
+   * Wraps write context and shows removed fields and replacements if exists.
+   */
   jhipster7Migration?: boolean;
   sbsBlueprint?: boolean;
   checkBlueprint?: boolean;
+  /**
+   * Compose with bootstrap generator.
+   *
+   * Bootstrap generator adds support to:
+   *  - multistep templates.
+   *  - sort jhipster configuration json.
+   *  - force jhipster configuration commit.
+   *  - earlier prettier config commit for correct prettier.
+   *  - prettier and eslint.
+   */
   jhipsterBootstrap?: boolean;
   /**
    * Store current version at .yo-rc.json.
@@ -168,6 +181,17 @@ export type JHipsterOptions = Record<string, JHipsterOption>;
 export type JHipsterCommandDefinition = {
   arguments?: JHipsterArguments;
   options: JHipsterOptions;
+  /**
+   * Import options from a generator.
+   * @example ['server', 'jhipster-blueprint:server']
+   */
   import?: string[];
+  /**
+   * Override options from the generator been blueprinted.
+   */
+  override?: boolean;
+  /**
+   * Load old options definition (yeoman's `this.options()`) from the generator.
+   */
   loadGeneratorOptions?: boolean;
 };

--- a/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
+++ b/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
@@ -49,7 +49,12 @@ export default class extends <%= generatorClass %>Generator {
 
 <%_ } else if (!customGenerator) { _%>
   constructor(args, opts, features) {
-    super(args, opts, { ...features, checkBlueprint: true });
+    super(args, opts, {
+      ...features,
+      checkBlueprint: true,
+      // Dropped it once migration is done.
+      jhipster7Migration: true,
+    });
   }
 
 <%_ } _%>


### PR DESCRIPTION
- enable jhipster 7 migration by default.
- follow option import at blueprints.
- allow blueprints to override main options.

related to https://github.com/jhipster/generator-jhipster/issues/23449
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
