### PR TITLE
Make banners similar between frameworks

### DIFF
--- a/generators/react/templates/src/main/webapp/app/modules/home/home.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/home/home.tsx.ejs
@@ -50,7 +50,7 @@ export const Home = () => {
         <span className="hipster rounded" />
       </Col>
       <Col md="9">
-        <h2><Translate contentKey="home.title">Welcome, <%= backendType %> Hipster!</Translate></h2>
+        <h1 className="display-4"><Translate contentKey="home.title">Welcome, <%= backendType %> Hipster!</Translate></h1>
         <p className="lead"><Translate contentKey="home.subtitle">This is your homepage</Translate></p>
         {
           (account?.login) ? (

--- a/generators/react/templates/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
@@ -36,7 +36,7 @@ export const Brand = () => (
 <NavbarBrand tag={Link} to="/" className="brand-logo">
   <BrandIcon />
   <span className="brand-title"><Translate contentKey="global.title"><%= capitalizedBaseName %></Translate></span>
-  <span className="navbar-version">{VERSION}</span>
+  <span className="navbar-version">{VERSION.toLowerCase().startsWith('v') ? VERSION : `v${VERSION}`}</span>
 </NavbarBrand>
 );
 

--- a/generators/react/templates/src/main/webapp/app/shared/layout/header/header.scss.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/layout/header/header.scss.ejs
@@ -33,7 +33,7 @@ Developement Ribbon
   transform: rotate(-45deg);
   overflow: hidden;
   position: absolute;
-  top: 30px;
+  top: 40px;
   white-space: nowrap;
   width: 15em;
   z-index: 99999;
@@ -105,7 +105,7 @@ Navbar styles
 }
 
 .navbar-version {
-  font-size: 10px;
+  font-size: 0.65em;
   color: $header-color-secondary;
   padding: 0 0 0 10px;
 }
@@ -119,13 +119,14 @@ Navbar styles
     width: auto;
     display: inline-block;
     img {
-      height: 45px;
+      width: 45px;
     }
   }
 }
 
 .brand-title {
-  font-size: 24px;
+  font-size: 1.25rem;
+  margin-left: .25rem;
   color: $header-color;
   &:hover {
     color: $header-color-hover;

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue.ejs
@@ -177,7 +177,7 @@
     Navbar
     ========================================================================== */
   .navbar-version {
-    font-size: 10px;
+    font-size: 0.65em;
 <%_ if (clientThemeNone) { _%>
     color: #ccc;
 <%_ } _%>
@@ -243,7 +243,6 @@
 
   .navbar-title {
     display: inline-block;
-    vertical-align: middle;
 <%_ if (clientThemeNone && !clientThemeDark) { _%>
     color: white;
 <%_ } _%>
@@ -253,14 +252,14 @@
     Logo styles
     ========================================================================== */
   .navbar-brand.logo {
-    padding: 5px 15px;
+    padding: 0 7px;
   }
 
   .logo .logo-img {
     height: 45px;
     display: inline-block;
     vertical-align: middle;
-    width: 70px;
+    width: 45px;
   }
 
   .logo-img {


### PR DESCRIPTION
I created apps using the following commands:

```
jhipster --defaults --skip-install --client-framework angular
jhipster --defaults --skip-install --client-framework react
jhipster --defaults --skip-install --client-framework vue
```

Here are the results:

<img width="301" alt="Screenshot 2023-10-30 at 11 44 17 AM" src="https://github.com/jhipster/generator-jhipster/assets/17892/14a1922a-bd81-4287-adba-23554b1c8850">
<img width="335" alt="Screenshot 2023-10-30 at 11 53 44 AM" src="https://github.com/jhipster/generator-jhipster/assets/17892/a587ee58-29ef-4da2-ae9d-700f3ecb0099">
<img width="296" alt="Screenshot 2023-10-30 at 11 56 04 AM" src="https://github.com/jhipster/generator-jhipster/assets/17892/5a1cac93-8c11-4953-b21d-f234f48a5bc2">

This PR makes the banners more similar. You might notice there are still some differences. Notably, Angular has no line around the body content, React has a line with a silver background, and Vue has no line but does have a gray background. 

<img width="1250" alt="angular" src="https://github.com/jhipster/generator-jhipster/assets/17892/546c8761-81d7-4718-9453-fa890152ae42">
<img width="1050" alt="react" src="https://github.com/jhipster/generator-jhipster/assets/17892/6f15f12e-8c0c-4575-ac85-4572d2e064dc">
<img width="1021" alt="vue" src="https://github.com/jhipster/generator-jhipster/assets/17892/89814986-f9b6-4a05-9edc-2f62181773ca">

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
