### PR TITLE
rename javadoc to documentation

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/detail/_entityFile_-detail.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/detail/_entityFile_-detail.component.html.ejs
@@ -32,7 +32,7 @@
     const fieldName = field.fieldName;
     const fieldType = field.fieldType;
 _%>
-        <dt><span <%= jhiPrefix %>Translate="<%= field.fieldTranslationKey %>"<% if (field.javadoc) { if (enableTranslation) { %> [ngbTooltip]="'<%= i18nKeyPrefix %>.help.<%= fieldName %>' | translate"<% } else { %> ngbTooltip="<%= field.javadoc %>"<% } } %>>__jhiTransformTranslate__('<%- field.fieldTranslationKey %>')</span></dt>
+        <dt><span <%= jhiPrefix %>Translate="<%= field.fieldTranslationKey %>"<% if (field.documentation) { if (enableTranslation) { %> [ngbTooltip]="'<%= i18nKeyPrefix %>.help.<%= fieldName %>' | translate"<% } else { %> ngbTooltip="<%= field.documentation %>"<% } } %>>__jhiTransformTranslate__('<%- field.fieldTranslationKey %>')</span></dt>
         <dd>
     <%_ if (field.fieldIsEnum) { _%>
           <%# TODO: import enum and use its key as label _%>

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-update.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-update.component.html.ejs
@@ -45,7 +45,7 @@
 _%>
 
                 <div class="mb-3"<% if (field.autoGenerate) { %> *ngIf="editForm.controls.<%= field.fieldName %>.value !== null"<% } %>>
-                    <label class="form-label" <%= jhiPrefix %>Translate="<%= translationKey %>" for="field_<%= fieldName %>"<% if (field.javadoc) { if (enableTranslation) { %> [ngbTooltip]="'<%= i18nKeyPrefix %>.help.<%= fieldName %>' | translate"<% } else { %> ngbTooltip="<%= field.javadoc %>"<% } } %>><%= fieldNameHumanized %></label>
+                    <label class="form-label" <%= jhiPrefix %>Translate="<%= translationKey %>" for="field_<%= fieldName %>"<% if (field.documentation) { if (enableTranslation) { %> [ngbTooltip]="'<%= i18nKeyPrefix %>.help.<%= fieldName %>' | translate"<% } else { %> ngbTooltip="<%= field.documentation %>"<% } } %>><%= fieldNameHumanized %></label>
   <%_ if (field.fieldIsEnum) { _%>
                     <select class="form-control" name="<%= fieldName %>" formControlName="<%= fieldName %>" id="field_<%= fieldName %>" data-cy="<%= fieldName %>">
     <%_ const enumPrefix = frontendAppName + '.'+ fieldType; _%>

--- a/generators/base-application/support/enum.mjs
+++ b/generators/base-application/support/enum.mjs
@@ -90,7 +90,7 @@ export const getEnumInfo = (field, clientRootFolder) => {
   const customValuesState = getCustomValuesState(enums);
   return {
     enumName: field.fieldType,
-    javadoc: field.fieldTypeJavadoc && formatDocAsJavaDoc(field.fieldTypeJavadoc),
+    javadoc: field.fieldTypeDocumentation && formatDocAsJavaDoc(field.fieldTypeDocumentation),
     enumInstance: field.enumInstance,
     enums,
     ...customValuesState,

--- a/generators/base-application/support/enum.spec.mts
+++ b/generators/base-application/support/enum.spec.mts
@@ -8,7 +8,7 @@ describe('base-application - support - enum', () => {
 
       before(() => {
         const clientRootFolder = 'root';
-        const field = { enumName: 'fieldName', fieldType: 'BigLetters', fieldValues: 'AAA, BBB', fieldTypeJavadoc: 'enum comment' };
+        const field = { enumName: 'fieldName', fieldType: 'BigLetters', fieldValues: 'AAA, BBB', fieldTypeDocumentation: 'enum comment' };
         enumInfo = getEnumInfo(field, clientRootFolder);
       });
 

--- a/generators/base-application/support/prepare-entity.mts
+++ b/generators/base-application/support/prepare-entity.mts
@@ -519,7 +519,7 @@ export function preparePostEntityCommonDerivedProperties(entity: Entity) {
   const fieldsType = sortedUniq(fields.map(({ fieldType }) => fieldType).filter(fieldType => !fieldIsEnum(fieldType)));
 
   // TODO move to server generator
-  entity.anyFieldHasDocumentation = entity.fields.some(({ javadoc }) => javadoc);
+  entity.anyFieldHasDocumentation = entity.fields.some(({ documentation }) => documentation);
 
   entity.anyFieldIsZonedDateTime = fieldsType.includes(ZONED_DATE_TIME);
   entity.anyFieldIsInstant = fieldsType.includes(INSTANT);

--- a/generators/base-application/support/prepare-field.mjs
+++ b/generators/base-application/support/prepare-field.mjs
@@ -375,7 +375,13 @@ export function fieldToReference(entity, field, pathPrefix = []) {
     field,
     multiple: false,
     owned: true,
-    doc: field.javadoc,
+    doc: field.documentation,
+    get propertyJavadoc() {
+      return field.fieldJavadoc;
+    },
+    get propertyApiDescription() {
+      return field.fieldApiDescription;
+    },
     label: field.fieldNameHumanized,
     name: field.fieldName,
     type: field.fieldType,

--- a/generators/base-application/support/prepare-relationship.mjs
+++ b/generators/base-application/support/prepare-relationship.mjs
@@ -261,7 +261,13 @@ function relationshipToReference(entity, relationship, pathPrefix = []) {
     relationship,
     owned: relationship.ownerSide,
     collection,
-    doc: relationship.javaDoc,
+    doc: relationship.documentation,
+    get propertyJavadoc() {
+      return relationship.relationshipJavadoc;
+    },
+    get propertyApiDescription() {
+      return relationship.relationshipApiDescription;
+    },
     name,
     nameCapitalized: collection ? relationship.relationshipNameCapitalizedPlural : relationship.relationshipNameCapitalized,
     get type() {

--- a/generators/bootstrap-application-server/generator.mts
+++ b/generators/bootstrap-application-server/generator.mts
@@ -41,6 +41,7 @@ import {
   hibernateSnakeCase,
   loadServerConfig,
   loadDerivedServerConfig,
+  prepareRelationship,
 } from '../server/support/index.mjs';
 import { prepareField as prepareFieldForLiquibaseTemplates } from '../liquibase/support/index.mjs';
 import { dockerPlaceholderGenerator, getDockerfileContainers } from '../docker/utils.mjs';
@@ -181,6 +182,18 @@ export default class BoostrapApplicationServer extends BaseApplicationGenerator 
 
   get [BaseApplicationGenerator.PREPARING_EACH_ENTITY_FIELD]() {
     return this.preparingEachEntityField;
+  }
+
+  get preparingEachEntityRelationship() {
+    return this.asPreparingEachEntityRelationshipTaskGroup({
+      prepareRelationship({ entity, relationship }) {
+        prepareRelationship({ entity, relationship });
+      },
+    });
+  }
+
+  get [BaseApplicationGenerator.PREPARING_EACH_ENTITY_RELATIONSHIP]() {
+    return this.preparingEachEntityRelationship;
   }
 
   get postPreparingEachEntity() {

--- a/generators/common/generator.mjs
+++ b/generators/common/generator.mjs
@@ -100,6 +100,39 @@ export default class CommonGenerator extends BaseApplicationGenerator {
     return this.delegateTasksToBlueprint(() => this.configuring);
   }
 
+  get configuringEachEntity() {
+    return this.asConfiguringEachEntityTaskGroup({
+      migrateEntity({ entityConfig, entityStorage }) {
+        for (const field of entityConfig.fields) {
+          if (field.javadoc) {
+            field.documentation = field.javadoc;
+            delete field.javadoc;
+          }
+          if (field.fieldTypeJavadoc) {
+            field.fieldTypeDocumentation = field.fieldTypeJavadoc;
+            delete field.fieldTypeJavadoc;
+          }
+        }
+        for (const relationship of entityConfig.relationships) {
+          if (relationship.javadoc) {
+            relationship.documentation = relationship.javadoc;
+            delete relationship.javadoc;
+          }
+        }
+        if (entityConfig.javadoc) {
+          entityConfig.documentation = entityConfig.javadoc;
+          delete entityConfig.javadoc;
+        } else {
+          entityStorage.save();
+        }
+      },
+    });
+  }
+
+  get [BaseApplicationGenerator.CONFIGURING_EACH_ENTITY]() {
+    return this.asInitializingTaskGroup(this.delegateTasksToBlueprint(() => this.configuringEachEntity));
+  }
+
   // Public API method used by the getter and also by Blueprints
   get loading() {
     return {

--- a/generators/export-jdl/export-jdl.spec.mts
+++ b/generators/export-jdl/export-jdl.spec.mts
@@ -20,7 +20,7 @@ const files = {
       {
         fieldName: 'countryId',
         fieldType: 'Long',
-        javadoc: 'The country Id',
+        documentation: 'The country Id',
       },
       {
         fieldName: 'countryName',
@@ -106,7 +106,7 @@ const files = {
       },
       {
         fieldName: 'firstName',
-        javadoc: 'The firstname attribute.',
+        documentation: 'The firstname attribute.',
         fieldType: 'String',
       },
       {
@@ -138,7 +138,7 @@ const files = {
       },
     ],
     changelogDate: '20160926083805',
-    javadoc: 'The Employee entity.',
+    documentation: 'The Employee entity.',
     entityTableName: 'emp',
     dto: 'mapstruct',
     pagination: 'infinite-scroll',

--- a/generators/languages/templates/entity/i18n/entity_al.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_al.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<%for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ar-ly.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ar-ly.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_az-Latn-az.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_az-Latn-az.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_bg.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_bg.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_bn.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_bn.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_by.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_by.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ca.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ca.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_cs.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_cs.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_da.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_da.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_de.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_de.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_el.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_el.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_en.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_en.json.ejs
@@ -52,13 +52,13 @@
             ,
             "<%= relationship.relationshipName %>": "<%= relationship.relationshipNameHumanized %>"
 <%_ } -%>
-<%_ const fieldsWithDoc = fields.filter(field => field.javadoc); -%>
+<%_ const fieldsWithDoc = fields.filter(field => field.documentation); -%>
 <%_ if (fieldsWithDoc.length > 0) { -%>
   <%_ const lastField = fieldsWithDoc[fieldsWithDoc.length - 1]; -%>
             ,
             "help": {
   <%_ for (const field of fieldsWithDoc) { _%>
-                "<%= field.fieldName %>": "<%= field.javadoc %>"<% if (field !== lastField) { %>,<% } %>
+                "<%= field.fieldName %>": "<%= field.documentation %>"<% if (field !== lastField) { %>,<% } %>
   <%_ } _%>
             }
 <%_ } _%>

--- a/generators/languages/templates/entity/i18n/entity_es.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_es.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_et.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_et.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_fa.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_fa.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_fi.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_fi.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_fr.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_fr.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_gl.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_gl.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_hi.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_hi.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_hr.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_hr.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_hu.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_hu.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_hy.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_hy.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_id.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_id.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_it.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_it.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ja.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ja.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ko.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ko.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_kr-Latn-kr.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_kr-Latn-kr.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_mr.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_mr.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_my.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_my.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_nl.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_nl.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_pa.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_pa.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_pl.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_pl.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_pt-br.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_pt-br.json.ejs
@@ -62,13 +62,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_pt-pt.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_pt-pt.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ro.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ro.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ru.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ru.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_si.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_si.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_sk.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_sk.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_sr.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_sr.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_sv.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_sv.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ta.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ta.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_te.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_te.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_th.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_th.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_tr.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_tr.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_ua.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_ua.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_uz-Cyrl-uz.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_uz-Cyrl-uz.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_uz-Latn-uz.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_uz-Latn-uz.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_vi.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_vi.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_zh-cn.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_zh-cn.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/languages/templates/entity/i18n/entity_zh-tw.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_zh-tw.json.ejs
@@ -45,13 +45,13 @@ let helpBlocks = 0; %>
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {
-            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            if (typeof fields[idx].documentation !== 'undefined') ++helpBlocks; %>,
             "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
-                if (fields[idx].javadoc) {
+                if (fields[idx].documentation) {
                     --helpBlocks; %>
-                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].documentation %>"<% if (helpBlocks > 0) { %>,<% }
                 }
             } %>
             }<% } %>

--- a/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -34,9 +34,9 @@
         Added the entity <%= entity.entityClass %>.
     -->
     <changeSet id="<%= changelogDate %>-1" author="jhipster">
-        <createTable tableName="<%= entity.entityTableName %>"<%- this.formatAsLiquibaseRemarks(entity.javadoc, true) %>>
+        <createTable tableName="<%= entity.entityTableName %>"<%- this.formatAsLiquibaseRemarks(entity.documentation, true) %>>
 <%_ for (field of fields) { _%>
-            <column name="<%= field.columnName %>" type="<%= field.columnType %>"<%- this.formatAsLiquibaseRemarks(field.javadoc, true) %><% if (field.id && field.liquibaseAutoIncrement) { %> autoIncrement="true" startWith="1500"<%_ } %>>
+            <column name="<%= field.columnName %>" type="<%= field.columnType %>"<%- this.formatAsLiquibaseRemarks(field.documentation, true) %><% if (field.id && field.liquibaseAutoIncrement) { %> autoIncrement="true" startWith="1500"<%_ } %>>
     <%_ if (field.id) { _%>
                 <constraints primaryKey="true" nullable="false"/>
     <%_ } else if (field.unique) { _%>

--- a/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/updated_entity.xml.ejs
+++ b/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/updated_entity.xml.ejs
@@ -31,7 +31,7 @@
     <changeSet id="<%= changelogDate %>-1-add-columns" author="jhipster">
         <addColumn tableName="<%= entity.entityTableName %>">
     <%_ for (field of addedFields) { _%>
-            <column name="<%= field.columnName %>" type="<%= field.columnType %>"<%- this.formatAsLiquibaseRemarks(field.javadoc, true) %>/>
+            <column name="<%= field.columnName %>" type="<%= field.columnType %>"<%- this.formatAsLiquibaseRemarks(field.documentation, true) %>/>
         <%_ if (field.shouldCreateContentType) { _%>
             <column name="<%= field.columnName %>_content_type" type="varchar(255)"/>
         <%_ }

--- a/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-detail.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-detail.tsx.ejs
@@ -70,12 +70,12 @@ _%>
                   <%= fieldNameHumanized %>
                 </Translate>
               </span>
-  <%_ if (field.javadoc) { _%>
+  <%_ if (field.documentation) { _%>
               <UncontrolledTooltip target="<%= fieldName %>">
     <%_ if (enableTranslation) { _%>
                 <Translate contentKey="<%= i18nKeyPrefix %>.help.<%= fieldName %>"/>
     <%_ } else { _%>
-                <%= field.javadoc %>
+                <%= field.documentation %>
     <%_ } _%>
               </UncontrolledTooltip>
   <%_ } _%>

--- a/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-update.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-update.tsx.ejs
@@ -305,12 +305,12 @@ _%>
            <%- include('react_validators'); %>
         />
   <%_ } _%>
-  <%_ if (field.javadoc) { _%>
+  <%_ if (field.documentation) { _%>
           <UncontrolledTooltip target="<%= fieldName %>Label">
     <%_ if (enableTranslation) { _%>
             <Translate contentKey="<%= i18nKeyPrefix %>.help.<%= fieldName %>"/>
     <%_ } else { _%>
-            <%= field.javadoc %>
+            <%= field.documentation %>
     <%_ } _%>
           </UncontrolledTooltip>
   <%_ } _%>

--- a/generators/server/generator.mjs
+++ b/generators/server/generator.mjs
@@ -29,8 +29,6 @@ import {
   javaBeanCase as javaBeanClassNameFormat,
   buildJavaGetter as javaGetter,
   buildJavaSetter as javaSetter,
-  formatDocAsApiDescription,
-  formatDocAsJavaDoc,
   getJavaValueGeneratorForType as getJavaValueForType,
   getPrimaryKeyValue as getPKValue,
   generateKeyStore,
@@ -1006,39 +1004,6 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
       entityTableName = `${jhiTablePrefix}_${entityTableName}`;
     }
     return entityTableName;
-  }
-
-  /**
-   * @private
-   * Format As Field Javadoc
-   *
-   * @param {string} text - text to format
-   * @returns field javadoc
-   */
-  formatAsFieldJavadoc(text) {
-    return formatDocAsJavaDoc(text, 4);
-  }
-
-  /**
-   * @private
-   * Format As Api Description
-   *
-   * @param {string} text - text to format
-   * @returns formatted api description
-   */
-  formatAsApiDescription(text) {
-    return formatDocAsApiDescription(text);
-  }
-
-  /**
-   * @private
-   * Format As Class Javadoc
-   *
-   * @param {string} text - text to format
-   * @returns class javadoc
-   */
-  formatAsClassJavadoc(text) {
-    return formatDocAsJavaDoc(text, 0);
   }
 
   /**

--- a/generators/server/support/index.mts
+++ b/generators/server/support/index.mts
@@ -28,6 +28,7 @@ export * from './needles.mjs';
 export { default as prepareEntity } from './prepare-entity.mjs';
 export * from './prepare-entity.mjs';
 export { default as prepareField } from './prepare-field.mjs';
+export * from './prepare-relationship.mjs';
 export * from './relationship.mjs';
 export * from './spring-factories.mjs';
 export * from './string.mjs';

--- a/generators/server/support/prepare-entity.mjs
+++ b/generators/server/support/prepare-entity.mjs
@@ -24,6 +24,7 @@ import { isReservedTableName } from '../../../jdl/jhipster/reserved-keywords.js'
 import { normalizePathEnd } from '../../base/support/index.mjs';
 import { hibernateSnakeCase } from './string.mjs';
 import { getDatabaseTypeData } from './database.mjs';
+import { formatDocAsApiDescription, formatDocAsJavaDoc } from './doc.mjs';
 
 const { ELASTICSEARCH } = searchEngineTypes;
 const NO_SEARCH_ENGINE = searchEngineTypes.NO;
@@ -43,6 +44,11 @@ export default function prepareEntity(entity) {
   entity.entityAbsolutePackage = entityAbsolutePackage;
   entity.entityAbsoluteFolder = entityAbsoluteFolder;
   entity.entityAbsoluteClass = `${entityAbsolutePackage}.domain.${persistClass}`;
+
+  if (entity.documentation) {
+    entity.entityJavadoc = formatDocAsJavaDoc(entity.documentation);
+    entity.entityApiDescription = formatDocAsApiDescription(entity.documentation);
+  }
 
   if (isReservedTableName(entity.entityInstance, entity.prodDatabaseType ?? entity.databaseType) && entity.jhiPrefix) {
     entity.entityInstanceDbSafe = `${entity.jhiPrefix}${entity.entityClass}`;
@@ -90,7 +96,7 @@ export function preparePostEntityServerDerivedProperties(entity) {
   entity.relationshipsContainOtherSideIgnore = entity.relationships.some(relationship => relationship.ignoreOtherSideProperty);
 
   entity.importApiModelProperty =
-    entity.relationships.some(relationship => relationship.javadoc) || entity.fields.some(field => field.javadoc);
+    entity.relationships.some(relationship => relationship.documentation) || entity.fields.some(field => field.documentation);
 
   entity.uniqueEnums = {};
 

--- a/generators/server/support/prepare-field.mjs
+++ b/generators/server/support/prepare-field.mjs
@@ -22,6 +22,7 @@ import _ from 'lodash';
 import { databaseTypes, entityOptions, fieldTypes, reservedKeywords } from '../../../jdl/jhipster/index.mjs';
 import { getUXConstraintName } from './database.mjs';
 import { hibernateSnakeCase } from './string.mjs';
+import { formatDocAsApiDescription, formatDocAsJavaDoc } from './doc.mjs';
 
 const TYPE_BYTES = fieldTypes.RelationalOnlyDBTypes.BYTES;
 const TYPE_BYTE_BUFFER = fieldTypes.RelationalOnlyDBTypes.BYTE_BUFFER;
@@ -47,6 +48,11 @@ export default function prepareField(entityWithConfig, field, generator) {
     field.transient = true;
     // Disable update form.
     field.readonly = true;
+  }
+
+  if (field.documentation) {
+    field.fieldJavadoc = formatDocAsJavaDoc(field.documentation, 4);
+    field.fieldApiDescription = formatDocAsApiDescription(field.documentation);
   }
 
   if (field.id && entityWithConfig.primaryKey) {

--- a/generators/server/support/prepare-relationship.mts
+++ b/generators/server/support/prepare-relationship.mts
@@ -1,0 +1,8 @@
+import { formatDocAsApiDescription, formatDocAsJavaDoc } from './doc.mjs';
+
+export function prepareRelationship({ relationship }: { relationship: any; entity: any }) {
+  if (relationship.documentation) {
+    relationship.relationshipJavadoc = formatDocAsJavaDoc(relationship.documentation, 4);
+    relationship.relationshipApiDescription = formatDocAsApiDescription(relationship.documentation);
+  }
+}

--- a/generators/server/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
+++ b/generators/server/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
@@ -90,9 +90,9 @@ import <%= otherEntity.entityAbsoluteClass %>;
  * A <%= persistClass %>.
  */
 <%_ } else { _%>
-<%- this.formatAsClassJavadoc(javadoc) %>
+<%- entityJavadoc %>
   <%_ if (!dtoMapstruct) { _%>
-@Schema(description = "<%- this.formatAsApiDescription(javadoc) %>")
+@Schema(description = "<%- entityApiDescription %>")
   <%_ } _%>
 <%_ } _%>
 <&- fragments.annotationSection() -&>
@@ -112,10 +112,10 @@ public class <%= persistClass %> <&- fragments.extendsSection() -&>implements Se
 <&- fragments.field<%- field.fieldNameCapitalized %>CustomDeclarationSection() -&>
 <&_ if (!fragments.field<%- field.fieldNameCapitalized %>CustomDeclarationSection()) { -&>
   <%_ if (typeof field.javadoc !== 'undefined') { _%>
-<%- this.formatAsFieldJavadoc(field.javadoc) %>
+<%- field.fieldJavadoc %>
   <%_ } _%>
   <%_ if (!dtoMapstruct && typeof field.javadoc !== 'undefined') { _%>
-    @Schema(description = "<%- this.formatAsApiDescription(field.javadoc) %>"<% if (field.fieldValidationRequired) { %>, required = true<% } %>)
+    @Schema(description = "<%- field.fieldApiDescription %>"<% if (field.fieldValidationRequired) { %>, required = true<% } %>)
   <%_ } _%>
 <&- fragments.field<%- field.fieldNameCapitalized %>AnnotationSection() -&>
     private <%= field.javaFieldType %> <%= field.fieldName %>;
@@ -133,9 +133,9 @@ public class <%= persistClass %> <&- fragments.extendsSection() -&>implements Se
 // An embedded entity should not reference entities that embed it, unless the other entities are also embedded
 for (relationship of relationships.filter(relationship => !relationship.embedded || relationship.otherEntity.embedded || relationship.ownerSide)) {
   if (typeof relationship.javadoc !== 'undefined') { _%>
-<%- this.formatAsFieldJavadoc(relationship.javadoc) %>
+<%- relationship.relationshipJavadoc %>
     <%_ if (!dtoMapstruct) { _%>
-    @Schema(description = "<%- this.formatAsApiDescription(relationship.javadoc) %>")
+    @Schema(description = "<%- relationship.relationshipyApiDescription %>")
     <%_ } _%>
   <%_ } _%>
 <&- fragments.relationship<%- relationship.relationshipNameCapitalized %>AnnotationSection() -&>

--- a/generators/server/templates/src/main/java/_package_/_entityPackage_/service/dto/_dtoClass_.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/_entityPackage_/service/dto/_dtoClass_.java.ejs
@@ -66,7 +66,7 @@ import <%= `${otherEntity.entityAbsolutePackage}.service.dto.${otherEntity.dtoCl
  * A DTO for the {@link <%= entityAbsolutePackage %>.domain.<%= persistClass %>} entity.
  */
 <%_ if (typeof javadoc !== 'undefined') { _%>
-@Schema(description = "<%- this.formatAsApiDescription(javadoc) %>")
+@Schema(description = "<%- entityApiDescription %>")
 <%_ } _%>
 @SuppressWarnings("common-java:DuplicatedBlocks")
 public class <%= dtoClass %> implements Serializable {
@@ -74,7 +74,7 @@ public class <%= dtoClass %> implements Serializable {
 <%_ for (reference of dtoReferences) {
   if (typeof reference.doc !== 'undefined') {
 _%>
-<%- this.formatAsFieldJavadoc(reference.doc) %>
+<%- reference.propertyJavadoc %>
   <%_ }
   const field = reference.field;
   const required = field && field.fieldValidate && field.fieldValidationRequired;
@@ -84,7 +84,7 @@ _%>
     <%_ }
   } _%>
   <%_ if (reference.doc) { _%>
-    @Schema(description = "<%- this.formatAsApiDescription(reference.doc) %>"<% if (required) { %>, required = true<% } %>)
+    @Schema(description = "<%- reference.propertyApiDescription %>"<% if (required) { %>, required = true<% } %>)
   <%_ } _%>
   <%_ if (field && field.fieldTypeBytes && databaseTypeSql) { _%>
     @Lob

--- a/jdl/__snapshots__/jdl-importer.spec.ts.snap
+++ b/jdl/__snapshots__/jdl-importer.spec.ts.snap
@@ -27,6 +27,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
   "exportedEntities": [
     JSONEntity {
       "applications": "*",
+      "documentation": "",
       "dto": undefined,
       "embedded": undefined,
       "entityTableName": "country",
@@ -37,7 +38,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "Country",
@@ -57,6 +57,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
     },
     JSONEntity {
       "applications": "*",
+      "documentation": "",
       "dto": undefined,
       "embedded": true,
       "entityTableName": "department",
@@ -85,7 +86,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "Department",
@@ -102,7 +102,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
           "relationshipType": "one-to-one",
         },
         {
-          "javadoc": "A relationship",
+          "documentation": "A relationship",
           "otherEntityName": "employee",
           "otherEntityRelationshipName": "department",
           "relationshipName": "employee",
@@ -121,14 +121,15 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
     },
     JSONEntity {
       "applications": "*",
+      "documentation": "The Employee entity.\\nSecond line in documentation.",
       "dto": "mapstruct",
       "embedded": undefined,
       "entityTableName": "employee",
       "fields": [
         {
+          "documentation": "The firstname attribute.",
           "fieldName": "firstName",
           "fieldType": "String",
-          "javadoc": "The firstname attribute.",
         },
         {
           "fieldName": "lastName",
@@ -156,7 +157,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "The Employee entity.\\nSecond line in javadoc.",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "Employee",
@@ -186,7 +186,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
           "relationshipType": "many-to-one",
         },
         {
-          "javadoc": "Another side of the same relationship,",
+          "documentation": "Another side of the same relationship,",
           "otherEntityName": "department",
           "otherEntityRelationshipName": "employee",
           "relationshipName": "department",
@@ -206,6 +206,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
     },
     JSONEntity {
       "applications": "*",
+      "documentation": "",
       "dto": undefined,
       "embedded": undefined,
       "entityTableName": "job",
@@ -235,7 +236,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "Job",
@@ -270,6 +270,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
     },
     JSONEntity {
       "applications": "*",
+      "documentation": "JobHistory comment.",
       "dto": undefined,
       "embedded": undefined,
       "entityTableName": "job_history",
@@ -293,7 +294,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "JobHistory comment.",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "JobHistory",
@@ -327,6 +327,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
     },
     JSONEntity {
       "applications": "*",
+      "documentation": "",
       "dto": undefined,
       "embedded": undefined,
       "entityTableName": "location",
@@ -349,7 +350,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "Location",
@@ -377,6 +377,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
     },
     JSONEntity {
       "applications": "*",
+      "documentation": "",
       "dto": undefined,
       "embedded": undefined,
       "entityTableName": "region",
@@ -387,7 +388,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "Region",
@@ -398,6 +398,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
     },
     JSONEntity {
       "applications": "*",
+      "documentation": "",
       "dto": undefined,
       "embedded": undefined,
       "entityTableName": "task",
@@ -412,7 +413,6 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
       ],
       "fluentMethods": undefined,
-      "javadoc": "",
       "jpaMetamodelFiltering": undefined,
       "microserviceName": "mymicroservice",
       "name": "Task",
@@ -681,12 +681,12 @@ exports[`jdl - JDLImporter import when passing the unidirectionalRelationships o
     "applications": [
       "jhipster",
     ],
+    "documentation": undefined,
     "dto": undefined,
     "embedded": undefined,
     "entityTableName": "a",
     "fields": [],
     "fluentMethods": undefined,
-    "javadoc": undefined,
     "jpaMetamodelFiltering": undefined,
     "name": "A",
     "pagination": undefined,
@@ -751,12 +751,12 @@ exports[`jdl - JDLImporter import when passing the unidirectionalRelationships o
     "applications": [
       "jhipster",
     ],
+    "documentation": undefined,
     "dto": undefined,
     "embedded": undefined,
     "entityTableName": "b",
     "fields": [],
     "fluentMethods": undefined,
-    "javadoc": undefined,
     "jpaMetamodelFiltering": undefined,
     "name": "B",
     "pagination": undefined,

--- a/jdl/__test-files__/big_sample.jdl
+++ b/jdl/__test-files__/big_sample.jdl
@@ -32,7 +32,7 @@ entity Job {
 
 /**
  * The Employee entity.
- * Second line in javadoc.
+ * Second line in documentation.
  */
 entity Employee {
   /**

--- a/jdl/__test-files__/complex_jdl.jdl
+++ b/jdl/__test-files__/complex_jdl.jdl
@@ -32,7 +32,7 @@ entity Job {
 
 /**
  * The Employee entity.
- * Second line in javadoc.
+ * Second line in documentation.
  */
 entity Employee {
   /**

--- a/jdl/__test-files__/jhipster_app/.jhipster/Country.json
+++ b/jdl/__test-files__/jhipster_app/.jhipster/Country.json
@@ -22,7 +22,7 @@
     {
       "fieldName": "countryId",
       "fieldType": "Long",
-      "javadoc": "The country Id"
+      "documentation": "The country Id"
     },
     {
       "fieldName": "countryName",

--- a/jdl/__test-files__/jhipster_app/.jhipster/Department.json
+++ b/jdl/__test-files__/jhipster_app/.jhipster/Department.json
@@ -13,7 +13,7 @@
       "relationshipValidateRules": "required",
       "relationshipName": "employee",
       "otherEntityName": "employee",
-      "javadoc": "A relationship",
+      "documentation": "A relationship",
       "otherEntityRelationshipName": "department"
     },
     {

--- a/jdl/__test-files__/jhipster_app/.jhipster/Employee.json
+++ b/jdl/__test-files__/jhipster_app/.jhipster/Employee.json
@@ -3,7 +3,7 @@
     {
       "relationshipName": "department",
       "otherEntityName": "department",
-      "javadoc": "Another side of the same relationship",
+      "documentation": "Another side of the same relationship",
       "relationshipType": "many-to-one",
       "otherEntityField": "foo"
     },
@@ -27,7 +27,7 @@
     },
     {
       "fieldName": "firstName",
-      "javadoc": "The firstname attribute.",
+      "documentation": "The firstname attribute.",
       "fieldType": "String"
     },
     {
@@ -59,7 +59,7 @@
     }
   ],
   "changelogDate": "20160926083805",
-  "javadoc": "The Employee entity.",
+  "documentation": "The Employee entity.",
   "jpaMetamodelFiltering": true,
   "entityTableName": "emp",
   "dto": "mapstruct",

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Country.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Country.json
@@ -21,6 +21,6 @@
   "dto": "no",
   "pagination": "pager",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "country"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Department.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Department.json
@@ -27,6 +27,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "department"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Employee.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Employee.json
@@ -53,6 +53,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "employee"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Job.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Job.json
@@ -33,6 +33,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "job"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/JobHistory.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/JobHistory.json
@@ -41,6 +41,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "job_history"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Location.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Location.json
@@ -33,6 +33,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "location"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Region.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Region.json
@@ -12,6 +12,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "region"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Task.json
+++ b/jdl/__test-files__/json_to_jdl_converter/app_with_entities/.jhipster/Task.json
@@ -24,6 +24,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "task"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/multi_apps/app1/.jhipster/Region.json
+++ b/jdl/__test-files__/json_to_jdl_converter/multi_apps/app1/.jhipster/Region.json
@@ -12,6 +12,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "region"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/multi_apps/app2/.jhipster/Country.json
+++ b/jdl/__test-files__/json_to_jdl_converter/multi_apps/app2/.jhipster/Country.json
@@ -12,6 +12,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "country"
 }

--- a/jdl/__test-files__/json_to_jdl_converter/multi_apps/app2/.jhipster/Location.json
+++ b/jdl/__test-files__/json_to_jdl_converter/multi_apps/app2/.jhipster/Location.json
@@ -33,6 +33,6 @@
   "dto": "no",
   "pagination": "no",
   "service": "no",
-  "javadoc": "",
+  "documentation": "",
   "entityTableName": "location"
 }

--- a/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-converter.ts
@@ -48,7 +48,7 @@ function createJSONEntities(jdlEntities: JDLEntity[]): Map<string, JSONEntity> {
       new JSONEntity({
         entityName,
         entityTableName: getTableNameFromEntityName(jdlEntity.tableName),
-        javadoc: formatComment(jdlEntity.comment),
+        documentation: formatComment(jdlEntity.comment),
       }),
     );
   });

--- a/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-information-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-information-converter.spec.ts
@@ -88,12 +88,12 @@ describe('jdl - JDLToJSONBasicEntityConverter', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
   "applications": [],
+  "documentation": "The best entity",
   "dto": undefined,
   "embedded": undefined,
   "entityTableName": "entity_a",
   "fields": [],
   "fluentMethods": undefined,
-  "javadoc": "The best entity",
   "jpaMetamodelFiltering": undefined,
   "name": "A",
   "pagination": undefined,

--- a/jdl/converters/jdl-to-json/jdl-to-json-field-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-field-converter.spec.ts
@@ -197,7 +197,7 @@ describe('jdl - JDLToJSONFieldConverter', () => {
 {
   "fieldName": "enumField",
   "fieldType": "CustomEnum",
-  "fieldTypeJavadoc": "enum comment",
+  "fieldTypeDocumentation": "enum comment",
   "fieldValues": "AA,AB",
   "fieldValuesJavadocs": {
     "AA": "some comment",
@@ -231,9 +231,9 @@ describe('jdl - JDLToJSONFieldConverter', () => {
         it('should convert them', () => {
           jestExpect(convertedField).toMatchInlineSnapshot(`
 {
+  "documentation": "The best field",
   "fieldName": "firstField",
   "fieldType": "String",
-  "javadoc": "The best field",
 }
 `);
         });
@@ -383,9 +383,9 @@ describe('jdl - JDLToJSONFieldConverter', () => {
         it('should convert them', () => {
           jestExpect(convertedField).toMatchInlineSnapshot(`
 {
+  "documentation": "The best field",
   "fieldName": "firstField",
   "fieldType": "String",
-  "javadoc": "The best field",
   "options": {
     "id": 42,
   },

--- a/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
@@ -62,13 +62,13 @@ function getConvertedFieldsForEntity(jdlEntity: JDLEntity, jdlObject: JDLObject)
     };
     const comment = formatComment(jdlField.comment);
     if (comment) {
-      fieldData.javadoc = comment;
+      fieldData.documentation = comment;
     }
     if (jdlObject.hasEnum(jdlField.type)) {
       fieldData.fieldValues = jdlObject.getEnum(fieldData.fieldType).getValuesAsString();
       const fieldTypeComment = jdlObject.getEnum(fieldData.fieldType).comment;
       if (fieldTypeComment) {
-        fieldData.fieldTypeJavadoc = fieldTypeComment;
+        fieldData.fieldTypeDocumentation = fieldTypeComment;
       }
       const fieldValuesJavadocs = jdlObject.getEnum(fieldData.fieldType).getValueJavadocs();
       if (fieldValuesJavadocs && Object.keys(fieldValuesJavadocs).length > 0) {

--- a/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.spec.ts
@@ -293,7 +293,7 @@ describe('jdl - JDLToJSONRelationshipConverter', () => {
           jestExpect(relationshipsForA).toMatchInlineSnapshot(`
             [
               {
-                "javadoc": "A to B",
+                "documentation": "A to B",
                 "otherEntityName": "b",
                 "otherEntityRelationshipName": "a",
                 "relationshipName": "b",
@@ -305,7 +305,7 @@ describe('jdl - JDLToJSONRelationshipConverter', () => {
           jestExpect(relationshipsForB).toMatchInlineSnapshot(`
             [
               {
-                "javadoc": "A to B but in the destination",
+                "documentation": "A to B but in the destination",
                 "otherEntityName": "a",
                 "otherEntityRelationshipName": "b",
                 "relationshipName": "a",

--- a/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.ts
@@ -91,7 +91,7 @@ function setRelationshipsFromEntity(relatedRelationships, entityName) {
       convertedRelationship.relationshipValidateRules = REQUIRED;
     }
     if (relationshipToConvert.commentInFrom) {
-      convertedRelationship.javadoc = relationshipToConvert.commentInFrom;
+      convertedRelationship.documentation = relationshipToConvert.commentInFrom;
     }
     const splitField: any = extractField(relationshipToConvert.injectedFieldInFrom);
     convertedRelationship.relationshipName = camelCase(splitField.relationshipName || relationshipToConvert.to);
@@ -122,7 +122,7 @@ function setRelationshipsToEntity(relatedRelationships, entityName) {
       convertedRelationship.relationshipValidateRules = REQUIRED;
     }
     if (relationshipToConvert.commentInTo) {
-      convertedRelationship.javadoc = relationshipToConvert.commentInTo;
+      convertedRelationship.documentation = relationshipToConvert.commentInTo;
     }
     const splitField: any = extractField(relationshipToConvert.injectedFieldInTo);
     convertedRelationship.relationshipName = camelCase(splitField.relationshipName || relationshipToConvert.from);

--- a/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.spec.ts
@@ -174,24 +174,24 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
         it('should convert the entity', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": [
-                "toto",
-              ],
-              "dto": undefined,
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": undefined,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "service": undefined,
-            }
-          `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
         });
       });
       context('with options', () => {
@@ -281,30 +281,30 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
         it('should convert the entity', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "angularJSSuffix": "suffix",
-              "applications": [
-                "toto",
-              ],
-              "clientRootFolder": "../client_root_folder",
-              "dto": "mapstruct",
-              "embedded": true,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": false,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": true,
-              "microserviceName": "myMs",
-              "name": "A",
-              "pagination": "pagination",
-              "readOnly": true,
-              "relationships": [],
-              "searchEngine": "couchbase",
-              "service": "serviceImpl",
-              "skipClient": true,
-              "skipServer": true,
-            }
-          `);
+JSONEntity {
+  "angularJSSuffix": "suffix",
+  "applications": [
+    "toto",
+  ],
+  "clientRootFolder": "../client_root_folder",
+  "documentation": "The best entity",
+  "dto": "mapstruct",
+  "embedded": true,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": false,
+  "jpaMetamodelFiltering": true,
+  "microserviceName": "myMs",
+  "name": "A",
+  "pagination": "pagination",
+  "readOnly": true,
+  "relationships": [],
+  "searchEngine": "couchbase",
+  "service": "serviceImpl",
+  "skipClient": true,
+  "skipServer": true,
+}
+`);
         });
       });
       context('when setting the DTO option without the service option', () => {
@@ -348,24 +348,24 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
         });
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": [
-                "toto",
-              ],
-              "dto": "mapstruct",
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": undefined,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "service": "serviceClass",
-            }
-          `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": "mapstruct",
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": "serviceClass",
+}
+`);
         });
       });
       context('when setting the filtering option without the service option', () => {
@@ -411,24 +411,24 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
         });
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": [
-                "toto",
-              ],
-              "dto": undefined,
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": true,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "service": "serviceClass",
-            }
-          `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": true,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": "serviceClass",
+}
+`);
         });
       });
       context('when the searching option is set with exclusions', () => {
@@ -464,25 +464,25 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
         it('should prevent the entities from being searched', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": [
-                "toto",
-              ],
-              "dto": undefined,
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": undefined,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "searchEngine": "no",
-              "service": undefined,
-            }
-          `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "searchEngine": "no",
+  "service": undefined,
+}
+`);
         });
       });
       context('with fields', () => {
@@ -521,33 +521,33 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": [
-                  "toto",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "firstField",
-                    "fieldType": "String",
-                  },
-                  {
-                    "fieldName": "secondField",
-                    "fieldType": "Integer",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "fieldName": "firstField",
+      "fieldType": "String",
+    },
+    {
+      "fieldName": "secondField",
+      "fieldType": "Integer",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('when having blobs', () => {
@@ -595,45 +595,45 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": [
-                  "toto",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "anyBlobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "any",
-                  },
-                  {
-                    "fieldName": "textBlobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "text",
-                  },
-                  {
-                    "fieldName": "blobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "any",
-                  },
-                  {
-                    "fieldName": "imageBlobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "image",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "fieldName": "anyBlobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "any",
+    },
+    {
+      "fieldName": "textBlobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "text",
+    },
+    {
+      "fieldName": "blobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "any",
+    },
+    {
+      "fieldName": "imageBlobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "image",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with field types being enums', () => {
@@ -667,30 +667,30 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": [
-                  "toto",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "a",
-                "fields": [
-                  {
-                    "fieldName": "enumField",
-                    "fieldType": "CustomEnum",
-                    "fieldValues": "AA,AB",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "a",
+  "fields": [
+    {
+      "fieldName": "enumField",
+      "fieldType": "CustomEnum",
+      "fieldValues": "AA,AB",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with comments', () => {
@@ -724,30 +724,30 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": [
-                  "toto",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "firstField",
-                    "fieldType": "String",
-                    "javadoc": "The best field",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "documentation": "The best field",
+      "fieldName": "firstField",
+      "fieldType": "String",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with validations', () => {
@@ -836,60 +836,60 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": [
-                  "toto",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "stringField",
-                    "fieldType": "String",
-                    "fieldValidateRules": [
-                      "required",
-                      "unique",
-                      "minlength",
-                      "maxlength",
-                      "pattern",
-                    ],
-                    "fieldValidateRulesMaxlength": 10,
-                    "fieldValidateRulesMinlength": 0,
-                    "fieldValidateRulesPattern": "^d$",
-                  },
-                  {
-                    "fieldName": "integerField",
-                    "fieldType": "Integer",
-                    "fieldValidateRules": [
-                      "min",
-                      "max",
-                    ],
-                    "fieldValidateRulesMax": 10,
-                    "fieldValidateRulesMin": 0,
-                  },
-                  {
-                    "fieldName": "blobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "any",
-                    "fieldValidateRules": [
-                      "minbytes",
-                      "maxbytes",
-                    ],
-                    "fieldValidateRulesMaxbytes": 10,
-                    "fieldValidateRulesMinbytes": 0,
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "fieldName": "stringField",
+      "fieldType": "String",
+      "fieldValidateRules": [
+        "required",
+        "unique",
+        "minlength",
+        "maxlength",
+        "pattern",
+      ],
+      "fieldValidateRulesMaxlength": 10,
+      "fieldValidateRulesMinlength": 0,
+      "fieldValidateRulesPattern": "^d$",
+    },
+    {
+      "fieldName": "integerField",
+      "fieldType": "Integer",
+      "fieldValidateRules": [
+        "min",
+        "max",
+      ],
+      "fieldValidateRulesMax": 10,
+      "fieldValidateRulesMin": 0,
+    },
+    {
+      "fieldName": "blobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "any",
+      "fieldValidateRules": [
+        "minbytes",
+        "maxbytes",
+      ],
+      "fieldValidateRulesMaxbytes": 10,
+      "fieldValidateRulesMinbytes": 0,
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with options', () => {
@@ -926,33 +926,33 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": [
-                  "toto",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "firstField",
-                    "fieldType": "String",
-                    "javadoc": "The best field",
-                    "options": {
-                      "id": 42,
-                    },
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": [
+    "toto",
+  ],
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "documentation": "The best field",
+      "fieldName": "firstField",
+      "fieldType": "String",
+      "options": {
+        "id": 42,
+      },
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
       });
@@ -1279,7 +1279,7 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
             jestExpect(relationshipsForA).toMatchInlineSnapshot(`
               [
                 {
-                  "javadoc": "A to B",
+                  "documentation": "A to B",
                   "otherEntityName": "b",
                   "otherEntityRelationshipName": "a",
                   "relationshipName": "b",
@@ -1291,7 +1291,7 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
             jestExpect(relationshipsForB).toMatchInlineSnapshot(`
               [
                 {
-                  "javadoc": "A to B but in the destination",
+                  "documentation": "A to B but in the destination",
                   "otherEntityName": "a",
                   "otherEntityRelationshipName": "b",
                   "relationshipName": "a",
@@ -1794,117 +1794,117 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
 
         it('should set them', () => {
           jestExpect(convertedEntitiesForTataApplication).toMatchInlineSnapshot(`
-            [
-              JSONEntity {
-                "applications": [
-                  "tata",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": "pagination",
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              },
-              JSONEntity {
-                "applications": [
-                  "tata",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_b",
-                "fields": [],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "B",
-                "pagination": "infinite-scroll",
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              },
-              JSONEntity {
-                "applications": [
-                  "tata",
-                  "tutu",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_c",
-                "fields": [],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "C",
-                "pagination": "pagination",
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              },
-            ]
-          `);
+[
+  JSONEntity {
+    "applications": [
+      "tata",
+    ],
+    "documentation": "The best entity",
+    "dto": undefined,
+    "embedded": undefined,
+    "entityTableName": "entity_a",
+    "fields": [],
+    "fluentMethods": undefined,
+    "jpaMetamodelFiltering": undefined,
+    "name": "A",
+    "pagination": "pagination",
+    "readOnly": undefined,
+    "relationships": [],
+    "service": undefined,
+  },
+  JSONEntity {
+    "applications": [
+      "tata",
+    ],
+    "documentation": "The best entity",
+    "dto": undefined,
+    "embedded": undefined,
+    "entityTableName": "entity_b",
+    "fields": [],
+    "fluentMethods": undefined,
+    "jpaMetamodelFiltering": undefined,
+    "name": "B",
+    "pagination": "infinite-scroll",
+    "readOnly": undefined,
+    "relationships": [],
+    "service": undefined,
+  },
+  JSONEntity {
+    "applications": [
+      "tata",
+      "tutu",
+    ],
+    "documentation": "The best entity",
+    "dto": undefined,
+    "embedded": undefined,
+    "entityTableName": "entity_c",
+    "fields": [],
+    "fluentMethods": undefined,
+    "jpaMetamodelFiltering": undefined,
+    "name": "C",
+    "pagination": "pagination",
+    "readOnly": undefined,
+    "relationships": [],
+    "service": undefined,
+  },
+]
+`);
           jestExpect(convertedEntitiesForTutuApplication).toMatchInlineSnapshot(`
-            [
-              JSONEntity {
-                "applications": [
-                  "tata",
-                  "tutu",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_c",
-                "fields": [],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "C",
-                "pagination": "pagination",
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              },
-              JSONEntity {
-                "applications": [
-                  "tutu",
-                ],
-                "dto": "mapstruct",
-                "embedded": undefined,
-                "entityTableName": "entity_d",
-                "fields": [],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "D",
-                "pagination": "infinite-scroll",
-                "readOnly": undefined,
-                "relationships": [],
-                "service": "serviceClass",
-              },
-              JSONEntity {
-                "applications": [
-                  "tutu",
-                ],
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_e",
-                "fields": [],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "E",
-                "pagination": "infinite-scroll",
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              },
-            ]
-          `);
+[
+  JSONEntity {
+    "applications": [
+      "tata",
+      "tutu",
+    ],
+    "documentation": "The best entity",
+    "dto": undefined,
+    "embedded": undefined,
+    "entityTableName": "entity_c",
+    "fields": [],
+    "fluentMethods": undefined,
+    "jpaMetamodelFiltering": undefined,
+    "name": "C",
+    "pagination": "pagination",
+    "readOnly": undefined,
+    "relationships": [],
+    "service": undefined,
+  },
+  JSONEntity {
+    "applications": [
+      "tutu",
+    ],
+    "documentation": "The best entity",
+    "dto": "mapstruct",
+    "embedded": undefined,
+    "entityTableName": "entity_d",
+    "fields": [],
+    "fluentMethods": undefined,
+    "jpaMetamodelFiltering": undefined,
+    "name": "D",
+    "pagination": "infinite-scroll",
+    "readOnly": undefined,
+    "relationships": [],
+    "service": "serviceClass",
+  },
+  JSONEntity {
+    "applications": [
+      "tutu",
+    ],
+    "documentation": "The best entity",
+    "dto": undefined,
+    "embedded": undefined,
+    "entityTableName": "entity_e",
+    "fields": [],
+    "fluentMethods": undefined,
+    "jpaMetamodelFiltering": undefined,
+    "name": "E",
+    "pagination": "infinite-scroll",
+    "readOnly": undefined,
+    "relationships": [],
+    "service": undefined,
+  },
+]
+`);
         });
       });
     });

--- a/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.spec.ts
@@ -159,22 +159,22 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
         it('should convert the entity', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": "*",
-              "dto": undefined,
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": undefined,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "service": undefined,
-            }
-          `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
         });
       });
       context('with options', () => {
@@ -261,28 +261,28 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
         it('should convert the entity', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "angularJSSuffix": "suffix",
-              "applications": "*",
-              "clientRootFolder": "../client_root_folder",
-              "dto": "mapstruct",
-              "embedded": true,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": false,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": true,
-              "microserviceName": "myMs",
-              "name": "A",
-              "pagination": "pagination",
-              "readOnly": true,
-              "relationships": [],
-              "searchEngine": "couchbase",
-              "service": "serviceImpl",
-              "skipClient": true,
-              "skipServer": true,
-            }
-          `);
+JSONEntity {
+  "angularJSSuffix": "suffix",
+  "applications": "*",
+  "clientRootFolder": "../client_root_folder",
+  "documentation": "The best entity",
+  "dto": "mapstruct",
+  "embedded": true,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": false,
+  "jpaMetamodelFiltering": true,
+  "microserviceName": "myMs",
+  "name": "A",
+  "pagination": "pagination",
+  "readOnly": true,
+  "relationships": [],
+  "searchEngine": "couchbase",
+  "service": "serviceImpl",
+  "skipClient": true,
+  "skipServer": true,
+}
+`);
         });
       });
       context('when setting the DTO option without the service option', () => {
@@ -326,22 +326,22 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
         });
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": "*",
-              "dto": "mapstruct",
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": undefined,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "service": "serviceClass",
-            }
-          `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": "mapstruct",
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": "serviceClass",
+}
+`);
         });
       });
       context('when setting the filtering option without the service option', () => {
@@ -384,22 +384,22 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
         });
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": "*",
-              "dto": undefined,
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": true,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "service": "serviceClass",
-            }
-          `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": true,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": "serviceClass",
+}
+`);
         });
       });
       context('when the searching option is set with exclusions', () => {
@@ -432,23 +432,23 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
         it('should prevent the entities from being searched', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
-            JSONEntity {
-              "applications": "*",
-              "dto": undefined,
-              "embedded": undefined,
-              "entityTableName": "entity_a",
-              "fields": [],
-              "fluentMethods": undefined,
-              "javadoc": "The best entity",
-              "jpaMetamodelFiltering": undefined,
-              "name": "A",
-              "pagination": undefined,
-              "readOnly": undefined,
-              "relationships": [],
-              "searchEngine": "no",
-              "service": undefined,
-            }
-          `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "searchEngine": "no",
+  "service": undefined,
+}
+`);
         });
       });
       context('with fields', () => {
@@ -484,31 +484,31 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": "*",
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "firstField",
-                    "fieldType": "String",
-                  },
-                  {
-                    "fieldName": "secondField",
-                    "fieldType": "Integer",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "fieldName": "firstField",
+      "fieldType": "String",
+    },
+    {
+      "fieldName": "secondField",
+      "fieldType": "Integer",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('when having blobs', () => {
@@ -553,43 +553,43 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": "*",
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "anyBlobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "any",
-                  },
-                  {
-                    "fieldName": "textBlobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "text",
-                  },
-                  {
-                    "fieldName": "blobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "any",
-                  },
-                  {
-                    "fieldName": "imageBlobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "image",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "fieldName": "anyBlobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "any",
+    },
+    {
+      "fieldName": "textBlobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "text",
+    },
+    {
+      "fieldName": "blobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "any",
+    },
+    {
+      "fieldName": "imageBlobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "image",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with field types being enums', () => {
@@ -620,28 +620,28 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": "*",
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "a",
-                "fields": [
-                  {
-                    "fieldName": "enumField",
-                    "fieldType": "CustomEnum",
-                    "fieldValues": "AA,AB",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "a",
+  "fields": [
+    {
+      "fieldName": "enumField",
+      "fieldType": "CustomEnum",
+      "fieldValues": "AA,AB",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with comments', () => {
@@ -672,28 +672,28 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": "*",
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "firstField",
-                    "fieldType": "String",
-                    "javadoc": "The best field",
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "documentation": "The best field",
+      "fieldName": "firstField",
+      "fieldType": "String",
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with validations', () => {
@@ -779,58 +779,58 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": "*",
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "stringField",
-                    "fieldType": "String",
-                    "fieldValidateRules": [
-                      "required",
-                      "unique",
-                      "minlength",
-                      "maxlength",
-                      "pattern",
-                    ],
-                    "fieldValidateRulesMaxlength": 10,
-                    "fieldValidateRulesMinlength": 0,
-                    "fieldValidateRulesPattern": "^d$",
-                  },
-                  {
-                    "fieldName": "integerField",
-                    "fieldType": "Integer",
-                    "fieldValidateRules": [
-                      "min",
-                      "max",
-                    ],
-                    "fieldValidateRulesMax": 10,
-                    "fieldValidateRulesMin": 0,
-                  },
-                  {
-                    "fieldName": "blobField",
-                    "fieldType": "byte[]",
-                    "fieldTypeBlobContent": "any",
-                    "fieldValidateRules": [
-                      "minbytes",
-                      "maxbytes",
-                    ],
-                    "fieldValidateRulesMaxbytes": 10,
-                    "fieldValidateRulesMinbytes": 0,
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "fieldName": "stringField",
+      "fieldType": "String",
+      "fieldValidateRules": [
+        "required",
+        "unique",
+        "minlength",
+        "maxlength",
+        "pattern",
+      ],
+      "fieldValidateRulesMaxlength": 10,
+      "fieldValidateRulesMinlength": 0,
+      "fieldValidateRulesPattern": "^d$",
+    },
+    {
+      "fieldName": "integerField",
+      "fieldType": "Integer",
+      "fieldValidateRules": [
+        "min",
+        "max",
+      ],
+      "fieldValidateRulesMax": 10,
+      "fieldValidateRulesMin": 0,
+    },
+    {
+      "fieldName": "blobField",
+      "fieldType": "byte[]",
+      "fieldTypeBlobContent": "any",
+      "fieldValidateRules": [
+        "minbytes",
+        "maxbytes",
+      ],
+      "fieldValidateRulesMaxbytes": 10,
+      "fieldValidateRulesMinbytes": 0,
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
         context('with options', () => {
@@ -864,31 +864,31 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
 
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
-              JSONEntity {
-                "applications": "*",
-                "dto": undefined,
-                "embedded": undefined,
-                "entityTableName": "entity_a",
-                "fields": [
-                  {
-                    "fieldName": "firstField",
-                    "fieldType": "String",
-                    "javadoc": "The best field",
-                    "options": {
-                      "id": 42,
-                    },
-                  },
-                ],
-                "fluentMethods": undefined,
-                "javadoc": "The best entity",
-                "jpaMetamodelFiltering": undefined,
-                "name": "A",
-                "pagination": undefined,
-                "readOnly": undefined,
-                "relationships": [],
-                "service": undefined,
-              }
-            `);
+JSONEntity {
+  "applications": "*",
+  "documentation": "The best entity",
+  "dto": undefined,
+  "embedded": undefined,
+  "entityTableName": "entity_a",
+  "fields": [
+    {
+      "documentation": "The best field",
+      "fieldName": "firstField",
+      "fieldType": "String",
+      "options": {
+        "id": 42,
+      },
+    },
+  ],
+  "fluentMethods": undefined,
+  "jpaMetamodelFiltering": undefined,
+  "name": "A",
+  "pagination": undefined,
+  "readOnly": undefined,
+  "relationships": [],
+  "service": undefined,
+}
+`);
           });
         });
       });
@@ -1195,7 +1195,7 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
             jestExpect(relationshipsForA).toMatchInlineSnapshot(`
               [
                 {
-                  "javadoc": "A to B",
+                  "documentation": "A to B",
                   "otherEntityName": "b",
                   "otherEntityRelationshipName": "a",
                   "relationshipName": "b",
@@ -1207,7 +1207,7 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
             jestExpect(relationshipsForB).toMatchInlineSnapshot(`
               [
                 {
-                  "javadoc": "A to B but in the destination",
+                  "documentation": "A to B but in the destination",
                   "otherEntityName": "a",
                   "otherEntityRelationshipName": "b",
                   "relationshipName": "a",

--- a/jdl/converters/json-to-jdl-entity-converter.spec.ts
+++ b/jdl/converters/json-to-jdl-entity-converter.spec.ts
@@ -66,7 +66,7 @@ describe('jdl - JSONToJDLEntityConverter', () => {
       });
 
       context('when parsing a JSON entity to JDL', () => {
-        it('should parse entity javadoc', () => {
+        it('should parse entity documentation', () => {
           expect(jdlObject.entities.Employee.comment).eq('The Employee entity.');
         });
         it('should parse tableName', () => {
@@ -76,7 +76,7 @@ describe('jdl - JSONToJDLEntityConverter', () => {
           expect(jdlObject.entities.Country.fields.countryId.type).eq('Long');
           expect(jdlObject.entities.Country.fields.countryName.type).eq('String');
         });
-        it('should parse field javadoc', () => {
+        it('should parse field documentation', () => {
           expect(jdlObject.entities.Country.fields.countryId.comment).eq('The country Id');
           expect(jdlObject.entities.Country.fields.countryName.comment).to.be.undefined;
         });

--- a/jdl/converters/json-to-jdl-entity-converter.ts
+++ b/jdl/converters/json-to-jdl-entity-converter.ts
@@ -83,7 +83,7 @@ function convertJSONToJDLEntity(entity: Entity, entityName: string): JDLEntity {
   const jdlEntity = new JDLEntity({
     name: entityName,
     tableName: entity.entityTableName,
-    comment: entity.javadoc,
+    comment: entity.documentation,
   });
   addFields(jdlEntity, entity);
   return jdlEntity;
@@ -99,7 +99,7 @@ function convertJSONToJDLField(field: Field) {
   const jdlField = new JDLField({
     name: lowerFirst(field.fieldName),
     type: field.fieldType,
-    comment: field.javadoc,
+    comment: field.documentation,
   });
   if (jdlField.type === BYTES) {
     jdlField.type = getTypeForBlob(field.fieldTypeBlobContent);
@@ -137,7 +137,7 @@ function addEnumsToJDL(entity: Entity) {
         new JDLEnum({
           name: field.fieldType,
           values: getEnumValuesFromString(field.fieldValues),
-          comment: field.fieldTypeJavadoc,
+          comment: field.fieldTypeDocumentation,
         }),
       );
     }
@@ -237,7 +237,7 @@ function getSourceEntitySideAttributes(entityName: string, relationship: Relatio
     sourceEntity: entityName,
     injectedFieldInSourceEntity: getInjectedFieldInSourceEntity(relationship),
     injectedFieldInSourceIsRequired: relationship.relationshipValidateRules,
-    commentForSourceEntity: relationship.javadoc,
+    commentForSourceEntity: relationship.documentation,
   };
 }
 
@@ -257,7 +257,7 @@ function getDestinationEntitySideAttributes(isEntityTheDestinationSideEntity, de
     injectedFieldInDestinationEntity += `(${foundDestinationSideEntity.otherEntityField})`;
   }
   const injectedFieldInDestinationIsRequired = !!foundDestinationSideEntity.relationshipValidateRules;
-  const commentForDestinationEntity = foundDestinationSideEntity.javadoc;
+  const commentForDestinationEntity = foundDestinationSideEntity.documentation;
   return {
     injectedFieldInDestinationEntity,
     injectedFieldInDestinationIsRequired,

--- a/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.spec.ts
@@ -36,7 +36,7 @@ describe('jdl - EntityConverter', () => {
           [
             {
               name: 'A',
-              javadoc: '/** No comment */',
+              documentation: '/** No comment */',
             },
             {
               name: 'B',

--- a/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.ts
@@ -36,7 +36,7 @@ export function convertEntities(parsedEntities, jdlFieldGetterFunction): JDLEnti
     const jdlEntity = new JDLEntity({
       name: parsedEntity.name,
       tableName: parsedEntity.tableName || parsedEntity.name,
-      comment: formatComment(parsedEntity.javadoc),
+      comment: formatComment(parsedEntity.documentation),
     });
     const jdlFields = jdlFieldGetterFunction.call(undefined, parsedEntity);
     jdlEntity.addFields(jdlFields);

--- a/jdl/converters/parsed-jdl-to-jdl-object/enum-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/enum-converter.spec.ts
@@ -39,7 +39,7 @@ describe('jdl - EnumConverter', () => {
               { key: 'FRANCE', value: 'FRANCE' },
               { key: 'ITALY', value: 'ITALY' },
             ],
-            javadoc: 'A comment',
+            documentation: 'A comment',
           },
         ]);
       });

--- a/jdl/converters/parsed-jdl-to-jdl-object/enum-converter.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/enum-converter.ts
@@ -43,6 +43,6 @@ function convertEnum(enumeration): JDLEnum {
   return new JDLEnum({
     name: enumeration.name,
     values: enumeration.values,
-    comment: formatComment(enumeration.javadoc),
+    comment: formatComment(enumeration.documentation),
   });
 }

--- a/jdl/converters/parsed-jdl-to-jdl-object/field-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/field-converter.spec.ts
@@ -74,7 +74,7 @@ JDLField {
           const convertedField = convertField({
             name: 'AnAwesomeField',
             type: 'String',
-            javadoc: 'An awesome comment!',
+            documentation: 'An awesome comment!',
           });
           commentFromConvertedField = convertedField.comment;
         });

--- a/jdl/converters/parsed-jdl-to-jdl-object/field-converter.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/field-converter.ts
@@ -37,8 +37,8 @@ export function convertField(field): JDLField {
     name,
     type: field.type,
   });
-  if (field.javadoc) {
-    jdlField.comment = formatComment(field.javadoc);
+  if (field.documentation) {
+    jdlField.comment = formatComment(field.documentation);
   }
   return jdlField;
 }

--- a/jdl/converters/parsed-jdl-to-jdl-object/relationship-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/relationship-converter.spec.ts
@@ -40,13 +40,13 @@ describe('jdl - RelationshipConverter', () => {
                   name: 'Source',
                   injectedField: 'destination',
                   required: true,
-                  javadoc: '/**\n * Required\n */',
+                  documentation: '/**\n * Required\n */',
                 },
                 to: {
                   name: 'Destination',
                   injectedField: 'source',
                   required: false,
-                  javadoc: '/**\n * Not required\n */',
+                  documentation: '/**\n * Not required\n */',
                 },
                 cardinality: 'one-to-many',
                 options: {
@@ -101,12 +101,12 @@ describe('jdl - RelationshipConverter', () => {
                 from: {
                   name: 'Source',
                   required: true,
-                  javadoc: '/**\n * Required\n */',
+                  documentation: '/**\n * Required\n */',
                 },
                 to: {
                   name: 'Destination',
                   required: false,
-                  javadoc: '/**\n * Not required\n */',
+                  documentation: '/**\n * Not required\n */',
                 },
                 cardinality: 'one-to-many',
                 options: {

--- a/jdl/converters/parsed-jdl-to-jdl-object/relationship-converter.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/relationship-converter.ts
@@ -43,8 +43,8 @@ export function convertRelationships(parsedRelationships, annotationToOptionConv
       injectedFieldInTo: parsedRelationship.to.injectedField,
       isInjectedFieldInFromRequired: parsedRelationship.from.required,
       isInjectedFieldInToRequired: parsedRelationship.to.required,
-      commentInFrom: formatComment(parsedRelationship.from.javadoc),
-      commentInTo: formatComment(parsedRelationship.to.javadoc),
+      commentInFrom: formatComment(parsedRelationship.from.documentation),
+      commentInTo: formatComment(parsedRelationship.to.documentation),
       options: {
         global: annotationToOptionConverter.call(undefined, parsedRelationship.options.global),
         source: annotationToOptionConverter.call(undefined, parsedRelationship.options.source),

--- a/jdl/converters/types.ts
+++ b/jdl/converters/types.ts
@@ -15,7 +15,7 @@ export type Relationship = {
 } & Record<string, any>;
 
 export type Entity = {
-  javadoc?: string;
+  documentation?: string;
   fields?: Field[];
   relationships?: Relationship[];
 } & Record<string, any>;

--- a/jdl/exporters/jhipster-entity-exporter.spec.ts
+++ b/jdl/exporters/jhipster-entity-exporter.spec.ts
@@ -68,7 +68,7 @@ describe('jdl - JHipsterEntityExporter', () => {
               ],
               relationships: [],
               changelogDate: '42',
-              javadoc: '',
+              documentation: '',
               entityTableName: 'a',
               dto: NO_DTO,
               pagination: NO_PAGINATION,
@@ -127,7 +127,7 @@ describe('jdl - JHipsterEntityExporter', () => {
               ],
               relationships: [],
               changelogDate: '42',
-              javadoc: '',
+              documentation: '',
               entityTableName: 'a',
               dto: NO_DTO,
               pagination: NO_PAGINATION,
@@ -152,6 +152,7 @@ describe('jdl - JHipsterEntityExporter', () => {
   {
     "applications": [],
     "changelogDate": "42",
+    "documentation": "",
     "dto": "no",
     "entityTableName": "a",
     "fields": [
@@ -162,7 +163,6 @@ describe('jdl - JHipsterEntityExporter', () => {
       },
     ],
     "fluentMethods": true,
-    "javadoc": "",
     "jpaMetamodelFiltering": false,
     "name": "A",
     "pagination": "no",

--- a/jdl/jdl-importer.spec.ts
+++ b/jdl/jdl-importer.spec.ts
@@ -83,7 +83,7 @@ relationship OneToMany {
             return 1;
           })
           .map(exportedEntity => {
-            exportedEntity.javadoc = exportedEntity.javadoc || '';
+            exportedEntity.documentation = exportedEntity.documentation || '';
             return exportedEntity;
           });
       });

--- a/jdl/jhipster/json-entity.spec.ts
+++ b/jdl/jhipster/json-entity.spec.ts
@@ -52,12 +52,12 @@ describe('jdl - JSONEntity', () => {
         jestExpect(entity).toMatchInlineSnapshot(`
 JSONEntity {
   "applications": [],
+  "documentation": undefined,
   "dto": undefined,
   "embedded": undefined,
   "entityTableName": undefined,
   "fields": [],
   "fluentMethods": undefined,
-  "javadoc": undefined,
   "jpaMetamodelFiltering": undefined,
   "name": "Toto",
   "pagination": undefined,
@@ -78,7 +78,7 @@ JSONEntity {
           entityTableName: 'titi',
           fields: [42],
           fluentMethods: true,
-          javadoc: '',
+          documentation: '',
           jpaMetamodelFiltering: true,
           pagination: 'pagination',
           readOnly: true,
@@ -100,6 +100,7 @@ JSONEntity {
   "angularJSSuffix": "yes",
   "applications": [],
   "clientRootFolder": "oh",
+  "documentation": "",
   "dto": "mapstruct",
   "embedded": true,
   "entityTableName": "titi",
@@ -107,7 +108,6 @@ JSONEntity {
     42,
   ],
   "fluentMethods": true,
-  "javadoc": "",
   "jpaMetamodelFiltering": true,
   "microserviceName": "nope",
   "name": "Titi",
@@ -262,7 +262,7 @@ JSONEntity {
       before(() => {
         jsonEntity = new JSONEntity({
           entityName: 'Toto',
-          javadoc: 'A comment',
+          documentation: 'A comment',
         });
         jsonEntity.setOptions({
           dto: 'mapstruct',
@@ -274,12 +274,12 @@ JSONEntity {
         jestExpect(jsonEntity).toMatchInlineSnapshot(`
 JSONEntity {
   "applications": [],
+  "documentation": "A comment",
   "dto": "mapstruct",
   "embedded": undefined,
   "entityTableName": undefined,
   "fields": [],
   "fluentMethods": undefined,
-  "javadoc": "A comment",
   "jpaMetamodelFiltering": undefined,
   "name": "Toto",
   "pagination": "pagination",

--- a/jdl/jhipster/json-entity.ts
+++ b/jdl/jhipster/json-entity.ts
@@ -32,7 +32,7 @@ class JSONEntity {
    *        - entityName, the entity name (mandatory)
    *        - fields, a field iterable
    *        - relationships, a relationship iterable
-   *        - javadoc,
+   *        - documentation,
    *        - entityTableName, defaults to the snake-cased entity name,
    *        - dto, defaults to 'no',
    *        - pagination, defaults to 'no',
@@ -51,7 +51,7 @@ class JSONEntity {
     this.name = merged.name;
     this.fields = merged.fields;
     this.relationships = merged.relationships;
-    this.javadoc = merged.javadoc;
+    this.documentation = merged.documentation;
     this.entityTableName = merged.entityTableName;
     this.dto = merged.dto;
     this.pagination = merged.pagination;

--- a/jdl/models/jdl-enum.ts
+++ b/jdl/models/jdl-enum.ts
@@ -44,13 +44,13 @@ export default class JDLEnum {
   }
 
   getValueJavadocs() {
-    const javadocs = {};
+    const documentations = {};
     this.values.forEach(jdlEnumValue => {
       if (jdlEnumValue.comment) {
-        javadocs[jdlEnumValue.name] = jdlEnumValue.comment;
+        documentations[jdlEnumValue.name] = jdlEnumValue.comment;
       }
     });
-    return javadocs;
+    return documentations;
   }
 
   toString() {

--- a/jdl/parsing/dsl-api.spec.ts
+++ b/jdl/parsing/dsl-api.spec.ts
@@ -42,11 +42,11 @@ describe('jdl - JDL DSL API', () => {
               name: 'field',
               type: 'String',
               validations: [],
-              javadoc: null,
+              documentation: null,
               annotations: [{ optionName: 'Id', type: 'UNARY' }],
             },
           ],
-          javadoc: null,
+          documentation: null,
         });
       });
     });

--- a/jdl/parsing/grammar.spec.ts
+++ b/jdl/parsing/grammar.spec.ts
@@ -380,7 +380,7 @@ entity C
 {
   "annotations": [],
   "body": [],
-  "javadoc": null,
+  "documentation": null,
   "name": "A",
   "tableName": "A",
 }
@@ -400,7 +400,7 @@ entity C
 {
   "annotations": [],
   "body": [],
-  "javadoc": null,
+  "documentation": null,
   "name": "A",
   "tableName": "a_table",
 }
@@ -479,7 +479,7 @@ entity A`);
     },
   ],
   "body": [],
-  "javadoc": null,
+  "documentation": null,
   "name": "A",
   "tableName": "A",
 }
@@ -500,7 +500,7 @@ entity A`);
 {
   "annotations": [],
   "body": [],
-  "javadoc": "A comment",
+  "documentation": "A comment",
   "name": "A",
   "tableName": "A",
 }
@@ -524,7 +524,7 @@ entity A`);
 {
   "annotations": [],
   "body": [],
-  "javadoc": "
+  "documentation": "
  * Big
  * comment.
 ",
@@ -559,7 +559,7 @@ entity A`);
     },
   ],
   "body": [],
-  "javadoc": "A comment",
+  "documentation": "A comment",
   "name": "A",
   "tableName": "A",
 }
@@ -608,13 +608,13 @@ entity A`);
           "type": "UNARY",
         },
       ],
-      "javadoc": "field comment",
+      "documentation": "field comment",
       "name": "name",
       "type": "String",
       "validations": [],
     },
   ],
-  "javadoc": null,
+  "documentation": null,
   "name": "A",
   "tableName": "A",
 }
@@ -1023,7 +1023,7 @@ entity A {
       it('should parse them', () => {
         jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": null,
+  "documentation": null,
   "name": "MyEnum",
   "values": [
     {
@@ -1057,7 +1057,7 @@ entity A {
       it('should parse them', () => {
         jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": null,
+  "documentation": null,
   "name": "MyEnum",
   "values": [
     {
@@ -1096,7 +1096,7 @@ entity A {
       it('should parse it', () => {
         jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": null,
+  "documentation": null,
   "name": "MyEnum",
   "values": [
     {
@@ -1137,7 +1137,7 @@ entity A {
       it('should parse it', () => {
         jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": "country enum",
+  "documentation": "country enum",
   "name": "MyEnum",
   "values": [
     {
@@ -1192,7 +1192,7 @@ entity A {
       it('should parse it', () => {
         jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": "country enum",
+  "documentation": "country enum",
   "name": "MyEnum",
   "values": [
     {
@@ -1248,7 +1248,7 @@ entity A {
       it('should parse it', () => {
         jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": null,
+  "documentation": null,
   "name": "MyEnum",
   "values": [
     {
@@ -1302,7 +1302,7 @@ entity A {
         it('should parse it', () => {
           jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": null,
+  "documentation": null,
   "name": "MyEnum",
   "values": [
     {
@@ -1339,7 +1339,7 @@ entity A {
         it('should parse it', () => {
           jestExpect(parsedEnum).toMatchInlineSnapshot(`
 {
-  "javadoc": null,
+  "documentation": null,
   "name": "MyEnum",
   "values": [
     {
@@ -1388,8 +1388,8 @@ entity A {
 {
   "cardinality": "OneToOne",
   "from": {
+    "documentation": null,
     "injectedField": null,
-    "javadoc": null,
     "name": "A",
   },
   "options": {
@@ -1398,8 +1398,8 @@ entity A {
     "source": [],
   },
   "to": {
+    "documentation": null,
     "injectedField": null,
-    "javadoc": null,
     "name": "B",
   },
 }
@@ -1588,8 +1588,8 @@ entity A {
   {
     "cardinality": "OneToOne",
     "from": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "A",
     },
     "options": {
@@ -1603,16 +1603,16 @@ entity A {
       "source": [],
     },
     "to": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "B",
     },
   },
   {
     "cardinality": "OneToOne",
     "from": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "B",
     },
     "options": {
@@ -1621,16 +1621,16 @@ entity A {
       "source": [],
     },
     "to": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "C",
     },
   },
   {
     "cardinality": "OneToOne",
     "from": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "D",
     },
     "options": {
@@ -1644,8 +1644,8 @@ entity A {
       "source": [],
     },
     "to": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "E",
     },
   },
@@ -1669,8 +1669,8 @@ entity A {
   {
     "cardinality": "OneToOne",
     "from": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "A",
     },
     "options": {
@@ -1684,8 +1684,8 @@ entity A {
       ],
     },
     "to": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "B",
     },
   },
@@ -1707,8 +1707,8 @@ entity A {
   {
     "cardinality": "OneToOne",
     "from": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "A",
     },
     "options": {
@@ -1722,8 +1722,8 @@ entity A {
       "source": [],
     },
     "to": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "B",
     },
   },
@@ -1745,8 +1745,8 @@ entity A {
   {
     "cardinality": "OneToOne",
     "from": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "A",
     },
     "options": {
@@ -1765,8 +1765,8 @@ entity A {
       ],
     },
     "to": {
+      "documentation": null,
       "injectedField": null,
-      "javadoc": null,
       "name": "B",
     },
   },

--- a/jdl/parsing/jdl-ast-builder-visitor.ts
+++ b/jdl/parsing/jdl-ast-builder-visitor.ts
@@ -137,9 +137,9 @@ export default class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
       });
     }
 
-    let javadoc = null;
+    let documentation = null;
     if (context.JAVADOC) {
-      javadoc = trimComment(context.JAVADOC[0].image);
+      documentation = trimComment(context.JAVADOC[0].image);
     }
 
     const name = context.NAME[0].image;
@@ -159,7 +159,7 @@ export default class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
       name,
       tableName,
       body,
-      javadoc,
+      documentation,
     };
   }
 
@@ -208,7 +208,7 @@ export default class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
       // this.visit(context.type) is equivalent to this.visit(context.type[0])
       type: this.visit(context.type),
       validations,
-      javadoc: comment,
+      documentation: comment,
       annotations,
     };
   }
@@ -302,7 +302,7 @@ export default class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
   }
 
   relationshipSide(context) {
-    const javadoc = this.visit(context.comment);
+    const documentation = this.visit(context.comment);
     const name = context.NAME[0].image;
 
     const required = !!context.REQUIRED;
@@ -319,7 +319,7 @@ export default class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
     const ast: any = {
       name,
       injectedField,
-      javadoc,
+      documentation,
       required,
     };
 
@@ -345,12 +345,12 @@ export default class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
   enumDeclaration(context) {
     const name = context.NAME[0].image;
     const values = this.visit(context.enumPropList);
-    let javadoc = null;
+    let documentation = null;
     if (context.JAVADOC) {
-      javadoc = trimComment(context.JAVADOC[0].image);
+      documentation = trimComment(context.JAVADOC[0].image);
     }
 
-    return { name, values, javadoc };
+    return { name, values, documentation };
   }
 
   enumPropList(context) {

--- a/jdl/utils/object-utils.spec.ts
+++ b/jdl/utils/object-utils.spec.ts
@@ -225,7 +225,7 @@ describe('jdl - ObjectUtils', () => {
             name: 'MyEntity',
             fields: [],
             relationships: [],
-            javadoc: undefined,
+            documentation: undefined,
           };
           const secondObject = {
             name: 'MyEntity',
@@ -701,7 +701,7 @@ describe('jdl - ObjectUtils', () => {
 
         before(() => {
           const firstObject = {
-            javadoc: 'My first comment',
+            documentation: 'My first comment',
             fields: [
               {
                 id: 1,
@@ -727,7 +727,7 @@ describe('jdl - ObjectUtils', () => {
             service: 'no',
           };
           const secondObject = {
-            javadoc: 'My Second Comment',
+            documentation: 'My Second Comment',
             fields: [
               {
                 id: 1,
@@ -761,7 +761,7 @@ describe('jdl - ObjectUtils', () => {
       });
       context('as they do not have the same number of attributes', () => {
         type ObjectType = {
-          javadoc: string;
+          documentation: string;
           fields: (
             | { id: number; theAnswer: number; notTheAnswer?: undefined }
             | { id: number; notTheAnswer: number; theAnswer?: undefined }
@@ -779,7 +779,7 @@ describe('jdl - ObjectUtils', () => {
 
         before(() => {
           firstObject = {
-            javadoc: 'My first comment',
+            documentation: 'My first comment',
             fields: [
               {
                 id: 1,
@@ -805,7 +805,7 @@ describe('jdl - ObjectUtils', () => {
             service: 'no',
           };
           secondObject = {
-            javadoc: 'My first comment',
+            documentation: 'My first comment',
             fields: [
               {
                 id: 1,

--- a/jdl/utils/object-utils.ts
+++ b/jdl/utils/object-utils.ts
@@ -54,7 +54,7 @@ export function areEntitiesEqual(firstEntity: any, secondEntity: any) {
   if (
     firstEntity.fields.length !== secondEntity.fields.length ||
     firstEntity.relationships.length !== secondEntity.relationships.length ||
-    firstEntity.javadoc !== secondEntity.javadoc ||
+    firstEntity.documentation !== secondEntity.documentation ||
     firstEntity.entityTableName !== secondEntity.entityTableName ||
     Object.keys(firstEntity).length !== Object.keys(secondEntity).length
   ) {

--- a/test-integration/samples/jdl-default/app.jdl
+++ b/test-integration/samples/jdl-default/app.jdl
@@ -81,7 +81,7 @@ entity Job {
 
 /**
  * The Employee entity.
- * Second line in javadoc.
+ * Second line in documentation.
  */
 entity Employee {
   /**


### PR DESCRIPTION
Rename technology specific javadoc to documentation.

Related to https://github.com/jhipster/generator-jhipster/issues/23449.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
