### PR TITLE
Export annotations

### DIFF
--- a/generators/app/__snapshots__/generator.spec.mts.snap
+++ b/generators/app/__snapshots__/generator.spec.mts.snap
@@ -111,7 +111,9 @@ exports[`generator - app jdlStore with application and entities should match sna
   entities Foo, Bar
 }
 
+@ChangelogDate("20200101000100")
 entity Foo
+@ChangelogDate("20200101000200")
 entity Bar
 ",
     "stateCleared": "modified",
@@ -151,7 +153,9 @@ exports[`generator - app jdlStore with incremental changelog application and ent
 {
   ".jhipster/Bar.json": {
     "contents": "{
-  "changelogDate": "20200101000200",
+  "annotations": {
+    "changelogDate": "20200101000200"
+  },
   "fields": [],
   "name": "Bar",
   "relationships": []
@@ -161,7 +165,9 @@ exports[`generator - app jdlStore with incremental changelog application and ent
   },
   ".jhipster/Foo.json": {
     "contents": "{
-  "changelogDate": "20200101000100",
+  "annotations": {
+    "changelogDate": "20200101000100"
+  },
   "fields": [],
   "name": "Foo",
   "relationships": []
@@ -191,7 +197,9 @@ exports[`generator - app jdlStore with incremental changelog application and ent
   entities Foo, Bar
 }
 
+@ChangelogDate("20200101000100")
 entity Foo
+@ChangelogDate("20200101000200")
 entity Bar
 ",
     "stateCleared": "modified",

--- a/generators/app/__snapshots__/generator.spec.mts.snap
+++ b/generators/app/__snapshots__/generator.spec.mts.snap
@@ -69,26 +69,6 @@ Options:
 
 exports[`generator - app jdlStore with application and entities should match snapshot 1`] = `
 {
-  ".jhipster/Bar.json": {
-    "contents": "{
-  "changelogDate": "20200101000200",
-  "fields": [],
-  "name": "Bar",
-  "relationships": []
-}
-",
-    "stateCleared": "modified",
-  },
-  ".jhipster/Foo.json": {
-    "contents": "{
-  "changelogDate": "20200101000100",
-  "fields": [],
-  "name": "Foo",
-  "relationships": []
-}
-",
-    "stateCleared": "modified",
-  },
   ".yo-rc.json": {
     "contents": "{
   "generator-jhipster": {

--- a/generators/base-application/generator.mts
+++ b/generators/base-application/generator.mts
@@ -174,7 +174,7 @@ export default class BaseApplicationGenerator<
    */
   getExistingEntities(): { name: string; definition: Record<string, any> }[] {
     function isBefore(e1, e2) {
-      return e1.definition.changelogDate - e2.definition.changelogDate;
+      return (e1.definition.annotations?.changelogDate ?? 0) - (e2.definition.annotations?.changelogDate ?? 0);
     }
 
     const configDir = this.getEntitiesConfigPath();

--- a/generators/base-entity-changes/generator.mts
+++ b/generators/base-entity-changes/generator.mts
@@ -74,7 +74,7 @@ export default abstract class GeneratorBaseEntityChanges extends GeneratorBaseAp
 
     const entitiesByName = Object.fromEntries(entityNames.map(entityName => [entityName, this.sharedData.getEntity(entityName)]));
     const entitiesWithExistingChangelog = entityNames.filter(
-      entityName => !this.isChangelogNew({ entityName, changelogDate: entitiesByName[entityName].changelogDate }),
+      entityName => !this.isChangelogNew({ entityName, changelogDate: entitiesByName[entityName].annotations?.changelogDate }),
     );
     const previousEntitiesByName = Object.fromEntries(
       entityNames

--- a/generators/bootstrap-application-base/generator.mts
+++ b/generators/bootstrap-application-base/generator.mts
@@ -167,10 +167,15 @@ export default class BootstrapApplicationBase extends BaseApplicationGenerator {
   get configuringEachEntity() {
     return this.asConfiguringEachEntityTaskGroup({
       configureEntity({ entityStorage, entityConfig }) {
-        entityStorage.defaults({ fields: [], relationships: [] });
+        entityStorage.defaults({ fields: [], relationships: [], annotations: {} });
 
-        if (entityConfig.changelogDate === undefined) {
-          entityConfig.changelogDate = this.dateFormatForLiquibase();
+        if (entityConfig.changelogDate) {
+          entityConfig.annotations.changelogDate = entityConfig.changelogDate;
+          delete entityConfig.changelogDate;
+        }
+        if (!entityConfig.annotations.changelogDate) {
+          entityConfig.annotations.changelogDate = this.dateFormatForLiquibase();
+          entityStorage.save();
         }
       },
 
@@ -242,8 +247,9 @@ export default class BootstrapApplicationBase extends BaseApplicationGenerator {
               throw new Error(`Fail to bootstrap '${entityName}', already exists.`);
             }
           } else {
-            const entity = entityStorage.getAll();
+            let entity = entityStorage.getAll() as any;
             entity.name = entity.name ?? entityName;
+            entity = { ...entity, ...entity.annotations };
             this.sharedData.setEntity(entityName, entity);
           }
         }

--- a/generators/bootstrap-application-base/generator.mts
+++ b/generators/bootstrap-application-base/generator.mts
@@ -85,13 +85,7 @@ export default class BootstrapApplicationBase extends BaseApplicationGenerator {
           const destinationPath = this.destinationPath();
           const jdlStorePath = this.destinationPath(this.jhipsterConfig.jdlStore);
 
-          this.features.commitTransformFactory = () =>
-            exportJDLTransform({
-              destinationPath,
-              jdlStorePath,
-              // JDL export does not support exporting annotations, keep entities config to avoid losing information.
-              keepEntitiesConfig: true,
-            });
+          this.features.commitTransformFactory = () => exportJDLTransform({ destinationPath, jdlStorePath });
           await this.pipeline({ refresh: true, pendingFiles: false }, importJDLTransform({ destinationPath, jdlStorePath }));
         }
       },

--- a/generators/bootstrap-application/generator.spec.mts
+++ b/generators/bootstrap-application/generator.spec.mts
@@ -121,6 +121,9 @@ describe(`generator - ${generator}`, () => {
 {
   ".jhipster/EntityA.json": {
     "contents": "{
+  "annotations": {
+    "changelogDate": "20220129025419"
+  },
   "changelogDate": "20220129025419",
   "fields": [
     {
@@ -136,6 +139,9 @@ describe(`generator - ${generator}`, () => {
   },
   ".jhipster/User.json": {
     "contents": "{
+  "annotations": {
+    "changelogDate": "20220129025420"
+  },
   "changelogDate": "20220129025420",
   "fields": [
     {
@@ -168,6 +174,9 @@ describe(`generator - ${generator}`, () => {
 {
   "adminUserDto": "AdminUserDTO",
   "allReferences": Any<Array>,
+  "annotations": {
+    "changelogDate": "20220129025420",
+  },
   "anyFieldHasDocumentation": false,
   "anyFieldHasFileBasedContentType": false,
   "anyFieldHasImageContentType": false,
@@ -673,6 +682,9 @@ describe(`generator - ${generator}`, () => {
           `
 {
   "allReferences": Any<Array>,
+  "annotations": {
+    "changelogDate": "20220129025419",
+  },
   "anyFieldHasDocumentation": false,
   "anyFieldHasFileBasedContentType": false,
   "anyFieldHasImageContentType": false,
@@ -966,6 +978,9 @@ describe(`generator - ${generator}`, () => {
 {
   ".jhipster/EntityA.json": {
     "contents": "{
+  "annotations": {
+    "changelogDate": "20220129025419"
+  },
   "changelogDate": "20220129025419",
   "fields": [
     {
@@ -996,6 +1011,9 @@ describe(`generator - ${generator}`, () => {
           `
 {
   "allReferences": Any<Array>,
+  "annotations": {
+    "changelogDate": "20220129025419",
+  },
   "anyFieldHasDocumentation": false,
   "anyFieldHasFileBasedContentType": false,
   "anyFieldHasImageContentType": false,

--- a/generators/export-jdl/generator.mts
+++ b/generators/export-jdl/generator.mts
@@ -62,7 +62,7 @@ export default class extends BaseGenerator {
           }
         } catch (error: unknown) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          throw new Error(`An error occurred while exporting to JDL: ${(error as any).message}\n${error}`);
+          throw new Error(`An error occurred while exporting to JDL: ${(error as any).message}\n${error}`, { cause: error });
         }
       },
     });

--- a/generators/jdl/__snapshots__/generator.spec.mts.snap
+++ b/generators/jdl/__snapshots__/generator.spec.mts.snap
@@ -4,6 +4,7 @@ exports[`generator - jdl --json-only option for two applications and entity jdl 
 {
   "jhipster/.jhipster/Foo.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster"
   ],
@@ -30,6 +31,7 @@ exports[`generator - jdl --json-only option for two applications and entity jdl 
   },
   "jhipster2/.jhipster/Bar.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster2"
   ],
@@ -77,6 +79,7 @@ exports[`generator - jdl for one application and entity jdl with --ignore-applic
 {
   ".jhipster/Foo.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster"
   ],
@@ -95,6 +98,7 @@ exports[`generator - jdl for one application and entity jdl with valid jdl shoul
 {
   ".jhipster/Foo.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster"
   ],
@@ -126,6 +130,7 @@ exports[`generator - jdl for two applications and entity jdl with --ignore-appli
 {
   "jhipster/.jhipster/Foo.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster"
   ],
@@ -139,6 +144,7 @@ exports[`generator - jdl for two applications and entity jdl with --ignore-appli
   },
   "jhipster2/.jhipster/Bar.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster2"
   ],
@@ -233,6 +239,7 @@ exports[`generator - jdl with a microservices stack generating json should gener
 {
   "gatewayApp/.jhipster/Bar.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "gatewayApp"
   ],
@@ -246,6 +253,7 @@ exports[`generator - jdl with a microservices stack generating json should gener
   },
   "gatewayApp/.jhipster/Foo.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster",
     "gatewayApp"
@@ -275,6 +283,7 @@ exports[`generator - jdl with a microservices stack generating json should gener
   },
   "jhipster/.jhipster/Foo.json": {
     "contents": "{
+  "annotations": {},
   "applications": [
     "jhipster",
     "gatewayApp"

--- a/generators/server/generator.mjs
+++ b/generators/server/generator.mjs
@@ -457,7 +457,7 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
           entityConfig.jpaMetamodelFiltering = false;
         }
       },
-      configureEntityTable({ application, entityName, entityConfig, entityStorage }) {
+      configureEntityTable({ application, entityName, entityConfig }) {
         if ((application.applicationTypeGateway && entityConfig.microserviceName) || entityConfig.skipServer) return;
 
         entityConfig.entityTableName = entityConfig.entityTableName || hibernateSnakeCase(entityName);
@@ -481,22 +481,13 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
           entityConfig.pagination = NO_PAGINATION;
         }
 
-        // Validate root entity json content
-        if (entityConfig.changelogDate === undefined) {
-          const currentDate = this.dateFormatForLiquibase();
-          if (entityStorage.existed) {
-            this.log.verboseInfo(`changelogDate is missing in .jhipster/${entityConfig.name}.json, using ${currentDate} as fallback`);
-          }
-          entityConfig.changelogDate = currentDate;
-        }
-
         if (entityConfig.incrementalChangelog === undefined) {
           // Keep entity's original incrementalChangelog option.
           entityConfig.incrementalChangelog =
             application.incrementalChangelog &&
             !existsSync(
               this.destinationPath(
-                `src/main/resources/config/liquibase/changelog/${entityConfig.changelogDate}_added_entity_${entityConfig.name}.xml`,
+                `src/main/resources/config/liquibase/changelog/${entityConfig.annotations?.changelogDate}_added_entity_${entityConfig.name}.xml`,
               ),
             );
         }

--- a/jdl/__snapshots__/jdl-importer.spec.ts.snap
+++ b/jdl/__snapshots__/jdl-importer.spec.ts.snap
@@ -26,6 +26,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
   "exportedDeployments": [],
   "exportedEntities": [
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "",
       "dto": undefined,
@@ -56,6 +57,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
       "skipServer": true,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "",
       "dto": undefined,
@@ -120,6 +122,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "The Employee entity.\\nSecond line in documentation.",
       "dto": "mapstruct",
@@ -205,6 +208,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
       "service": "serviceClass",
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "",
       "dto": undefined,
@@ -269,6 +273,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "JobHistory comment.",
       "dto": undefined,
@@ -326,6 +331,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "",
       "dto": undefined,
@@ -376,6 +382,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "",
       "dto": undefined,
@@ -397,6 +404,7 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": "",
       "dto": undefined,
@@ -686,6 +694,7 @@ exports[`jdl - JDLImporter import when parsing deployment config should export t
 exports[`jdl - JDLImporter import when passing the unidirectionalRelationships option when parsing one JDL application and entities should return the corresponding exportedApplicationsWithEntities 1`] = `
 [
   JSONEntity {
+    "annotations": {},
     "applications": [
       "jhipster",
     ],
@@ -756,6 +765,7 @@ exports[`jdl - JDLImporter import when passing the unidirectionalRelationships o
     "service": undefined,
   },
   JSONEntity {
+    "annotations": {},
     "applications": [
       "jhipster",
     ],

--- a/jdl/__test-files__/annotations.jdl
+++ b/jdl/__test-files__/annotations.jdl
@@ -9,7 +9,7 @@ entity A {
   noAnnotation String
 }
 
-@paginate(pagination)
+@pagination(pagination)
 @dto(mapstruct)
 @service(serviceClass)
 @myCustomUnaryOption
@@ -17,7 +17,7 @@ entity B
 
 @skipClient
 @filter
-@paginate(pagination)
+@pagination(pagination)
 @myCustomBinaryOption(customValue2)
 entity C
 

--- a/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-converter.ts
@@ -49,6 +49,7 @@ function createJSONEntities(jdlEntities: JDLEntity[]): Map<string, JSONEntity> {
         entityName,
         entityTableName: getTableNameFromEntityName(jdlEntity.tableName),
         documentation: formatComment(jdlEntity.comment),
+        annotations: jdlEntity.annotations,
       }),
     );
   });

--- a/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-information-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-information-converter.spec.ts
@@ -87,6 +87,7 @@ describe('jdl - JDLToJSONBasicEntityConverter', () => {
         it('should convert the entity', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [],
   "documentation": "The best entity",
   "dto": undefined,

--- a/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.spec.ts
@@ -175,6 +175,7 @@ describe('jdl - JDLWithApplicationsToJSONConverter', () => {
         it('should convert the entity', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -283,6 +284,7 @@ JSONEntity {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
   "angularJSSuffix": "suffix",
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -349,6 +351,7 @@ JSONEntity {
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -412,6 +415,7 @@ JSONEntity {
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -465,6 +469,7 @@ JSONEntity {
         it('should prevent the entities from being searched', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -522,6 +527,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -596,6 +602,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -668,6 +675,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -725,6 +733,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -837,6 +846,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -927,6 +937,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [
     "toto",
   ],
@@ -1796,6 +1807,7 @@ JSONEntity {
           jestExpect(convertedEntitiesForTataApplication).toMatchInlineSnapshot(`
 [
   JSONEntity {
+    "annotations": {},
     "applications": [
       "tata",
     ],
@@ -1813,6 +1825,7 @@ JSONEntity {
     "service": undefined,
   },
   JSONEntity {
+    "annotations": {},
     "applications": [
       "tata",
     ],
@@ -1830,6 +1843,7 @@ JSONEntity {
     "service": undefined,
   },
   JSONEntity {
+    "annotations": {},
     "applications": [
       "tata",
       "tutu",
@@ -1852,6 +1866,7 @@ JSONEntity {
           jestExpect(convertedEntitiesForTutuApplication).toMatchInlineSnapshot(`
 [
   JSONEntity {
+    "annotations": {},
     "applications": [
       "tata",
       "tutu",
@@ -1870,6 +1885,7 @@ JSONEntity {
     "service": undefined,
   },
   JSONEntity {
+    "annotations": {},
     "applications": [
       "tutu",
     ],
@@ -1887,6 +1903,7 @@ JSONEntity {
     "service": "serviceClass",
   },
   JSONEntity {
+    "annotations": {},
     "applications": [
       "tutu",
     ],

--- a/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.spec.ts
+++ b/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.spec.ts
@@ -160,6 +160,7 @@ describe('jdl - JDLWithoutApplicationToJSONConverter', () => {
         it('should convert the entity', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -263,6 +264,7 @@ JSONEntity {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
   "angularJSSuffix": "suffix",
+  "annotations": {},
   "applications": "*",
   "clientRootFolder": "../client_root_folder",
   "documentation": "The best entity",
@@ -327,6 +329,7 @@ JSONEntity {
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": "mapstruct",
@@ -385,6 +388,7 @@ JSONEntity {
         it('should set the service option to serviceClass', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -433,6 +437,7 @@ JSONEntity {
         it('should prevent the entities from being searched', () => {
           jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -485,6 +490,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -554,6 +560,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -621,6 +628,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -673,6 +681,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -780,6 +789,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,
@@ -865,6 +875,7 @@ JSONEntity {
           it('should convert them', () => {
             jestExpect(convertedEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": "*",
   "documentation": "The best entity",
   "dto": undefined,

--- a/jdl/converters/json-to-jdl-entity-converter.ts
+++ b/jdl/converters/json-to-jdl-entity-converter.ts
@@ -84,6 +84,7 @@ function convertJSONToJDLEntity(entity: Entity, entityName: string): JDLEntity {
     name: entityName,
     tableName: entity.entityTableName,
     comment: entity.documentation,
+    annotations: entity.annotations,
   });
   addFields(jdlEntity, entity);
   return jdlEntity;

--- a/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.spec.ts
@@ -51,12 +51,14 @@ describe('jdl - EntityConverter', () => {
         expect(convertedEntities).toMatchInlineSnapshot(`
 [
   JDLEntity {
+    "annotations": {},
     "comment": "/** No comment */",
     "fields": {},
     "name": "A",
     "tableName": "A",
   },
   JDLEntity {
+    "annotations": {},
     "comment": undefined,
     "fields": {},
     "name": "B",

--- a/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/entity-converter.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { lowerFirst } from 'lodash-es';
 import { JDLEntity } from '../../models/index.mjs';
 import { formatComment } from '../../utils/format-utils.js';
 
@@ -37,6 +38,12 @@ export function convertEntities(parsedEntities, jdlFieldGetterFunction): JDLEnti
       name: parsedEntity.name,
       tableName: parsedEntity.tableName || parsedEntity.name,
       comment: formatComment(parsedEntity.documentation),
+      annotations: Object.fromEntries(
+        parsedEntity.annotations?.map(annotation => [
+          lowerFirst(annotation.optionName),
+          annotation.type === 'UNARY' ? true : annotation.optionValue,
+        ]) ?? [],
+      ),
     });
     const jdlFields = jdlFieldGetterFunction.call(undefined, parsedEntity);
     jdlEntity.addFields(jdlFields);

--- a/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.spec.ts
@@ -728,14 +728,9 @@ JDLDeployment {
       });
       context('when parsing entities with annotations', () => {
         context('that are not capitalized', () => {
-          let dtoOption;
-          let filterOption;
-          let paginationOption;
-          let serviceOption;
-          let skipClientOption;
-          let customUnaryOption;
-          let customBinaryOption;
-          let customBinaryOption2;
+          let entityA;
+          let entityB;
+          let entityC;
           let fieldAnnotation;
           let relationshipAnnotationOnSource;
           let relationshipAnnotationOnDestination;
@@ -746,30 +741,40 @@ JDLDeployment {
               parsedContent: input,
               applicationType: MONOLITH,
             });
-            dtoOption = jdlObject.getOptionsForName(binaryOptions.Options.DTO)[0];
-            filterOption = jdlObject.getOptionsForName(unaryOptions.FILTER)[0];
-            paginationOption = jdlObject.getOptionsForName(binaryOptions.Options.PAGINATION)[0];
-            serviceOption = jdlObject.getOptionsForName(binaryOptions.Options.SERVICE)[0];
-            skipClientOption = jdlObject.getOptionsForName(unaryOptions.SKIP_CLIENT)[0];
-            customUnaryOption = jdlObject.getOptionsForName('myCustomUnaryOption')[0];
-            customBinaryOption = jdlObject.getOptionsForName('myCustomBinaryOption')[0];
-            customBinaryOption2 = jdlObject.getOptionsForName('myCustomBinaryOption')[1];
+            entityA = jdlObject.entities.A;
+            entityB = jdlObject.entities.B;
+            entityC = jdlObject.entities.C;
             fieldAnnotation = jdlObject.entities.A.fields.name.options.id;
             relationshipAnnotationOnSource = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.source;
             relationshipAnnotationOnDestination = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.destination;
           });
 
           it('should set the annotations as options', () => {
-            expect(dtoOption.entityNames).to.deep.equal(new Set(['A', 'B']));
-            expect(filterOption.entityNames).to.deep.equal(new Set(['C']));
-            expect(paginationOption.entityNames).to.deep.equal(new Set(['B', 'C']));
-            expect(serviceOption.entityNames).to.deep.equal(new Set(['A', 'B']));
-            expect(skipClientOption.entityNames).to.deep.equal(new Set(['A', 'C']));
-            expect(customUnaryOption.entityNames).to.deep.equal(new Set(['A', 'B']));
-            expect(customBinaryOption.entityNames).to.deep.equal(new Set(['A']));
-            expect(customBinaryOption2.entityNames).to.deep.equal(new Set(['C']));
-            expect(customBinaryOption.value).to.deep.equal('customValue');
-            expect(customBinaryOption2.value).to.deep.equal('customValue2');
+            jestExpect(entityA.annotations).toMatchInlineSnapshot(`
+{
+  "dto": "mapstruct",
+  "myCustomBinaryOption": "customValue",
+  "myCustomUnaryOption": true,
+  "service": "serviceClass",
+  "skipClient": true,
+}
+`);
+            jestExpect(entityB.annotations).toMatchInlineSnapshot(`
+{
+  "dto": "mapstruct",
+  "myCustomUnaryOption": true,
+  "pagination": "pagination",
+  "service": "serviceClass",
+}
+`);
+            jestExpect(entityC.annotations).toMatchInlineSnapshot(`
+{
+  "filter": true,
+  "myCustomBinaryOption": "customValue2",
+  "pagination": "pagination",
+  "skipClient": true,
+}
+`);
             expect(fieldAnnotation).to.deep.equal(true);
             jestExpect(relationshipAnnotationOnSource).toMatchInlineSnapshot(`
 {
@@ -784,14 +789,9 @@ JDLDeployment {
           });
         });
         context('that are capitalized', () => {
-          let dtoOption;
-          let filterOption;
-          let paginationOption;
-          let serviceOption;
-          let skipClientOption;
-          let customUnaryOption;
-          let customBinaryOption;
-          let customBinaryOption2;
+          let entityA;
+          let entityB;
+          let entityC;
           let fieldAnnotation;
           let relationshipAnnotationOnSource;
           let relationshipAnnotationOnDestination;
@@ -802,30 +802,40 @@ JDLDeployment {
               parsedContent: input,
               applicationType: MONOLITH,
             });
-            dtoOption = jdlObject.getOptionsForName(binaryOptions.Options.DTO)[0];
-            filterOption = jdlObject.getOptionsForName(unaryOptions.FILTER)[0];
-            paginationOption = jdlObject.getOptionsForName(binaryOptions.Options.PAGINATION)[0];
-            serviceOption = jdlObject.getOptionsForName(binaryOptions.Options.SERVICE)[0];
-            skipClientOption = jdlObject.getOptionsForName(unaryOptions.SKIP_CLIENT)[0];
-            customUnaryOption = jdlObject.getOptionsForName('myCustomUnaryOption')[0];
-            customBinaryOption = jdlObject.getOptionsForName('myCustomBinaryOption')[0];
-            customBinaryOption2 = jdlObject.getOptionsForName('myCustomBinaryOption')[1];
+            entityA = jdlObject.entities.A;
+            entityB = jdlObject.entities.B;
+            entityC = jdlObject.entities.C;
             fieldAnnotation = jdlObject.entities.A.fields.name.options.id;
             relationshipAnnotationOnSource = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.source;
             relationshipAnnotationOnDestination = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.destination;
           });
 
           it('should set the annotations as options with lower-case letters first', () => {
-            expect(dtoOption.entityNames).to.deep.equal(new Set(['A', 'B']));
-            expect(filterOption.entityNames).to.deep.equal(new Set(['C']));
-            expect(paginationOption.entityNames).to.deep.equal(new Set(['B', 'C']));
-            expect(serviceOption.entityNames).to.deep.equal(new Set(['A', 'B']));
-            expect(skipClientOption.entityNames).to.deep.equal(new Set(['A', 'C']));
-            expect(customUnaryOption.entityNames).to.deep.equal(new Set(['A', 'B']));
-            expect(customBinaryOption.entityNames).to.deep.equal(new Set(['A']));
-            expect(customBinaryOption2.entityNames).to.deep.equal(new Set(['C']));
-            expect(customBinaryOption.value).to.deep.equal('customValue');
-            expect(customBinaryOption2.value).to.deep.equal('customValue2');
+            jestExpect(entityA.annotations).toMatchInlineSnapshot(`
+{
+  "dto": "mapstruct",
+  "myCustomBinaryOption": "customValue",
+  "myCustomUnaryOption": true,
+  "service": "serviceClass",
+  "skipClient": true,
+}
+`);
+            jestExpect(entityB.annotations).toMatchInlineSnapshot(`
+{
+  "dto": "mapstruct",
+  "myCustomUnaryOption": true,
+  "paginate": "pagination",
+  "service": "serviceClass",
+}
+`);
+            jestExpect(entityC.annotations).toMatchInlineSnapshot(`
+{
+  "filter": true,
+  "myCustomBinaryOption": "customValue2",
+  "paginate": "pagination",
+  "skipClient": true,
+}
+`);
             expect(fieldAnnotation).to.deep.equal(true);
             jestExpect(relationshipAnnotationOnSource).toMatchInlineSnapshot(`
 {
@@ -841,14 +851,9 @@ JDLDeployment {
         });
       });
       context('when parsing a mix between annotations and regular options', () => {
-        let dtoOptions;
-        let filterOptions;
-        let paginationOptions;
-        let serviceOptions;
-        let skipClientOptions;
-        let skipServerOptions;
-        let readOnlyOptions;
-        let embeddedOptions;
+        let entityA;
+        let entityB;
+        let entityC;
 
         before(() => {
           const input = JDLReader.parseFromFiles([path.join(__dirname, '..', '..', '__test-files__', 'annotations_and_options.jdl')]);
@@ -856,41 +861,39 @@ JDLDeployment {
             parsedContent: input,
             applicationType: MONOLITH,
           });
-          dtoOptions = jdlObject.getOptionsForName(binaryOptions.Options.DTO);
-          filterOptions = jdlObject.getOptionsForName(unaryOptions.FILTER);
-          paginationOptions = jdlObject.getOptionsForName(binaryOptions.Options.PAGINATION);
-          serviceOptions = jdlObject.getOptionsForName(binaryOptions.Options.SERVICE);
-          skipClientOptions = jdlObject.getOptionsForName(unaryOptions.SKIP_CLIENT);
-          skipServerOptions = jdlObject.getOptionsForName(unaryOptions.SKIP_SERVER);
-          readOnlyOptions = jdlObject.getOptionsForName(unaryOptions.READ_ONLY);
-          embeddedOptions = jdlObject.getOptionsForName(unaryOptions.EMBEDDED);
+          entityA = jdlObject.entities.A;
+          entityB = jdlObject.entities.B;
+          entityC = jdlObject.entities.C;
         });
 
         it('correctly should set the options', () => {
-          expect(dtoOptions).to.have.length(1);
-          expect(dtoOptions[0].entityNames).to.deep.equal(new Set(['A', 'B']));
-
-          expect(filterOptions).to.have.length(1);
-          expect(filterOptions[0].entityNames).to.deep.equal(new Set(['C']));
-
-          expect(paginationOptions).to.have.length(1);
-          expect(paginationOptions[0].entityNames).to.deep.equal(new Set(['B', 'C']));
-
-          expect(serviceOptions).to.have.length(2);
-          expect(serviceOptions[0].entityNames).to.deep.equal(new Set(['A', 'B']));
-          expect(serviceOptions[1].entityNames).to.deep.equal(new Set(['A']));
-
-          expect(skipClientOptions).to.have.length(1);
-          expect(skipClientOptions[0].entityNames).to.deep.equal(new Set(['A', 'C']));
-
-          expect(skipServerOptions).to.have.length(1);
-          expect(skipServerOptions[0].entityNames).to.deep.equal(new Set(['A']));
-
-          expect(readOnlyOptions).to.have.length(1);
-          expect(readOnlyOptions[0].entityNames).to.deep.equal(new Set(['A', 'C']));
-
-          expect(embeddedOptions).to.have.length(1);
-          expect(embeddedOptions[0].entityNames).to.deep.equal(new Set(['B', 'C']));
+          it('should set the annotations as options with lower-case letters first', () => {
+            jestExpect(entityA.annotations).toMatchInlineSnapshot(`
+{
+  "dto": "mapstruct",
+  "myCustomBinaryOption": "customValue",
+  "myCustomUnaryOption": true,
+  "service": "serviceClass",
+  "skipClient": true,
+}
+`);
+            jestExpect(entityB.annotations).toMatchInlineSnapshot(`
+{
+  "dto": "mapstruct",
+  "myCustomUnaryOption": true,
+  "paginate": "pagination",
+  "service": "serviceClass",
+}
+`);
+            jestExpect(entityC.annotations).toMatchInlineSnapshot(`
+{
+  "filter": true,
+  "myCustomBinaryOption": "customValue2",
+  "paginate": "pagination",
+  "skipClient": true,
+}
+`);
+          });
         });
       });
       context('when having a pattern validation with a quote in it', () => {

--- a/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.ts
@@ -18,7 +18,6 @@
  */
 import * as _ from 'lodash-es';
 import JDLObject from '../../models/jdl-object.js';
-import JDLUnaryOption from '../../models/jdl-unary-option.js';
 import JDLBinaryOption from '../../models/jdl-binary-option.js';
 import { applicationTypes, binaryOptions } from '../../jhipster/index.mjs';
 
@@ -106,7 +105,6 @@ function fillClassesAndFields() {
   jdlEntities.forEach(jdlEntity => {
     jdlObject.addEntity(jdlEntity);
   });
-  addOptionsFromEntityAnnotations();
 }
 
 function getJDLFieldsFromParsedEntity(entity) {
@@ -119,35 +117,6 @@ function getJDLFieldsFromParsedEntity(entity) {
     fields.push(jdlField);
   }
   return fields;
-}
-
-function addOptionsFromEntityAnnotations() {
-  parsedContent.entities.forEach(entity => {
-    const entityName = entity.name;
-    const annotations = entity.annotations;
-    annotations.forEach(annotation => {
-      let annotationName = _.lowerFirst(annotation.optionName);
-      if (annotation.type === 'UNARY') {
-        jdlObject.addOption(
-          new JDLUnaryOption({
-            name: annotationName,
-            entityNames: [entityName],
-          }),
-        );
-      } else if (annotation.type === 'BINARY') {
-        if (annotationName === 'paginate') {
-          annotationName = binaryOptions.Options.PAGINATION;
-        }
-        jdlObject.addOption(
-          new JDLBinaryOption({
-            name: annotationName,
-            value: annotation.optionValue,
-            entityNames: [entityName],
-          }),
-        );
-      }
-    });
-  });
 }
 
 function getValidations(field) {

--- a/jdl/exporters/jhipster-entity-exporter.ts
+++ b/jdl/exporters/jhipster-entity-exporter.ts
@@ -70,8 +70,9 @@ function updateEntities(subFolder) {
 function updateEntityToGenerateWithExistingOne(filePath, entity) {
   if (doesFileExist(filePath)) {
     const fileOnDisk = readJSONFile(filePath);
-    if (fileOnDisk && fileOnDisk.changelogDate) {
-      entity.changelogDate = fileOnDisk.changelogDate;
+    if (!entity.annotations?.changelogDate && fileOnDisk?.annotations?.changelogDate) {
+      entity.annotations = entity.annotations || {};
+      entity.annotations.changelogDate = fileOnDisk.annotations.changelogDate;
       return { ...fileOnDisk, ...entity };
     }
   }

--- a/jdl/integration-test.spec.ts
+++ b/jdl/integration-test.spec.ts
@@ -66,53 +66,61 @@ describe('jdl - integration tests', () => {
 
     context('with annotations', () => {
       let result: Map<any, any[]>;
-      const jdl = `
-@BooleanTrue(true)
+      let convertedJdl: string;
+      const jdl = `@BooleanTrue(true)
 @BooleanFalse(false)
 @Integer(1)
 @Decimal(10.1)
 @Escaped("a.b")
 @String(foo)
 @Unary
-entity A {}
+entity A
 `;
+      const expectedJdl = jdl.replace('(true)', '').replace('(foo)', '("foo")');
 
       beforeEach(() => {
+        const jdlObject = DocumentParser.parseFromConfigurationObject({
+          parsedContent: parseFromContent(jdl),
+          applicationType: MONOLITH,
+        });
         result = convertWithoutApplication({
           applicationName,
           databaseType: 'sql',
-          jdlObject: DocumentParser.parseFromConfigurationObject({
-            parsedContent: parseFromContent(jdl),
-            applicationType: MONOLITH,
-          }),
+          jdlObject,
         });
+        convertedJdl = jdlObject.toString();
       });
 
+      it('stringfied JDL should match original jdl', () => {
+        jestExpect(convertedJdl).toEqual(expectedJdl);
+      });
       it('should result matching', () => {
         jestExpect(result).toMatchInlineSnapshot(`
 Map {
   "jhipster" => [
     JSONEntity {
+      "annotations": {
+        "booleanFalse": false,
+        "booleanTrue": true,
+        "decimal": 10.1,
+        "escaped": "a.b",
+        "integer": 1,
+        "string": "foo",
+        "unary": true,
+      },
       "applications": "*",
-      "booleanFalse": false,
-      "booleanTrue": true,
-      "decimal": 10.1,
       "documentation": undefined,
       "dto": undefined,
       "embedded": undefined,
       "entityTableName": "a",
-      "escaped": "a.b",
       "fields": [],
       "fluentMethods": undefined,
-      "integer": 1,
       "jpaMetamodelFiltering": undefined,
       "name": "A",
       "pagination": undefined,
       "readOnly": undefined,
       "relationships": [],
       "service": undefined,
-      "string": "foo",
-      "unary": true,
     },
   ],
 }
@@ -151,6 +159,7 @@ relationship ManyToOne {
 Map {
   "jhipster" => [
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": undefined,
       "dto": undefined,
@@ -174,6 +183,7 @@ Map {
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": undefined,
       "dto": undefined,
@@ -204,23 +214,29 @@ Map {
 
     context('with unidirectional relationship and annotation at destination', () => {
       let result: Map<any, any[]>;
-      const jdl = `
-entity A {}
-entity B {}
+      let convertedJdl: string;
+      const jdl = `entity A
+entity B
 relationship ManyToOne {
   A{b} to @AnnotationAtASide B
 }
 `;
 
       beforeEach(() => {
+        const jdlObject = DocumentParser.parseFromConfigurationObject({
+          parsedContent: parseFromContent(jdl),
+          applicationType: MONOLITH,
+        });
         result = convertWithoutApplication({
           applicationName,
           databaseType: 'sql',
-          jdlObject: DocumentParser.parseFromConfigurationObject({
-            parsedContent: parseFromContent(jdl),
-            applicationType: MONOLITH,
-          }),
+          jdlObject,
         });
+        convertedJdl = jdlObject.toString();
+      });
+
+      it('convert back to jdl', () => {
+        jestExpect(convertedJdl).toBe(jdl);
       });
 
       it('should add relationship at one side', () => {
@@ -233,6 +249,7 @@ relationship ManyToOne {
 Map {
   "jhipster" => [
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": undefined,
       "dto": undefined,
@@ -258,6 +275,7 @@ Map {
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": undefined,
       "dto": undefined,
@@ -309,6 +327,7 @@ relationship ManyToOne {
 Map {
   "jhipster" => [
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": undefined,
       "dto": undefined,
@@ -334,6 +353,7 @@ Map {
       "service": undefined,
     },
     JSONEntity {
+      "annotations": {},
       "applications": "*",
       "documentation": undefined,
       "dto": undefined,

--- a/jdl/jdl-importer.spec.ts
+++ b/jdl/jdl-importer.spec.ts
@@ -302,18 +302,18 @@ relationship OneToOne {
       });
 
       it('sets the options', () => {
-        expect(returned.exportedEntities[0].service).to.equal('serviceClass');
-        expect(returned.exportedEntities[0].dto).to.equal('mapstruct');
-        expect(returned.exportedEntities[0].skipClient).to.be.true;
-        expect(returned.exportedEntities[0].myCustomUnaryOption).to.be.true;
-        expect(returned.exportedEntities[0].myCustomBinaryOption).to.equal('customValue');
-        expect(returned.exportedEntities[1].pagination).to.equal('pagination');
-        expect(returned.exportedEntities[1].dto).to.equal('mapstruct');
-        expect(returned.exportedEntities[1].service).to.equal('serviceClass');
-        expect(returned.exportedEntities[2].skipClient).to.be.true;
-        expect(returned.exportedEntities[2].jpaMetamodelFiltering).to.be.true;
-        expect(returned.exportedEntities[2].pagination).to.equal('pagination');
-        expect(returned.exportedEntities[2].myCustomBinaryOption).to.equal('customValue2');
+        expect(returned.exportedEntities[0].annotations.service).to.equal('serviceClass');
+        expect(returned.exportedEntities[0].annotations.dto).to.equal('mapstruct');
+        expect(returned.exportedEntities[0].annotations.skipClient).to.be.true;
+        expect(returned.exportedEntities[0].annotations.myCustomUnaryOption).to.be.true;
+        expect(returned.exportedEntities[0].annotations.myCustomBinaryOption).to.equal('customValue');
+        expect(returned.exportedEntities[1].annotations.pagination).to.equal('pagination');
+        expect(returned.exportedEntities[1].annotations.dto).to.equal('mapstruct');
+        expect(returned.exportedEntities[1].annotations.service).to.equal('serviceClass');
+        expect(returned.exportedEntities[2].annotations.skipClient).to.be.true;
+        expect(returned.exportedEntities[2].annotations.filter).to.be.true;
+        expect(returned.exportedEntities[2].annotations.pagination).to.equal('pagination');
+        expect(returned.exportedEntities[2].annotations.myCustomBinaryOption).to.equal('customValue2');
         expect(returned.exportedEntities[0].fields[0].options.id).to.be.true;
         expect(returned.exportedEntities[0].fields[0].options.multiValue).to.deep.equal(['value1', 'value2', 'value3']);
       });

--- a/jdl/jhipster/json-entity.spec.ts
+++ b/jdl/jhipster/json-entity.spec.ts
@@ -51,6 +51,7 @@ describe('jdl - JSONEntity', () => {
       it('should set default values', () => {
         jestExpect(entity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [],
   "documentation": undefined,
   "dto": undefined,
@@ -98,6 +99,7 @@ JSONEntity {
         jestExpect(entity).toMatchInlineSnapshot(`
 JSONEntity {
   "angularJSSuffix": "yes",
+  "annotations": {},
   "applications": [],
   "clientRootFolder": "oh",
   "documentation": "",
@@ -273,6 +275,7 @@ JSONEntity {
       it('should set them', () => {
         jestExpect(jsonEntity).toMatchInlineSnapshot(`
 JSONEntity {
+  "annotations": {},
   "applications": [],
   "documentation": "A comment",
   "dto": "mapstruct",

--- a/jdl/jhipster/json-entity.ts
+++ b/jdl/jhipster/json-entity.ts
@@ -24,6 +24,7 @@ import { upperFirst } from '../utils/string-utils.js';
  * The JSONEntity class represents a read-to-be exported to JSON entity.
  */
 class JSONEntity {
+  annotations: Record<string, boolean | string | number>;
   [x: string]: any;
 
   /**
@@ -50,6 +51,7 @@ class JSONEntity {
     const merged = merge(getDefaults(args.entityName), args);
     this.name = merged.name;
     this.fields = merged.fields;
+    this.annotations = merged.annotations;
     this.relationships = merged.relationships;
     this.documentation = merged.documentation;
     this.entityTableName = merged.entityTableName;
@@ -109,6 +111,10 @@ class JSONEntity {
       this[optionName] = options[optionName];
     });
   }
+
+  setAnnotations(annotations = {}) {
+    Object.assign(this.annotations, annotations);
+  }
 }
 
 export default JSONEntity;
@@ -119,5 +125,6 @@ function getDefaults(entityName) {
     fields: [],
     relationships: [],
     applications: [],
+    annotations: {},
   };
 }

--- a/jdl/models/jdl-entity.ts
+++ b/jdl/models/jdl-entity.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { upperFirst } from 'lodash-es';
 import { merge } from '../utils/object-utils.js';
 import getTableNameFromEntityName from '../jhipster/entity-table-name-creator.js';
 import JDLField from './jdl-field.js';
@@ -26,6 +27,7 @@ export default class JDLEntity {
   tableName: any;
   fields: Record<string, JDLField>;
   comment: any;
+  annotations: Record<string, boolean | string | number>;
 
   constructor(args) {
     const merged = merge(defaults(), args);
@@ -36,6 +38,7 @@ export default class JDLEntity {
     this.tableName = merged.tableName || merged.name;
     this.fields = merged.fields;
     this.comment = merged.comment;
+    this.annotations = merged.annotations ?? {};
   }
 
   /**
@@ -68,6 +71,16 @@ export default class JDLEntity {
         .map(line => ` * ${line}\n`)
         .join('')} */\n`;
     }
+    Object.entries(this.annotations).forEach(([key, value]) => {
+      key = upperFirst(key);
+      if (value === true) {
+        stringifiedEntity += `@${key}\n`;
+      } else if (typeof value === 'string') {
+        stringifiedEntity += `@${key}("${value}")\n`;
+      } else {
+        stringifiedEntity += `@${key}(${value})\n`;
+      }
+    });
     stringifiedEntity += `entity ${this.name}`;
     if (this.tableName && getTableNameFromEntityName(this.name) !== getTableNameFromEntityName(this.tableName)) {
       stringifiedEntity += ` (${this.tableName})`;
@@ -82,7 +95,7 @@ export default class JDLEntity {
 function defaults() {
   return {
     fields: {},
-    options: [],
+    annotations: {},
   };
 }
 

--- a/jdl/models/jdl-field.ts
+++ b/jdl/models/jdl-field.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { upperFirst } from 'lodash-es';
 import { merge } from '../utils/object-utils.js';
 
 export default class JDLField {
@@ -75,6 +76,16 @@ export default class JDLField {
         .map(line => ` * ${line}\n`)
         .join('')} */\n`;
     }
+    Object.entries(this.options ?? {}).forEach(([key, value]) => {
+      key = upperFirst(key);
+      if (value === true) {
+        string += `@${key}\n`;
+      } else if (typeof value === 'string') {
+        string += `@${key}("${value}")\n`;
+      } else {
+        string += `@${key}(${value})\n`;
+      }
+    });
     string += `${this.name} ${this.type}`;
     Object.keys(this.validations).forEach(validationName => {
       string += ` ${this.validations[validationName].toString()}`;

--- a/jdl/models/jdl-object.spec.ts
+++ b/jdl/models/jdl-object.spec.ts
@@ -332,6 +332,7 @@ describe('jdl - JDLObject', () => {
         jestExpect(returnedEntities).toMatchInlineSnapshot(`
 [
   JDLEntity {
+    "annotations": {},
     "comment": undefined,
     "fields": {},
     "name": "toto",

--- a/jdl/models/jdl-object.ts
+++ b/jdl/models/jdl-object.ts
@@ -265,10 +265,10 @@ export default class JDLObject {
       string += `${this.enums.toString()}\n`;
     }
     if (this.getRelationshipQuantity() !== 0) {
-      string += `${relationshipsToString(this.relationships)}\n`;
+      string += `${relationshipsToString(this.relationships)}`;
     }
     if (this.getOptionQuantity() !== 0) {
-      string += `${optionsToString(this.options)}`;
+      string += `\n${optionsToString(this.options)}`;
     }
     return string;
   }
@@ -303,7 +303,7 @@ function relationshipsToString(relationships) {
   if (string === '') {
     return '';
   }
-  return `${relationships.toString()}\n`;
+  return `${string}\n`;
 }
 function optionsToString(options) {
   const string = options.toString();

--- a/jdl/models/jdl-relationship.spec.ts
+++ b/jdl/models/jdl-relationship.spec.ts
@@ -398,11 +398,7 @@ describe('jdl - JDLRelationship', () => {
         it('should add them', () => {
           expect(relationship.toString()).to.equal(
             `relationship ${relationship.type} {
-  @id
-  ${relationship.from}{${relationship.injectedFieldInFrom}} to
-  @id
-  @idGenerator(sequence)
-  ${relationship.to}{${relationship.injectedFieldInTo}} with ${BUILT_IN_ENTITY}
+  @Id ${relationship.from}{${relationship.injectedFieldInFrom}} to @Id @IdGenerator(sequence) ${relationship.to}{${relationship.injectedFieldInTo}} with ${BUILT_IN_ENTITY}
 }`,
           );
         });

--- a/jdl/models/jdl-relationship.ts
+++ b/jdl/models/jdl-relationship.ts
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { upperFirst } from 'lodash-es';
 import { RelationshipSide, JDLRelationshipType } from '../basic-types/relationships.js';
 import { Validations } from '../jhipster/index.mjs';
 import { relationshipTypeExists } from '../jhipster/relationship-types.js';
@@ -118,9 +119,9 @@ export default class JDLRelationship implements JDLRelationshipModel {
     if (Object.keys(sourceOptions).length !== 0) {
       Object.keys(sourceOptions).forEach(name => {
         const value = sourceOptions[name];
-        string += `  @${name}${value != null && sourceOptions[name] !== true ? `(${value})` : ''}\n`;
+        name = upperFirst(name);
+        string += `@${name}${value != null && value !== true ? `(${value}) ` : ' '}`;
       });
-      string += '  ';
     }
     string += `${this.from}`;
     if (this.injectedFieldInFrom) {
@@ -137,12 +138,11 @@ export default class JDLRelationship implements JDLRelationshipModel {
     }
     const destinationOptions = this.options.destination;
     if (Object.keys(destinationOptions).length !== 0) {
-      string += '\n';
       Object.keys(destinationOptions).forEach(name => {
         const value = destinationOptions[name];
-        string += `  @${name}${value != null && destinationOptions[name] !== true ? `(${value})` : ''}\n`;
+        name = upperFirst(name);
+        string += `@${name}${value != null && value !== true ? `(${value}) ` : ' '}`;
       });
-      string += '  ';
     }
     string += `${this.to}`;
     if (this.injectedFieldInTo) {


### PR DESCRIPTION
- move annotations a separate object to don’t mixup with other fields.
- move changelogDate to that annotation object

Maybe changelogDate should be kept at root and exported like an annotation as an exception.

Fixes https://github.com/jhipster/generator-jhipster/issues/24262
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
