### PR TITLE
reinstate reactive mariadb tests using r2dbc-mysql

### DIFF
--- a/generators/app/__snapshots__/generator.spec.mts.snap
+++ b/generators/app/__snapshots__/generator.spec.mts.snap
@@ -685,6 +685,16 @@ exports[`generator - app with default config should match snapshot 1`] = `
   "prettierExtensions": "md,json,yml,html,cjs,mjs,js,ts,tsx,css,scss,java",
   "prettierJava": undefined,
   "prettierTabWidth": 2,
+  "prodDatabaseDriver": {
+    "jdbc": {
+      "artifactId": "postgresql",
+      "groupId": "org.postgresql",
+    },
+    "r2dbc": {
+      "artifactId": "r2dbc-postgresql",
+      "groupId": "org.postgresql",
+    },
+  },
   "prodDatabaseExtraOptions": "",
   "prodDatabaseName": "jhipster",
   "prodDatabasePassword": "",
@@ -1243,6 +1253,16 @@ exports[`generator - app with gateway should match snapshot 1`] = `
   "prettierExtensions": "md,json,yml,html,cjs,mjs,js,ts,tsx,css,scss,java",
   "prettierJava": undefined,
   "prettierTabWidth": 2,
+  "prodDatabaseDriver": {
+    "jdbc": {
+      "artifactId": "postgresql",
+      "groupId": "org.postgresql",
+    },
+    "r2dbc": {
+      "artifactId": "r2dbc-postgresql",
+      "groupId": "org.postgresql",
+    },
+  },
   "prodDatabaseExtraOptions": "",
   "prodDatabaseName": "jhipster",
   "prodDatabasePassword": "",
