### PR TITLE
[Fix] Option "browserTarget" is deprecated: Use 'buildTarget' instead.

### DIFF
--- a/generators/angular/templates/angular.json.ejs
+++ b/generators/angular/templates/angular.json.ejs
@@ -102,15 +102,15 @@
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "browserTarget": "<%= dasherizedBaseName %>:build:development",
+            "buildTarget": "<%= dasherizedBaseName %>:build:development",
             "port": <%= devServerPort %>
           },
           "configurations": {
             "production": {
-              "browserTarget": "<%= dasherizedBaseName %>:build:production"
+              "buildTarget": "<%= dasherizedBaseName %>:build:production"
             },
             "development": {
-              "browserTarget": "<%= dasherizedBaseName %>:build:development"
+              "buildTarget": "<%= dasherizedBaseName %>:build:development"
             }
           },
           "defaultConfiguration": "development"


### PR DESCRIPTION
Fixes deprecating warning when using `npm start` with Angular.

```
$ npm start

> blog@0.0.1-SNAPSHOT start
> ng serve --hmr

Option "browserTarget" is deprecated: Use 'buildTarget' instead.
NOTICE: Hot Module Replacement (HMR) is enabled for the dev server.
```

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
