### PR TITLE
replace lodash with lodash-es

### DIFF
--- a/.blueprint/code-workspace/generator.mjs
+++ b/.blueprint/code-workspace/generator.mjs
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import BaseGenerator from '../../generators/base/index.mjs';
 import { getPackageRoot } from '../../lib/index.mjs';
 import command from './command.mjs';

--- a/cli/environment-builder.mjs
+++ b/cli/environment-builder.mjs
@@ -21,7 +21,7 @@ import { existsSync, readFileSync } from 'fs';
 import path, { dirname, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import Environment from 'yeoman-environment';
 import { QueuedAdapter } from '@yeoman/adapter';
 

--- a/generators/angular/generator.mts
+++ b/generators/angular/generator.mts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import chalk from 'chalk';
 import { isFilePending } from 'mem-fs-editor/state';
 

--- a/generators/angular/needle-api/needle-client-angular.mts
+++ b/generators/angular/needle-api/needle-client-angular.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import needleClientBase from '../../client/needle-api/needle-client.mjs';
 import { LINE_LENGTH } from '../../generator-constants.mjs';

--- a/generators/app/generator.mjs
+++ b/generators/app/generator.mjs
@@ -18,7 +18,7 @@
  */
 /* eslint-disable consistent-return, import/no-named-as-default-member */
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import BaseApplicationGenerator from '../base-application/index.mjs';
 import { checkNode, loadStoredAppOptions } from './support/index.mjs';

--- a/generators/app/support/config.mts
+++ b/generators/app/support/config.mts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { NODE_VERSION } from '../../generator-constants.mjs';
 import { applicationTypes, authenticationTypes, databaseTypes, testFrameworkTypes } from '../../../jdl/index.js';
 import { getHipster, upperFirstCamelCase } from '../../base/support/index.mjs';

--- a/generators/base-application/support/entity.mts
+++ b/generators/base-application/support/entity.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Entity } from '../../../jdl/converters/types.js';
 
 const { upperFirst } = _;

