### PR TITLE
remove deprecated annotation from kubernetes ingress template

### DIFF
--- a/generators/kubernetes/__snapshots__/kubernetes.spec.mts.snap
+++ b/generators/kubernetes/__snapshots__/kubernetes.spec.mts.snap
@@ -2448,7 +2448,6 @@ metadata:
   namespace: default
   annotations:
     kubernetes.io/ingress.allow-http: "true"
-    kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: jhgate-ip
     cert-manager.io/issuer: letsencrypt-staging
     acme.cert-manager.io/http01-edit-in-place: "true"

--- a/generators/kubernetes/templates/ingress.yml.ejs
+++ b/generators/kubernetes/templates/ingress.yml.ejs
@@ -24,7 +24,6 @@ metadata:
   <%_ if (useKeycloak && ingressTypeGke) { _%>
   annotations:
     kubernetes.io/ingress.allow-http: "true"
-    kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: <%= app.baseName.toLowerCase()%>-ip
     cert-manager.io/issuer: letsencrypt-staging
     acme.cert-manager.io/http01-edit-in-place: "true"


### PR DESCRIPTION
Fix #23962

<!--
PR description.
-->

k8s sub-generator, remove deprecated annotation from Kubernetes ingress template

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
