### PR TITLE
fix writing task filename in generate-blueprint

### DIFF
--- a/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
+++ b/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
@@ -79,7 +79,7 @@ export default class extends <%= generatorClass %>Generator {
         await this.writeFiles({
           sections: {
             files: [
-              { templates: ['template-file-<%= jhipsterGenerator %>'] },
+              { templates: ['template-file-<%= generator %>'] },
             ],
           },
           context: application,


### PR DESCRIPTION
<!--
PR description.
-->

Example: In the 'server' sub-generator:
- Generated template file:
```
server
  templates
     template-file-server.ejs
```

- Code from 'generator.mjs':
```javascript
files: [{ templates: ['template-file-base-application'] }],
```

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
