### PR TITLE
drop app generator from generate-blueprint sample

### DIFF
--- a/.github/workflows/generator-generate-blueprint.yml
+++ b/.github/workflows/generator-generate-blueprint.yml
@@ -105,7 +105,6 @@ jobs:
       #----------------------------------------------------------------------
       - name: 'TESTS: blueprint files should be written'
         run: |
-          ls template-file-app
           ls template-file-client
           ls template-file-common
           ls template-file-cypress

--- a/test-integration/generate-blueprint-samples/default/.yo-rc.json
+++ b/test-integration/generate-blueprint-samples/default/.yo-rc.json
@@ -5,29 +5,6 @@
     "cli": true,
     "localBlueprint": false,
     "generators": {
-      "app": {
-        "command": false,
-        "priorities": [
-          "initializing",
-          "prompting",
-          "configuring",
-          "composing",
-          "loading",
-          "preparing",
-          "preparingEachEntity",
-          "preparingEachEntityField",
-          "preparingEachEntityRelationship",
-          "default",
-          "writing",
-          "writingEntities",
-          "postWriting",
-          "postWritingEntities",
-          "install",
-          "end"
-        ],
-        "sbs": false,
-        "written": true
-      },
       "client": {
         "command": false,
         "priorities": [
@@ -125,6 +102,6 @@
     "mainGenerator": "generate-blueprint",
     "prettierDefaultIndent": 2,
     "projectName": "CiTest",
-    "subGenerators": ["app", "client", "common", "cypress", "server"]
+    "subGenerators": ["client", "common", "cypress", "server"]
   }
 }


### PR DESCRIPTION
it's stable enough but is timing out too often.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
