### PR TITLE
stale workflow adjusts

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,9 +28,10 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@b69b346013879cedbf50c69f572cd85439a41936
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ascending: true
           stale-issue-label: 'area: stale'
           stale-issue-message: |
             This issue is stale because it has been open for too long without any activity.


### PR DESCRIPTION
- use `ascending` options to process old issues first
- use `main` branch for [optimized calls and caching feature](https://github.com/actions/stale/pull/1033)
Current `operations-per-run` is kept low to give time for contributors to give feedback if needed.

Related to https://github.com/jhipster/generator-jhipster/issues/22252.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
