### PR TITLE
ignore most CI workflows at every non main/maintenance branch

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -24,10 +24,9 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
-      - 'revert-*'
+    branches:
+      - 'main'
+      - '**maintenance'
     paths-ignore:
       - 'package*.json'
       - 'generators/react/**'

--- a/.github/workflows/devserver.yml
+++ b/.github/workflows/devserver.yml
@@ -24,9 +24,9 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+    branches:
+      - 'main'
+      - '**maintenance'
     paths:
       - 'generators/*client/**'
   pull_request:

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -24,9 +24,9 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
+    branches:
+      - 'main'
+      - '**maintenance'
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -24,10 +24,9 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
-      - 'revert-*'
+    branches:
+      - 'main'
+      - '**maintenance'
     paths-ignore:
       - 'package*.json'
       - 'generators/angular/**'

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -24,10 +24,9 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'skip_ci*'
-      - 'revert-*'
+    branches:
+      - 'main'
+      - '**maintenance'
     paths-ignore:
       - 'package*.json'
       - 'generators/angular/**'


### PR DESCRIPTION
We always create PR for others branches, CI on push are not useful for us.
Enable most CI workflow only for 
- main
- **maintenance
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
