### PR TITLE
Improve test defaults

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -5,7 +5,6 @@ module.exports = {
   timeout: 50000,
   ui: 'bdd',
   extension: ['js', 'spec.cjs', 'spec.mjs', 'spec.ts', 'spec.mts'],
-  require: ['test/mocha.config.cjs'],
   // Resolve absolute path for test with fork and different cwd.
   // `loader` options is passed to forks, but `require` is not.
   // Use node-option instead (it overrides loader option)

--- a/generators/base-application/generator.mts
+++ b/generators/base-application/generator.mts
@@ -118,6 +118,7 @@ export default class BaseApplicationGenerator<
     });
 
     if (this.options.applicationWithEntities) {
+      this.log.warn('applicationWithEntities option is deprecated');
       // Write new definitions to memfs
       this.config.set({
         ...this.config.getAll(),

--- a/generators/base/api.d.mts
+++ b/generators/base/api.d.mts
@@ -22,6 +22,9 @@ export type JHipsterGeneratorOptions = BaseOptions & {
   /* base options */
   applicationId?: string;
   applicationWithConfig?: ApplicationWithConfig;
+  /**
+   * @deprecated
+   */
   applicationWithEntities?: any;
   creationTimestamp?: string;
   ignoreErrors?: boolean;

--- a/generators/bootstrap-application-base/generator.spec.mts
+++ b/generators/bootstrap-application-base/generator.spec.mts
@@ -56,6 +56,7 @@ describe(`generator - ${generator}`, () => {
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": []
   }
 }

--- a/generators/bootstrap-application-client/generator.spec.mts
+++ b/generators/bootstrap-application-client/generator.spec.mts
@@ -56,6 +56,7 @@ describe(`generator - ${generator}`, () => {
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": []
   }
 }

--- a/generators/bootstrap-application-server/generator.spec.mts
+++ b/generators/bootstrap-application-server/generator.spec.mts
@@ -56,6 +56,7 @@ describe(`generator - ${generator}`, () => {
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": []
   }
 }

--- a/generators/ci-cd/__snapshots__/ci-cd.spec.mts.snap
+++ b/generators/ci-cd/__snapshots__/ci-cd.spec.mts.snap
@@ -7,6 +7,7 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Gradle Angular
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -121,6 +122,7 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Gradle Angular
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -247,6 +249,7 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Maven Angular 
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -361,6 +364,7 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Maven Angular 
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -487,6 +491,7 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: autoconfigure 
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -661,6 +666,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -749,6 +755,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -826,6 +833,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -914,6 +922,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -986,6 +995,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1098,6 +1108,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1207,6 +1218,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1313,6 +1325,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1441,6 +1454,7 @@ jobs:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1549,6 +1563,7 @@ gradle-package:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1685,6 +1700,7 @@ deploy-to-production:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1805,6 +1821,7 @@ maven-package:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -1931,6 +1948,7 @@ deploy-to-production:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -2061,6 +2079,7 @@ maven-package:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -2196,6 +2215,7 @@ webapp-prod:
   "generator-jhipster": {
     "baseName": "jhipster",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "skipServer": true
   }
@@ -2213,6 +2233,7 @@ exports[`generator - CI-CD Jenkins tests Jenkins: Gradle Angular NPM should matc
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -2395,6 +2416,7 @@ exports[`generator - CI-CD Jenkins tests Jenkins: Maven Angular NPM inside Docke
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -2669,6 +2691,7 @@ exports[`generator - CI-CD Jenkins tests Jenkins: Maven Angular NPM should match
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -2854,6 +2877,7 @@ exports[`generator - CI-CD Jenkins tests Jenkins: Maven Angular NPM with full op
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -3180,6 +3204,7 @@ notifications:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -3253,6 +3278,7 @@ notifications:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }
@@ -3332,6 +3358,7 @@ notifications:
   "generator-jhipster": {
     "baseName": "sampleMysql",
     "buildTool": "maven",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": ["cypress"]
   }

--- a/generators/common/__snapshots__/generator.spec.mjs.snap
+++ b/generators/common/__snapshots__/generator.spec.mjs.snap
@@ -83,6 +83,7 @@ overrides:
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": []
   }
 }

--- a/generators/cucumber/__snapshots__/generator.spec.mts.snap
+++ b/generators/cucumber/__snapshots__/generator.spec.mts.snap
@@ -6,6 +6,7 @@ exports[`generator - cucumber with default config should match files snapshot 1`
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "testFrameworks": [
       "cucumber"

--- a/generators/entities/generator.spec.mts
+++ b/generators/entities/generator.spec.mts
@@ -40,22 +40,20 @@ describe(`generator - ${generator}`, () => {
   describe('blueprint support', () => testBlueprintSupport(generator));
 
   context('regenerating', () => {
-    const applicationWithEntities = {
-      entities: [
-        {
-          name: 'Foo',
-          changelogDate: '20160926101210',
-        },
-        {
-          name: 'Bar',
-          changelogDate: '20160926101211',
-        },
-        {
-          name: 'Skip',
-          changelogDate: '20160926101212',
-        },
-      ],
-    };
+    const entities = [
+      {
+        name: 'Foo',
+        changelogDate: '20160926101210',
+      },
+      {
+        name: 'Bar',
+        changelogDate: '20160926101211',
+      },
+      {
+        name: 'Skip',
+        changelogDate: '20160926101212',
+      },
+    ];
 
     const fooFiles = [
       `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/20160926101210_added_entity_Foo.xml`,
@@ -79,13 +77,12 @@ describe(`generator - ${generator}`, () => {
       before(async () => {
         await helpers
           .run(generatorPath)
-          .withJHipsterConfig()
+          .withJHipsterConfig({}, entities)
           .withArguments(['Foo', 'Bar'])
           .withOptions({
             regenerate: true,
             force: true,
             ignoreNeedlesError: true,
-            applicationWithEntities,
           })
           .withMockedSource();
       });
@@ -115,12 +112,11 @@ describe(`generator - ${generator}`, () => {
       before(async () => {
         await helpers
           .run(generatorPath)
-          .withJHipsterConfig()
+          .withJHipsterConfig({}, entities)
           .withOptions({
             regenerate: true,
             force: true,
             ignoreNeedlesError: true,
-            applicationWithEntities,
           })
           .withMockedSource();
       });

--- a/generators/export-jdl/__snapshots__/export-jdl.spec.mts.snap
+++ b/generators/export-jdl/__snapshots__/export-jdl.spec.mts.snap
@@ -10,6 +10,7 @@ exports[`generator - export-jdl exports entities to a JDL file with file argumen
     baseName standard
     buildTool gradle
     cacheProvider ehcache
+    creationTimestamp 1577836800000
     databaseType sql
     devDatabaseType h2Memory
     enableHibernateCache true
@@ -127,6 +128,7 @@ exports[`generator - export-jdl exports entities to a JDL file without argument 
     baseName standard
     buildTool gradle
     cacheProvider ehcache
+    creationTimestamp 1577836800000
     databaseType sql
     devDatabaseType h2Memory
     enableHibernateCache true

--- a/generators/gatling/__snapshots__/generator.spec.mts.snap
+++ b/generators/gatling/__snapshots__/generator.spec.mts.snap
@@ -6,6 +6,7 @@ exports[`generator - gatling with default config should match files snapshot 1`]
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": []
   }
 }

--- a/generators/heroku/__snapshots__/heroku.spec.mts.snap
+++ b/generators/heroku/__snapshots__/heroku.spec.mts.snap
@@ -7,6 +7,7 @@ exports[`generator - Heroku microservice application with JAR deployment should 
   "generator-jhipster": {
     "applicationType": "microservice",
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "jhipster-test",
     "herokuDeployType": "jar",
@@ -222,6 +223,7 @@ exports[`generator - Heroku monolith application in the EU should match files sn
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "jhipster-test",
     "herokuDeployType": "jar",
@@ -435,6 +437,7 @@ exports[`generator - Heroku monolith application in the US should match files sn
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "jhipster-test",
     "herokuDeployType": "jar",
@@ -703,6 +706,7 @@ exports[`generator - Heroku monolith application with Git deployment should matc
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "jhipster-test",
     "herokuDeployType": "git",
@@ -918,6 +922,7 @@ exports[`generator - Heroku monolith application with PostgreSQL should match fi
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "jhipster-test",
     "herokuDeployType": "jar",
@@ -1155,6 +1160,7 @@ exports[`generator - Heroku monolith application with an unavailable app name sh
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "random-app-name",
     "herokuDeployType": "jar",
@@ -1380,6 +1386,7 @@ exports[`generator - Heroku monolith application with elasticsearch should match
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "jhipster-test",
     "herokuDeployType": "jar",
@@ -1585,6 +1592,7 @@ exports[`generator - Heroku monolith application with existing app should match 
     "contents": "{
   "generator-jhipster": {
     "baseName": "jhipster",
+    "creationTimestamp": 1577836800000,
     "entities": [],
     "herokuAppName": "jhipster-existing",
     "herokuDeployType": "git",

--- a/generators/server/__test-support/index.mts
+++ b/generators/server/__test-support/index.mts
@@ -68,10 +68,8 @@ export const shouldComposeWithSpringCloudStream = (sampleConfig, runResultSuppli
   }
 };
 
-const shouldComposeWithDatabasetype = (databaseType, testSample, runResultSupplier) => {
+const shouldComposeWithDatabasetype = (databaseType: string, shouldCompose: boolean, runResultSupplier) => {
   const generator = databaseType;
-  const shouldCompose =
-    typeof testSample === 'boolean' ? testSample : testSample?.applicationWithEntities?.config?.databaseType === databaseType;
   if (shouldCompose) {
     it(`should compose with ${generator} generator`, () => {
       assert(runResultSupplier().mockedGenerators[`jhipster:spring-data-${generator}`].calledOnce);
@@ -83,5 +81,5 @@ const shouldComposeWithDatabasetype = (databaseType, testSample, runResultSuppli
   }
 };
 
-export const shouldComposeWithCouchbase = (testSample, runResultSupplier) =>
-  shouldComposeWithDatabasetype(COUCHBASE, testSample, runResultSupplier);
+export const shouldComposeWithCouchbase = (shouldCompose: boolean, runResultSupplier) =>
+  shouldComposeWithDatabasetype(COUCHBASE, shouldCompose, runResultSupplier);

--- a/generators/upgrade/upgrade.spec.mts
+++ b/generators/upgrade/upgrade.spec.mts
@@ -17,14 +17,14 @@ const __dirname = dirname(__filename);
 describe('generator - upgrade', function () {
   describe('default application', () => {
     before(async () => {
-      const VERSION_PLACEHOLDERS = process.env.VERSION_PLACEHOLDERS;
-      delete process.env.VERSION_PLACEHOLDERS;
-
-      await helpers.runJHipster(GENERATOR_APP).withJHipsterConfig({
-        skipClient: true,
-        skipServer: true,
-        baseName: 'upgradeTest',
-      });
+      await helpers
+        .runJHipster(GENERATOR_APP)
+        .withJHipsterConfig({
+          skipClient: true,
+          skipServer: true,
+          baseName: 'upgradeTest',
+        })
+        .withOptions({ useVersionPlaceholders: false });
       await runResult
         .create(getGenerator(GENERATOR_UPGRADE))
         .withOptions({
@@ -32,10 +32,9 @@ describe('generator - upgrade', function () {
           force: true,
           silent: false,
           targetVersion: packageJson.version,
+          useVersionPlaceholders: false,
         })
         .run();
-
-      process.env.VERSION_PLACEHOLDERS = VERSION_PLACEHOLDERS;
     });
 
     it('generated git commits to match snapshot', () => {

--- a/test/mocha.config.cjs
+++ b/test/mocha.config.cjs
@@ -1,6 +1,0 @@
-exports.mochaHooks = {
-  beforeAll() {
-    process.env.FAKE_KEYTOOL = 'true';
-    process.env.VERSION_PLACEHOLDERS = 'true';
-  },
-};

--- a/test/support/tests.mjs
+++ b/test/support/tests.mjs
@@ -294,7 +294,8 @@ export const testBlueprintSupport = (generatorName, options = {}) => {
             .filter(gen => gen !== generatorName)
             .map(gen => `jhipster:${gen}`),
         ])
-        .withOptions({ blueprint: 'foo', baseName: 'jhipster' })
+        .withJHipsterConfig()
+        .withOptions({ blueprint: 'foo' })
         .onGenerator(generator => {
           spy = addSpies(generator);
         });
@@ -316,35 +317,6 @@ export const testBlueprintSupport = (generatorName, options = {}) => {
       if (skipSbsBlueprint) {
         this.skip();
       }
-      let options = { blueprint: 'foo-sbs', baseName: 'jhipster' };
-      if (entity) {
-        options = {
-          ...options,
-          applicationWithEntities: {
-            config: {
-              skipUserManagement: true,
-            },
-            entities: [
-              {
-                name: 'One',
-                fields: [{ fieldName: 'id', fieldType: 'Long' }],
-                relationships: [{ relationshipName: 'relationship', otherEntityName: 'Two', relationshipType: 'many-to-one' }],
-              },
-              {
-                name: 'Two',
-                fields: [
-                  { fieldName: 'id', fieldType: 'Long' },
-                  { fieldName: 'name', fieldType: 'String' },
-                ],
-                relationships: [
-                  { relationshipName: 'relationship1', otherEntityName: 'One', relationshipType: 'many-to-one' },
-                  { relationshipName: 'relationship2', otherEntityName: 'Two', relationshipType: 'many-to-one' },
-                ],
-              },
-            ],
-          },
-        };
-      }
       const context = helpers
         .run(generatorPath)
         .withMockedGenerators([
@@ -354,7 +326,31 @@ export const testBlueprintSupport = (generatorName, options = {}) => {
             .filter(gen => gen !== generatorName)
             .map(gen => `jhipster:${gen}`),
         ])
-        .withOptions(options)
+        .withJHipsterConfig(
+          {},
+          entity
+            ? [
+                {
+                  name: 'One',
+                  fields: [{ fieldName: 'id', fieldType: 'Long' }],
+                  relationships: [{ relationshipName: 'relationship', otherEntityName: 'Two', relationshipType: 'many-to-one' }],
+                },
+                {
+                  name: 'Two',
+                  fields: [
+                    { fieldName: 'id', fieldType: 'Long' },
+                    { fieldName: 'name', fieldType: 'String' },
+                  ],
+                  relationships: [
+                    { relationshipName: 'relationship1', otherEntityName: 'One', relationshipType: 'many-to-one' },
+                    { relationshipName: 'relationship2', otherEntityName: 'Two', relationshipType: 'many-to-one' },
+                  ],
+                },
+              ]
+            : undefined,
+        )
+        .commitFiles()
+        .withOptions({ blueprint: 'foo-sbs' })
         .onGenerator(generator => {
           spy = addSpies(generator);
         });

--- a/testing/helpers.mts
+++ b/testing/helpers.mts
@@ -8,7 +8,7 @@ import EnvironmentBuilder from '../cli/environment-builder.mjs';
 import { JHIPSTER_CONFIG_DIR } from '../generators/generator-constants.mjs';
 import { GENERATOR_WORKSPACES } from '../generators/generator-list.mjs';
 import getGenerator from './get-generator.mjs';
-import { createJHipsterLogger, normalizePathEnd } from '../generators/base/support/index.mjs';
+import { createJHipsterLogger, normalizePathEnd, parseCreationTimestamp } from '../generators/base/support/index.mjs';
 import BaseGenerator from '../generators/base/index.mjs';
 import type { JHipsterGeneratorOptions } from '../generators/base/api.mjs';
 import { getPackageRoot, isDistFolder } from '../lib/index.mjs';
@@ -111,7 +111,9 @@ class JHipsterRunContext extends RunContext<GeneratorTestType> {
   private generateApplicationsSet = false;
 
   withJHipsterConfig(configuration?: Record<string, unknown>, entities?: BaseEntity[]): this {
-    return this.withFiles(createFiles('', { baseName: 'jhipster', ...configuration }, entities));
+    return this.withFiles(
+      createFiles('', { baseName: 'jhipster', creationTimestamp: parseCreationTimestamp('2020-01-01'), ...configuration }, entities),
+    );
   }
 
   withSkipWritingPriorities(): this {
@@ -343,7 +345,14 @@ export function createTestHelpers(options: any = {}) {
   return helper;
 }
 
-const commonTestOptions = { reproducible: true, skipChecks: true, reproducibleTests: true, noInsight: true };
+const commonTestOptions = {
+  reproducible: true,
+  skipChecks: true,
+  reproducibleTests: true,
+  noInsight: true,
+  useVersionPlaceholders: true,
+  fakeKeytool: true,
+};
 
 export const basicHelpers = createTestHelpers({ generatorOptions: { ...commonTestOptions } });
 


### PR DESCRIPTION
- add a default creationTimestamp
- pass useVersionPlaceholders and fakeKeytool using test utilities defaults instead of env variable at mocha config bootstrap.
They will be applied at blueprints too.
- deprecate applicationWithEntities option. It's mainly used by tests now and `withJHipsterConfig` can be used instead.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