--- a/generators/base-application/support/enum.mjs
+++ b/generators/base-application/support/enum.mjs
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { formatDocAsJavaDoc } from '../../server/support/doc.mjs';
 
 const doesTheEnumValueHaveACustomValue = enumValue => {

--- a/generators/base-application/support/prepare-entity.mts
+++ b/generators/base-application/support/prepare-entity.mts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import pluralize from 'pluralize';
 
 import type BaseGenerator from '../../base-core/index.mjs';

--- a/generators/base-application/support/prepare-field.mjs
+++ b/generators/base-application/support/prepare-field.mjs
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { fieldTypes, validations } from '../../../jdl/jhipster/index.mjs';
 import { getTypescriptType, prepareField as prepareClientFieldForTemplates } from '../../client/support/index.mjs';
 import { prepareField as prepareServerFieldForTemplates } from '../../server/support/index.mjs';

--- a/generators/base-application/support/prepare-relationship.mjs
+++ b/generators/base-application/support/prepare-relationship.mjs
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import pluralize from 'pluralize';
 
 import {

--- a/generators/base-application/support/relationship.mts
+++ b/generators/base-application/support/relationship.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import { Relationship, Entity } from '../../../jdl/converters/types.js';
 import { ValidationResult } from '../../base/api.mjs';

--- a/generators/base-core/generator.mts
+++ b/generators/base-core/generator.mts
@@ -25,7 +25,7 @@ import assert from 'assert';
 import { requireNamespace } from '@yeoman/namespace';
 import chalk from 'chalk';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { simpleGit } from 'simple-git';
 import type { CopyOptions } from 'mem-fs-editor';
 import type { Data as TemplateData, Options as TemplateOptions } from 'ejs';

--- a/generators/base-workspaces/internal/deployments.mts
+++ b/generators/base-workspaces/internal/deployments.mts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { applicationOptions, deploymentOptions } from '../../../jdl/index.js';
 import { loadDerivedPlatformConfig, loadPlatformConfig, loadDerivedServerAndPlatformProperties } from '../../server/support/index.mjs';
 import type { GeneratorBaseCore } from '../../index.js';

--- a/generators/base/generator.mts
+++ b/generators/base/generator.mts
@@ -20,7 +20,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import semver from 'semver';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import type { ComposeOptions } from 'yeoman-generator';
 import { packageJson } from '../../lib/index.mjs';

--- a/generators/base/shared-data.mts
+++ b/generators/base/shared-data.mts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { type BaseApplication } from '../base-application/types.mjs';
 import { type Control } from './types.mjs';
 

--- a/generators/base/support/basename.mts
+++ b/generators/base/support/basename.mts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 const { camelCase } = _;
 

--- a/generators/base/support/needles.mts
+++ b/generators/base/support/needles.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import assert from 'assert';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import escapeStringRegexp from 'escape-string-regexp';
 import CoreGenerator from '../../base-core/index.mjs';
 import { CascatedEditFileCallback, EditFileCallback } from '../api.mjs';

--- a/generators/base/support/string.mts
+++ b/generators/base/support/string.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 /**
  * Calculate a hash code for a given string.

--- a/generators/bootstrap-application-base/generator.mts
+++ b/generators/bootstrap-application-base/generator.mts
@@ -18,7 +18,7 @@
  */
 import assert from 'assert';
 import os from 'os';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import chalk from 'chalk';
 import { passthrough } from '@yeoman/transform';
 

--- a/generators/bootstrap-application-base/utils.mjs
+++ b/generators/bootstrap-application-base/utils.mjs
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { authenticationTypes, databaseTypes, fieldTypes } from '../../jdl/jhipster/index.mjs';
 import { loadRequiredConfigIntoEntity } from '../base-application/support/index.mjs';
 import { hibernateSnakeCase } from '../server/support/string.mjs';

--- a/generators/bootstrap-application-server/generator.mts
+++ b/generators/bootstrap-application-server/generator.mts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import BaseApplicationGenerator from '../base-application/index.mjs';
 import { GENERATOR_BOOTSTRAP_APPLICATION_BASE } from '../generator-list.mjs';

--- a/generators/ci-cd/command.mts
+++ b/generators/ci-cd/command.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { JHipsterCommandDefinition } from '../base/api.mjs';
 
 const { kebabCase, intersection } = _;

--- a/generators/client/command.mts
+++ b/generators/client/command.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { testFrameworkTypes } from '../../jdl/jhipster/index.mjs';
 import { JHipsterCommandDefinition } from '../base/api.mjs';
 import { APPLICATION_TYPE_GATEWAY, APPLICATION_TYPE_MICROSERVICE, clientFrameworkTypes } from '../../jdl/index.js';

--- a/generators/client/needle-api/needle-client-vue.mts
+++ b/generators/client/needle-api/needle-client-vue.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import needleClientBase from './needle-client.mjs';
 import { stripMargin } from '../../base/support/index.mjs';
 import { createNeedleCallback } from '../../base/support/needles.mjs';

--- a/generators/docker-compose/generator.mjs
+++ b/generators/docker-compose/generator.mjs
@@ -21,7 +21,7 @@ import pathjs from 'path';
 import chalk from 'chalk';
 import jsyaml from 'js-yaml';
 import normalize from 'normalize-path';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import BaseWorkspacesGenerator from '../base-workspaces/index.mjs';
 

--- a/generators/docker/generator.mjs
+++ b/generators/docker/generator.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 /* eslint-disable camelcase */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import BaseApplicationGenerator from '../base-application/index.mjs';
 import { createDockerComposeFile, createDockerExtendedServices } from '../docker/support/index.mjs';
 import { GENERATOR_BOOTSTRAP_APPLICATION_SERVER, GENERATOR_DOCKER } from '../generator-list.mjs';

--- a/generators/docker/utils.mjs
+++ b/generators/docker/utils.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { DockerfileParser } from 'dockerfile-ast';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 const { camelCase } = _;
 

--- a/generators/entity/generator.mjs
+++ b/generators/entity/generator.mjs
@@ -20,7 +20,7 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import BaseApplicationGenerator from '../base-application/index.mjs';
 import prompts from './prompts.mjs';

--- a/generators/entity/prompts.mjs
+++ b/generators/entity/prompts.mjs
@@ -18,7 +18,7 @@
  */
 import fs from 'fs';
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   reservedKeywords,
   databaseTypes,

--- a/generators/heroku/generator.mjs
+++ b/generators/heroku/generator.mjs
@@ -21,7 +21,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import ChildProcess from 'child_process';
 import util from 'util';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import chalk from 'chalk';
 import { glob } from 'glob';
 import runAsync from 'run-async';

--- a/generators/java/support/util.mts
+++ b/generators/java/support/util.mts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { getMicroserviceAppName } from '../../base/support/index.mjs';
 
 const { upperFirst } = _;

--- a/generators/jdl/generator.mts
+++ b/generators/jdl/generator.mts
@@ -18,7 +18,7 @@
  */
 import { extname } from 'path';
 import { QueuedAdapter } from '@yeoman/adapter';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { create as createMemFs, type Store as MemFs } from 'mem-fs';
 import { create as createMemFsEditor, type MemFsEditor } from 'mem-fs-editor';
 

--- a/generators/kubernetes/kubernetes-base.mjs
+++ b/generators/kubernetes/kubernetes-base.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import crypto from 'crypto';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import { defaultKubernetesConfig } from './kubernetes-constants.mjs';
 import { loadFromYoRc } from '../base-workspaces/internal/docker-base.mjs';

--- a/generators/languages/generator.mjs
+++ b/generators/languages/generator.mjs
@@ -18,7 +18,7 @@
  */
 /* eslint-disable consistent-return */
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import BaseApplicationGenerator from '../base-application/index.mjs';
 import { askForLanguages, askI18n } from './prompts.mjs';

--- a/generators/languages/translation-data.mjs
+++ b/generators/languages/translation-data.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { inspect } from 'node:util';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { passthrough } from '@yeoman/transform';
 import { Minimatch } from 'minimatch';
 import { clearFileState } from 'mem-fs-editor/state';

--- a/generators/liquibase/generator.mts
+++ b/generators/liquibase/generator.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import fs from 'fs';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import BaseEntityChangesGenerator from '../base-entity-changes/index.mjs';
 import { GENERATOR_LIQUIBASE, GENERATOR_BOOTSTRAP_APPLICATION_SERVER } from '../generator-list.mjs';

--- a/generators/liquibase/support/prepare-field.mjs
+++ b/generators/liquibase/support/prepare-field.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import { databaseTypes, fieldTypes } from '../../../jdl/jhipster/index.mjs';
 

--- a/generators/liquibase/support/relationship.mts
+++ b/generators/liquibase/support/relationship.mts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { getFKConstraintName } from '../../server/support/index.mjs';
 
 function relationshipBaseDataEquals(relationshipA, relationshipB) {

--- a/generators/maven/internal/xml-store.mts
+++ b/generators/maven/internal/xml-store.mts
@@ -19,7 +19,7 @@
 
 import assert from 'assert';
 import { XMLParser, XMLBuilder, XmlBuilderOptions, X2jOptions } from 'fast-xml-parser';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 const { merge } = _;
 

--- a/generators/maven/support/pom-store.mts
+++ b/generators/maven/support/pom-store.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import sortKeys from 'sort-keys';
 
 import CoreGenerator from '../../base-core/index.mjs';

--- a/generators/project-name/generator.mjs
+++ b/generators/project-name/generator.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 /* eslint-disable consistent-return */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { getDefaultAppName } from './support/index.mjs';
 import BaseApplicationGenerator from '../base-application/index.mjs';
 

--- a/generators/react/generator.mjs
+++ b/generators/react/generator.mjs
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { isFilePending } from 'mem-fs-editor/state';
 import chalk from 'chalk';
 

--- a/generators/react/needle-api/needle-client-react.mts
+++ b/generators/react/needle-api/needle-client-react.mts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import needleClientBase from '../../client/needle-api/needle-client.mjs';
 import { stripMargin } from '../../base/support/index.mjs';

--- a/generators/server/entity-files.mjs
+++ b/generators/server/entity-files.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import fs from 'fs';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import chalk from 'chalk';
 import { cleanupOldFiles } from './entity-cleanup.mjs';
 import { moveToJavaPackageSrcDir, javaMainPackageTemplatesBlock, javaTestPackageTemplatesBlock } from './support/index.mjs';

--- a/generators/server/jdl/application-definition.mts
+++ b/generators/server/jdl/application-definition.mts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { JDLApplicationConfig, JHipsterOptionDefinition } from '../../../jdl/types/types.mjs';
 import databaseMigrationOption from '../options/database-migration.mjs';
 import messageBrokerOption from '../options/message-broker.mjs';

--- a/generators/server/prompts.mjs
+++ b/generators/server/prompts.mjs
@@ -18,7 +18,7 @@
  */
 
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import {
   applicationOptions,

--- a/generators/server/support/java-formatting.mjs
+++ b/generators/server/support/java-formatting.mjs
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 /**
  * @private

--- a/generators/server/support/prepare-field.mjs
+++ b/generators/server/support/prepare-field.mjs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import assert from 'assert';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import { databaseTypes, entityOptions, fieldTypes, reservedKeywords } from '../../../jdl/jhipster/index.mjs';
 import { getUXConstraintName } from './database.mjs';

--- a/generators/upgrade/upgrade.spec.mts
+++ b/generators/upgrade/upgrade.spec.mts
@@ -1,7 +1,7 @@
 import path, { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import fse from 'fs-extra';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { expect } from 'esmocha';
 
 import { execaCommandSync } from 'execa';

--- a/generators/vue/generator.mjs
+++ b/generators/vue/generator.mjs
@@ -18,7 +18,7 @@
  */
 import { relative } from 'path';
 import chalk from 'chalk';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { isFilePending } from 'mem-fs-editor/state';
 
 import BaseApplicationGenerator from '../base-application/index.mjs';

--- a/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { validations } from '../../jhipster/index.mjs';
 import formatComment from '../../utils/format-utils.js';
 import { camelCase } from '../../utils/string-utils.js';

--- a/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { relationshipOptions, validations } from '../../jhipster/index.mjs';
 import { camelCase, lowerFirst } from '../../utils/string-utils.js';
 import JDLRelationship from '../../models/jdl-relationship.js';

--- a/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.ts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import JDLObject from '../../models/jdl-object.js';
 import JDLUnaryOption from '../../models/jdl-unary-option.js';
 import JDLBinaryOption from '../../models/jdl-binary-option.js';

--- a/jdl/jdl-importer.ts
+++ b/jdl/jdl-importer.ts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import * as JDLReader from './readers/jdl-reader.js';
 import ParsedJDLToJDLObjectConverter from './converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.js';
 import { readJSONFile } from './readers/json-file-reader.js';

--- a/jdl/jhipster/entity-table-name-creator.ts
+++ b/jdl/jhipster/entity-table-name-creator.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 /**
  * Returns an entity table name based on the passed entity name.

--- a/jdl/jhipster/field-types.ts
+++ b/jdl/jhipster/field-types.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import validations from './validations.js';
 import JDLEnum from '../models/jdl-enum.js';
 import databaseTypes from './database-types.js';

--- a/jdl/jhipster/relationship-types.ts
+++ b/jdl/jhipster/relationship-types.ts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { JDLRelationshipType, RelationshipType, relationshipTypes } from '../basic-types/relationships.js';
 
 const { camelCase, upperFirst } = _;

--- a/jdl/models/jdl-deployment.ts
+++ b/jdl/models/jdl-deployment.ts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { deploymentOptions, applicationOptions, serviceDiscoveryTypes } from '../jhipster/index.mjs';
 import { merge } from '../utils/object-utils.js';
 import { join } from '../utils/set-utils.js';

--- a/jdl/parsing/api.ts
+++ b/jdl/parsing/api.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { EOF } from 'chevrotain';
 import JDLAstBuilderVisitor from './jdl-ast-builder-visitor.js';
 import { JDLLexer, tokens } from './lexer/lexer.js';

--- a/jdl/parsing/lexer/token-creator.ts
+++ b/jdl/parsing/lexer/token-creator.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { createToken, ITokenConfig } from 'chevrotain';
 
 import { NAME, KEYWORD, namePattern } from './shared-tokens.js';

--- a/jdl/parsing/self-checks/parsing-system-checker.ts
+++ b/jdl/parsing/self-checks/parsing-system-checker.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Lexer } from 'chevrotain';
 import TokenCollectorVisitor from './token-collector-visitor.js';
 

--- a/jdl/parsing/validator.ts
+++ b/jdl/parsing/validator.ts
@@ -18,7 +18,7 @@
  */
 /* eslint-disable no-useless-escape */
 
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 import { tokenMatcher as matchesToken } from 'chevrotain';
 
 import JDLParser from './jdl-parser.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "java-lint": "0.1.0",
         "js-yaml": "4.1.0",
         "latest-version": "7.0.0",
-        "lodash": "4.17.21",
         "lodash-es": "4.17.21",
         "mem-fs": "3.0.0",
         "mem-fs-editor": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "java-lint": "0.1.0",
     "js-yaml": "4.1.0",
     "latest-version": "7.0.0",
-    "lodash": "4.17.21",
     "lodash-es": "4.17.21",
     "mem-fs": "3.0.0",
     "mem-fs-editor": "10.0.2",

--- a/testing/helpers.mts
+++ b/testing/helpers.mts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import type { BaseEnvironmentOptions, GetGeneratorConstructor, BaseGenerator as YeomanGenerator } from '@yeoman/types';
 import { YeomanTest, RunContext, RunContextSettings, RunResult, result } from 'yeoman-test';
-import _ from 'lodash';
+import * as _ from 'lodash-es';
 
 import { basename, join } from 'path';
 import EnvironmentBuilder from '../cli/environment-builder.mjs';


### PR DESCRIPTION
`lodash-es` allows:
```
import { kebabCase } from 'lodash-es';
```

instead of:

```
import _ from 'lodash';
const { kebabCase } = _;
```
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
