### PR TITLE
Using getter in equals() methods to be Hibernate-safe

### DIFF
--- a/generators/java/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
+++ b/generators/java/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
@@ -343,7 +343,7 @@ _%>
             return false;
         }
 <%_ if (!embedded) { _%>
-        return <%= primaryKey.name %> != null && <%= primaryKey.name %>.equals(((<%= persistClass %>) o).getId());
+        return get<%= primaryKey.nameCapitalized %> != null && get<%= primaryKey.nameCapitalized %>.equals(((<%= persistClass %>) o).get<%= primaryKey.nameCapitalized %>());
 <%_ } else { _%>
         return false;
 <%_ } _%>

--- a/generators/java/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
+++ b/generators/java/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
@@ -343,7 +343,7 @@ _%>
             return false;
         }
 <%_ if (!embedded) { _%>
-        return get<%= primaryKey.nameCapitalized %> != null && get<%= primaryKey.nameCapitalized %>.equals(((<%= persistClass %>) o).get<%= primaryKey.nameCapitalized %>());
+        return get<%= primaryKey.nameCapitalized %>() != null && get<%= primaryKey.nameCapitalized %>().equals(((<%= persistClass %>) o).get<%= primaryKey.nameCapitalized %>());
 <%_ } else { _%>
         return false;
 <%_ } _%>

--- a/generators/java/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
+++ b/generators/java/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
@@ -343,7 +343,7 @@ _%>
             return false;
         }
 <%_ if (!embedded) { _%>
-        return <%= primaryKey.name %> != null && <%= primaryKey.name %>.equals(((<%= persistClass %>) o).<%= primaryKey.name %>);
+        return <%= primaryKey.name %> != null && <%= primaryKey.name %>.equals(((<%= persistClass %>) o).getId());
 <%_ } else { _%>
         return false;
 <%_ } _%>


### PR DESCRIPTION
Using getter in equals() methods to be Hibernate-safe

Fix #23753  The implementation of the equals method is not Hibernate-safe #23753 
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
