### PR TITLE
fix(#22487): Remove warning for resources plugins

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -758,7 +758,7 @@
                     <version>${maven-resources-plugin.version}</version>
                     <executions>
                         <execution>
-                            <id>default-resources</id>
+                            <id>config-resources</id>
                             <phase>validate</phase>
                             <goals>
                                 <goal>copy-resources</goal>
@@ -776,13 +776,6 @@
                                         <includes>
                                             <include>config/*.yml</include>
                                         </includes>
-                                    </resource>
-                                    <resource>
-                                        <directory><%= SERVER_MAIN_RES_DIR %></directory>
-                                        <filtering>false</filtering>
-                                        <excludes>
-                                            <exclude>config/*.yml</exclude>
-                                        </excludes>
                                     </resource>
                                 </resources>
                             </configuration>


### PR DESCRIPTION
This PR fixes only the warning emitted by the maven-resource-plugin

* It uses a specific execution ID to not have the configuration applied to the default resources:resources mojo
* It removes the copy of non-filtered files which is already done by resources:resources

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
