### PR TITLE
do not hide registration errors (login/email already used)

### DIFF
--- a/generators/server/templates/src/main/java/_package_/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/web/rest/errors/ExceptionTranslator.java.ejs
@@ -149,13 +149,10 @@ _%>
 
     private ProblemDetailWithCause getProblemDetailWithCause(Throwable ex) {
 <%_ if (!skipUserManagement) { _%>
-        if(ex instanceof <%= packageName %>.service.EmailAlreadyUsedException ||
-            ex instanceof <%= packageName %>.service.UsernameAlreadyUsedException) {
-                // return 201 - CREATED on purpose to not reveal information to potential attackers
-                // see https://github.com/jhipster/generator-jhipster/issues/21731
-                return ProblemDetailWithCauseBuilder.instance()
-                    .withStatus(201).build();
-            }
+        if(ex instanceof <%= packageName %>.service.UsernameAlreadyUsedException ) 
+            return (ProblemDetailWithCause) new LoginAlreadyUsedException().getBody();    
+        if(ex instanceof <%= packageName %>.service.EmailAlreadyUsedException ) 
+            return (ProblemDetailWithCause) new EmailAlreadyUsedException().getBody();
         if(ex instanceof <%= packageName %>.service.InvalidPasswordException )
             return (ProblemDetailWithCause) new InvalidPasswordException().getBody();
 

--- a/generators/server/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
@@ -529,14 +529,14 @@ class AccountResourceIT {
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(TestUtil.convertObjectToJsonBytes(secondUser))
             .exchange()
-            .expectStatus().isCreated();
+            .expectStatus().isBadRequest();
 <%_ } else { _%>
         restAccountMockMvc.perform(
             post("/api/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtil.convertObjectToJsonBytes(secondUser))<% if (authenticationUsesCsrf) { %>
                 .with(csrf())<% } %>)
-            .andExpect(status().isCreated());
+            .andExpect(status().is4xxClientError());
 <%_ } _%>
     }
 
@@ -655,14 +655,14 @@ class AccountResourceIT {
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(TestUtil.convertObjectToJsonBytes(secondUser))
             .exchange()
-            .expectStatus().isCreated();
+            .expectStatus().is4xxClientError();
 <%_ } else { _%>
         restAccountMockMvc.perform(
             post("/api/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtil.convertObjectToJsonBytes(secondUser))<% if (authenticationUsesCsrf) { %>
                 .with(csrf())<% } %>)
-            .andExpect(status().isCreated());
+            .andExpect(status().is4xxClientError());
 <%_ } _%>
     }
 


### PR DESCRIPTION
This reverts the change for hiding registration errors.

relates to #21731

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
