### PR TITLE
Adjusts for blueprint support

### DIFF
--- a/generators/bootstrap-application/generator.mts
+++ b/generators/bootstrap-application/generator.mts
@@ -102,9 +102,6 @@ export default class BootstrapApplicationGenerator extends BaseApplicationGenera
           if (application.clientFrameworkVue) {
             prettierExtensions = `${prettierExtensions},vue`;
           }
-          if (application.clientFrameworkSvelte) {
-            prettierExtensions = `${prettierExtensions},svelte`;
-          }
         }
         if (!application.skipServer) {
           prettierExtensions = `${prettierExtensions},java`;

--- a/generators/bootstrap/generator.mts
+++ b/generators/bootstrap/generator.mts
@@ -18,6 +18,7 @@
  */
 import { forceYoFiles, createConflicterTransform, createYoResolveTransform } from '@yeoman/conflicter';
 import { isFilePending } from 'mem-fs-editor/state';
+import prettier from 'prettier';
 
 import BaseGenerator from '../base/index.mjs';
 import {
@@ -50,6 +51,8 @@ export default class BootstrapGenerator extends BaseGenerator {
 
   upgradeCommand?: boolean;
   skipPrettier?: boolean;
+  prettierExtensions: string[] = PRETTIER_EXTENSIONS.split(',');
+  prettierOptions: prettier.Options = { plugins: [] };
 
   constructor(args: any, options: any, features: any) {
     super(args, options, { jhipsterBootstrap: false, uniqueGlobally: true, customCommitTask: () => this.commitSharedFs(), ...features });
@@ -185,7 +188,8 @@ export default class BootstrapGenerator extends BaseGenerator {
               ignoreErrors,
               prettierPackageJson: true,
               prettierJava: !this.jhipsterConfig.skipServer,
-              extensions: PRETTIER_EXTENSIONS,
+              extensions: this.prettierExtensions.join(','),
+              prettierOptions: this.prettierOptions,
             }),
           ]),
       ...(this.jhipsterConfig.autoCrlf ? [autoCrlfTransform(this.createGit())] : []),

--- a/generators/common/__snapshots__/generator.spec.mjs.snap
+++ b/generators/common/__snapshots__/generator.spec.mjs.snap
@@ -92,6 +92,8 @@ overrides:
   "README.md": {
     "contents": "# jhipster
 
+This application was generated using JHipster JHIPSTER_VERSION, you can find documentation and help at [https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION](https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION).
+
 
 ## Project Structure
 

--- a/generators/common/templates/README.md.jhi.ejs
+++ b/generators/common/templates/README.md.jhi.ejs
@@ -34,6 +34,8 @@
 _&>
 # <%= baseName %>
 
+This application was generated using JHipster <%= jhipsterVersion %>, you can find documentation and help at [<%= documentationArchiveUrl %>](<%= documentationArchiveUrl %>).
+
 <&- fragments.introSection() &>
 ## Project Structure
 

--- a/generators/generator-constants.mts
+++ b/generators/generator-constants.mts
@@ -111,4 +111,4 @@ export const SERVER_MAIN_SRC_DIR = `${MAIN_DIR}java/`;
 export const SERVER_MAIN_RES_DIR = `${MAIN_DIR}resources/`;
 export const SERVER_TEST_SRC_DIR = `${TEST_DIR}java/`;
 export const SERVER_TEST_RES_DIR = `${TEST_DIR}resources/`;
-export const PRETTIER_EXTENSIONS = 'md,json,yml,html,cjs,mjs,js,ts,tsx,css,scss,vue,svelte,java';
+export const PRETTIER_EXTENSIONS = 'md,json,yml,html,cjs,mjs,js,ts,tsx,css,scss,vue,java';

--- a/generators/info/generator.mts
+++ b/generators/info/generator.mts
@@ -29,13 +29,15 @@ import type { JHipsterGeneratorFeatures, JHipsterGeneratorOptions } from '../bas
 import { YO_RC_FILE } from '../generator-constants.mjs';
 import { replaceSensitiveConfig } from './support/utils.mjs';
 
+const isInfoCommand = commandName => commandName === 'info' || undefined;
+
 export default class InfoGenerator extends BaseApplicationGenerator {
   constructor(args: string | string[], options: JHipsterGeneratorOptions, features: JHipsterGeneratorFeatures) {
     super(args, options, {
       jhipsterBootstrap: false,
       storeJHipsterVersion: false,
-      customInstallTask: options.commandName === 'info' ? true : undefined,
-      customCommitTask: true,
+      customInstallTask: isInfoCommand(options.commandName),
+      customCommitTask: isInfoCommand(options.commandName),
       ...features,
     });
   }
@@ -62,8 +64,9 @@ export default class InfoGenerator extends BaseApplicationGenerator {
           console.log('\n##### **JHipster configuration not found**\n');
         }
 
-        if (this.jhipsterConfig.packages && this.jhipsterConfig.packages.length > 0) {
-          for (const pkg of this.jhipsterConfig.packages) {
+        const packages = this.jhipsterConfig.appsFolders ?? this.jhipsterConfig.packages ?? [];
+        if (packages.length > 0) {
+          for (const pkg of packages) {
             const yoRc = this.readDestinationJSON(this.destinationPath(pkg, YO_RC_FILE));
             if (yoRc) {
               const result = JSON.stringify(replaceSensitiveConfig(yoRc), null, 2);

--- a/generators/server/templates/README.md.jhi.spring-boot.ejs
+++ b/generators/server/templates/README.md.jhi.spring-boot.ejs
@@ -21,7 +21,6 @@
  EJS fragments will process % delimiter tags in template and & delimiter tags in the merge process.
 -%>
 <&_ if (fragment.introSection) { -&>
-This application was generated using JHipster <%= jhipsterVersion %>, you can find documentation and help at [<%= documentationArchiveUrl %>](<%= documentationArchiveUrl %>).
   <%_ if (applicationTypeGateway || applicationTypeMicroservice) { _%>
 
 This is a "<%= applicationType %>" application intended to be part of a microservice architecture, please refer to the [Doing microservices with JHipster][] page of the documentation for more information.


### PR DESCRIPTION
- prettier 3 doesn't looks for plugins anymore, adding an extension without the plugin results in error. Drop svelte extension for this reason.
- allow bootstrap prettier support to be customized.
- adjust README.
- info adjusts (fix workspaces support and make custom commit conditional).

Related to https://github.com/jhipster/generator-jhipster/issues/23449.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