@@ -1746,6 +1766,16 @@ exports[`generator - app with microservice should match snapshot 1`] = `
   "prettierExtensions": "md,json,yml,html,java",
   "prettierJava": undefined,
   "prettierTabWidth": 2,
+  "prodDatabaseDriver": {
+    "jdbc": {
+      "artifactId": "postgresql",
+      "groupId": "org.postgresql",
+    },
+    "r2dbc": {
+      "artifactId": "r2dbc-postgresql",
+      "groupId": "org.postgresql",
+    },
+  },
   "prodDatabaseExtraOptions": "",
   "prodDatabaseName": "jhipster",
   "prodDatabasePassword": "",

--- a/generators/docker/__snapshots__/generator.spec.mts.snap
+++ b/generators/docker/__snapshots__/generator.spec.mts.snap
@@ -14,7 +14,7 @@ services:
       - MANAGEMENT_PROMETHEUS_METRICS_EXPORT_ENABLED=true
       - SPRING_CLOUD_CONSUL_HOST=consul
       - SPRING_CLOUD_CONSUL_PORT=8500
-      - SPRING_R2DBC_URL=r2dbc:mariadb://mariadb:3306/jhipster?useLegacyDatetimeCode=false
+      - SPRING_R2DBC_URL=r2dbc:mysql://mariadb:3306/jhipster?useLegacyDatetimeCode=false
       - SPRING_LIQUIBASE_URL=jdbc:mariadb://mariadb:3306/jhipster?useLegacyDatetimeCode=false
       - SPRING_ELASTICSEARCH_URIS=http://elasticsearch:9200
     ports:

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -49,29 +49,11 @@ dependencies {
     implementation "com.h2database:h2"
     <%_ } _%>
   <%_ } _%>
-  <%_ if (devDatabaseTypeMysql) { _%>
+  <%_ if (devDatabaseTypeMariadb || devDatabaseTypeMssql || devDatabaseTypePostgres || devDatabaseTypeMysql) { _%>
     <%_ if (reactive) { _%>
-    implementation ("io.asyncer:r2dbc-mysql")
+    implementation "<%- prodDatabaseDriver.r2dbc.groupId %>:<%- prodDatabaseDriver.r2dbc.artifactId %>"
     <%_ } _%>
-    implementation "com.mysql:mysql-connector-j"
-  <%_ } _%>
-  <%_ if (devDatabaseTypePostgres) { _%>
-    <%_ if (reactive) { _%>
-    implementation "org.postgresql:r2dbc-postgresql"
-    <%_ } _%>
-    implementation "org.postgresql:postgresql"
-  <%_ } _%>
-  <%_ if (devDatabaseTypeMariadb) { _%>
-    <%_ if (reactive) { _%>
-    implementation "org.mariadb:r2dbc-mariadb"
-    <%_ } _%>
-    implementation "org.mariadb.jdbc:mariadb-java-client"
-  <%_ } _%>
-  <%_ if (devDatabaseTypeMssql) { _%>
-    <%_ if (reactive) { _%>
-    implementation "io.r2dbc:r2dbc-mssql"
-    <%_ } _%>
-    implementation "com.microsoft.sqlserver:mssql-jdbc"
+    implementation "<%- prodDatabaseDriver.jdbc.groupId %>:<%- prodDatabaseDriver.jdbc.artifactId %>"
   <%_ } _%>
   <%_ if (devDatabaseTypeOracle) { _%>
     implementation "com.oracle.database.jdbc:ojdbc8"

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -41,32 +41,22 @@ configurations {
 }
 
 dependencies {
-  <%_ if (prodDatabaseTypeMysql) { _%>
+  <%_ if (prodDatabaseTypeMariadb || prodDatabaseTypeMssql || prodDatabaseTypeMysql || prodDatabaseTypePostgresql) { _%>
     <%_ if (reactive) { _%>
-    implementation "io.asyncer:r2dbc-mysql"
+    implementation "<%- prodDatabaseDriver.r2dbc.groupId %>:<%- prodDatabaseDriver.r2dbc.artifactId %>"
     <%_ } _%>
-    implementation "com.mysql:mysql-connector-j"
+    implementation "<%- prodDatabaseDriver.jdbc.groupId %>:<%- prodDatabaseDriver.jdbc.artifactId %>"
+  <%_ } _%>
+  <%_ if (prodDatabaseTypeMysql) { _%>
     testImplementation "org.testcontainers:mysql"
   <%_ } _%>
   <%_ if (prodDatabaseTypePostgresql) { _%>
-    <%_ if (reactive) { _%>
-    implementation "org.postgresql:r2dbc-postgresql"
-    <%_ } _%>
-    implementation "org.postgresql:postgresql"
     testImplementation "org.testcontainers:postgresql"
   <%_ } _%>
   <%_ if (prodDatabaseTypeMariadb) { _%>
-    <%_ if (reactive) { _%>
-    implementation "org.mariadb:r2dbc-mariadb"
-    <%_ } _%>
-    implementation "org.mariadb.jdbc:mariadb-java-client"
     testImplementation "org.testcontainers:mariadb"
   <%_ } _%>
   <%_ if (prodDatabaseTypeMssql) { _%>
-    <%_ if (reactive) { _%>
-    implementation "io.r2dbc:r2dbc-mssql"
-    <%_ } _%>
-    implementation "com.microsoft.sqlserver:mssql-jdbc"
     testImplementation "org.testcontainers:mssqlserver"
   <%_ } _%>
   <%_ if (prodDatabaseTypeOracle) { _%>

--- a/generators/spring-data-relational/generator.mts
+++ b/generators/spring-data-relational/generator.mts
@@ -28,6 +28,7 @@ import { GeneratorDefinition as SpringBootGeneratorDefinition } from '../server/
 import { getDBCExtraOption, getJdbcUrl, getR2dbcUrl } from './support/index.mjs';
 import {
   getCommonMavenDefinition,
+  getDatabaseDriverForDatabase,
   getDatabaseTypeMavenDefinition,
   getH2MavenDefinition,
   getImperativeMavenDefinition,
@@ -78,6 +79,8 @@ export default class SqlGenerator extends BaseApplicationGenerator<SpringBootGen
         const anyApp = application as any;
         anyApp.devDatabaseExtraOptions = getDBCExtraOption(anyApp.devDatabaseType);
         anyApp.prodDatabaseExtraOptions = getDBCExtraOption(anyApp.prodDatabaseType);
+
+        anyApp.prodDatabaseDriver = getDatabaseDriverForDatabase(application.prodDatabaseType);
       },
     });
   }

--- a/generators/spring-data-relational/internal/dependencies.mts
+++ b/generators/spring-data-relational/internal/dependencies.mts
@@ -37,7 +37,9 @@ export type DatabaseArtifact = { jdbc: JavaArtifact; r2dbc: JavaArtifact };
 const databaseArtifactForDB: Record<string, DatabaseArtifact> = {
   mariadb: {
     jdbc: { groupId: 'org.mariadb.jdbc', artifactId: 'mariadb-java-client' },
-    r2dbc: { groupId: 'org.mariadb', artifactId: 'r2dbc-mariadb' },
+    // maria-r2dbc driver is failing.
+    // r2dbc: { groupId: 'org.mariadb', artifactId: 'r2dbc-mariadb' },
+    r2dbc: { groupId: 'io.asyncer', artifactId: 'r2dbc-mysql' },
   },
   mssql: {
     jdbc: { groupId: 'com.microsoft.sqlserver', artifactId: 'mssql-jdbc' },

--- a/generators/spring-data-relational/internal/dependencies.mts
+++ b/generators/spring-data-relational/internal/dependencies.mts
@@ -31,6 +31,30 @@ const testcontainerFileForDB = {
   postgresql: 'PostgreSqlTestContainer.java',
 };
 
+type JavaArtifact = { groupId: string; artifactId: string };
+export type DatabaseArtifact = { jdbc: JavaArtifact; r2dbc: JavaArtifact };
+
+const databaseArtifactForDB: Record<string, DatabaseArtifact> = {
+  mariadb: {
+    jdbc: { groupId: 'org.mariadb.jdbc', artifactId: 'mariadb-java-client' },
+    r2dbc: { groupId: 'org.mariadb', artifactId: 'r2dbc-mariadb' },
+  },
+  mssql: {
+    jdbc: { groupId: 'com.microsoft.sqlserver', artifactId: 'mssql-jdbc' },
+    r2dbc: { groupId: 'io.r2dbc', artifactId: 'r2dbc-mssql' },
+  },
+  mysql: {
+    jdbc: { groupId: 'com.mysql', artifactId: 'mysql-connector-j' },
+    r2dbc: { groupId: 'io.asyncer', artifactId: 'r2dbc-mysql' },
+  },
+  postgresql: {
+    jdbc: { groupId: 'org.postgresql', artifactId: 'postgresql' },
+    r2dbc: { groupId: 'org.postgresql', artifactId: 'r2dbc-postgresql' },
+  },
+};
+
+export const getDatabaseDriverForDatabase = (databaseType: string) => databaseArtifactForDB[databaseType];
+
 export const getCommonMavenDefinition = ({ javaDependencies }: { javaDependencies: Record<string, string> }) => ({
   properties: [
     { property: 'jaxb-runtime.version', value: javaDependencies['jaxb-runtime'] },
@@ -121,34 +145,34 @@ export const getDatabaseTypeMavenDefinition: (
     mariadb: {
       jdbc: {
         dependencies: [
-          { inProfile, groupId: 'org.mariadb.jdbc', artifactId: 'mariadb-java-client' },
+          { inProfile, ...databaseArtifactForDB.mariadb.jdbc },
           { groupId: 'org.testcontainers', artifactId: 'mariadb', scope: 'test' },
         ],
       },
       r2dbc: {
-        dependencies: [{ inProfile, groupId: 'org.mariadb', artifactId: 'r2dbc-mariadb' }],
+        dependencies: [{ inProfile, ...databaseArtifactForDB.mariadb.r2dbc }],
       },
     },
     mssql: {
       jdbc: {
         dependencies: [
-          { inProfile, groupId: 'com.microsoft.sqlserver', artifactId: 'mssql-jdbc' },
+          { inProfile, ...databaseArtifactForDB.mssql.jdbc },
           { groupId: 'org.testcontainers', artifactId: 'mssqlserver', scope: 'test' },
         ],
       },
       r2dbc: {
-        dependencies: [{ inProfile, groupId: 'io.r2dbc', artifactId: 'r2dbc-mssql' }],
+        dependencies: [{ inProfile, ...databaseArtifactForDB.mssql.r2dbc }],
       },
     },
     mysql: {
       jdbc: {
         dependencies: [
-          { inProfile, groupId: 'com.mysql', artifactId: 'mysql-connector-j' },
+          { inProfile, ...databaseArtifactForDB.mysql.jdbc },
           { groupId: 'org.testcontainers', artifactId: 'mysql', scope: 'test' },
         ],
       },
       r2dbc: {
-        dependencies: [{ inProfile, groupId: 'io.asyncer', artifactId: 'r2dbc-mysql' }],
+        dependencies: [{ inProfile, ...databaseArtifactForDB.mysql.r2dbc }],
       },
     },
     oracle: {
@@ -163,12 +187,12 @@ export const getDatabaseTypeMavenDefinition: (
     postgresql: {
       jdbc: {
         dependencies: [
-          { inProfile, groupId: 'org.postgresql', artifactId: 'postgresql' },
+          { inProfile, ...databaseArtifactForDB.postgresql.jdbc },
           { groupId: 'org.testcontainers', artifactId: 'postgresql', scope: 'test' },
         ],
       },
       r2dbc: {
-        dependencies: [{ inProfile, groupId: 'org.postgresql', artifactId: 'r2dbc-postgresql' }],
+        dependencies: [{ inProfile, ...databaseArtifactForDB.postgresql.r2dbc }],
       },
     },
   };

--- a/generators/spring-data-relational/support/database-data.mts
+++ b/generators/spring-data-relational/support/database-data.mts
@@ -116,6 +116,10 @@ const databaseData: Record<string, DatabaseDataSpec> = {
 
     constraintNameMaxLength: 64,
     tableNameMaxLength: 64,
+    r2dbc: {
+      // TODO switch to mariadb if r2dbc-mariadb is reinstated
+      protocolSuffix: 'mysql://',
+    },
   },
   [MYSQL]: {
     name: 'MySQL',

--- a/generators/spring-data-relational/support/database-url.spec.mts
+++ b/generators/spring-data-relational/support/database-url.spec.mts
@@ -145,16 +145,16 @@ describe('generator - sql - database-url', () => {
       });
     });
     describe('when called for mariadb', () => {
-      it('return r2dbc:mariadb://localhost:3306/test?useLegacyDatetimeCode=false', () => {
+      it('return r2dbc:mysql://localhost:3306/test?useLegacyDatetimeCode=false', () => {
         expect(getR2dbcUrl(MARIADB, { databaseName: 'test', hostname: 'localhost' })).toEqual(
-          'r2dbc:mariadb://localhost:3306/test?useLegacyDatetimeCode=false',
+          'r2dbc:mysql://localhost:3306/test?useLegacyDatetimeCode=false',
         );
       });
     });
     describe('when called for mariadb with skipExtraOptions enabled', () => {
-      it('return r2dbc:mariadb://localhost:3306/test', () => {
+      it('return r2dbc:mysql://localhost:3306/test', () => {
         expect(getR2dbcUrl(MARIADB, { databaseName: 'test', hostname: 'localhost', skipExtraOptions: true })).toEqual(
-          'r2dbc:mariadb://localhost:3306/test',
+          'r2dbc:mysql://localhost:3306/test',
         );
       });
     });

--- a/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
+++ b/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
@@ -69,7 +69,7 @@ public class SqlTestContainersSpringContextCustomizerFactory implements ContextC
                     }
                 }
 <%_ if (reactive) { _%>
-                testValues = testValues.and("spring.r2dbc.url=" + prodTestContainer.getTestContainer().getJdbcUrl().replace("jdbc", "r2dbc")<% if (prodDatabaseTypeMssql) { %>.replace(";encrypt=false", "")<% } %> + "<%- prodDatabaseExtraOptions %>");
+                testValues = testValues.and("spring.r2dbc.url=" + prodTestContainer.getTestContainer().getJdbcUrl().replace("jdbc", "r2dbc")<% if (prodDatabaseTypeMariadb) { %>.replace("mariadb", "mysql")<% } else if (prodDatabaseTypeMssql) { %>.replace(";encrypt=false", "")<% } %> + "<%- prodDatabaseExtraOptions %>");
                 testValues = testValues.and("spring.r2dbc.username=" + prodTestContainer.getTestContainer().getUsername());
                 testValues = testValues.and("spring.r2dbc.password=" + prodTestContainer.getTestContainer().getPassword());
                 testValues = testValues.and("spring.liquibase.url=" + prodTestContainer.getTestContainer().getJdbcUrl()  + "<%- prodDatabaseExtraOptions %>");

--- a/test-integration/jdl-samples/ms-mf-react-eureka-oauth2-mariadb-infinispan/blog-store.jdl
+++ b/test-integration/jdl-samples/ms-mf-react-eureka-oauth2-mariadb-infinispan/blog-store.jdl
@@ -27,8 +27,7 @@ application {
     creationTimestamp 1617901618886
     jwtSecretKey "ZjY4MTM4YjI5YzMwZjhjYjI2OTNkNTRjMWQ5Y2Q0Y2YwOWNmZTE2NzRmYzU3NTMwM2NjOTE3MTllOTM3MWRkMzcyYTljMjVmNmQ0Y2MxOTUzODc0MDhhMTlkMDIxMzI2YzQzZDM2ZDE3MmQ3NjVkODk3OTVmYzljYTQyZDNmMTQ="
     packageName com.okta.developer.gateway
-    // TODO switch to mariadb
-    prodDatabaseType mysql
+    prodDatabaseType mariadb
     serviceDiscoveryType eureka
     testFrameworks [cypress]
     microfrontends [blog, notification]
@@ -90,8 +89,7 @@ application {
     entitySuffix Entity
     jwtSecretKey "ZjY4MTM4YjI5YzMwZjhjYjI2OTNkNTRjMWQ5Y2Q0Y2YwOWNmZTE2NzRmYzU3NTMwM2NjOTE3MTllOTM3MWRkMzcyYTljMjVmNmQ0Y2MxOTUzODc0MDhhMTlkMDIxMzI2YzQzZDM2ZDE3MmQ3NjVkODk3OTVmYzljYTQyZDNmMTQ="
     packageName com.okta.developer.notification
-    // TODO switch to mariadb
-    prodDatabaseType mysql
+    prodDatabaseType mariadb
     reactive true
     serverPort 8083
     serviceDiscoveryType eureka

--- a/test-integration/workflow-samples/react.json
+++ b/test-integration/workflow-samples/react.json
@@ -34,7 +34,6 @@
     },
     {
       "name": "ms-mf-react-eureka-oauth2-mariadb-infinispan",
-      "skip-backend-tests": "r2dbc-mariadb fails at github ci, error cannot be reproduced locally",
       "jdl-samples": "ms-mf-react-eureka-oauth2-mariadb-infinispan",
       "extra-args": "--workspaces --monorepository",
       "workspaces": "true"


### PR DESCRIPTION
- switch mariadb to use r2dbc-mysql (again) commit https://github.com/jhipster/generator-jhipster/pull/24199/commits/a768dd3c92ae99f0407ed7decce117c0cb8a40c9
- add prodDatabaseDriver to application

Fixes https://github.com/jhipster/generator-jhipster/issues/20363.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
