### PR TITLE
make auth0 issuer uris configurable

### DIFF
--- a/generators/server/templates/README.md.jhi.spring-boot.ejs
+++ b/generators/server/templates/README.md.jhi.spring-boot.ejs
@@ -198,6 +198,9 @@ jhipster:
     oauth2:
       audience:
         - https://{your-auth0-domain}/api/v2/
+      auth0-issuer-uris:
+        - auth0.com
+        - {your-auth0-domain}
 ```
   <%_ if (cypressTests) { _%>
 

--- a/generators/server/templates/src/main/java/_package_/web/rest/LogoutResource_imperative.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/web/rest/LogoutResource_imperative.java.ejs
@@ -18,6 +18,7 @@
 -%>
 package <%= packageName %>.web.rest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -28,15 +29,18 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 import java.util.Map;
+import tech.jhipster.config.JHipsterProperties;
 
 /**
  * REST controller for managing global OIDC logout.
  */
 @RestController
 public class LogoutResource {
+    private final JHipsterProperties jhipsterProperties;
     private final ClientRegistration registration;
 
-    public LogoutResource(ClientRegistrationRepository registrations) {
+    public LogoutResource(JHipsterProperties jhipsterProperties, ClientRegistrationRepository registrations) {
+        this.jhipsterProperties = jhipsterProperties;
         this.registration = registrations.findByRegistrationId("oidc");
     }
 
@@ -53,7 +57,7 @@ public class LogoutResource {
         StringBuilder logoutUrl = new StringBuilder();
 
         String issuerUri = this.registration.getProviderDetails().getIssuerUri();
-        if (issuerUri.contains("auth0.com")) {
+        if (StringUtils.containsAny(issuerUri, jhipsterProperties.getSecurity().getOauth2().getAuth0IssuerUris().toArray(new String[]{}))) {
             logoutUrl.append(issuerUri.endsWith("/") ? issuerUri + "v2/logout" : issuerUri + "/v2/logout");
         } else {
             logoutUrl.append(this.registration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString());
@@ -61,7 +65,7 @@ public class LogoutResource {
 
         String originUrl = request.getHeader(HttpHeaders.ORIGIN);
 
-        if (issuerUri.contains("auth0.com")) {
+        if (StringUtils.containsAny(issuerUri, jhipsterProperties.getSecurity().getOauth2().getAuth0IssuerUris().toArray(new String[]{}))) {
             logoutUrl.append("?client_id=").append(this.registration.getClientId()).append("&returnTo=").append(originUrl);
         } else {
             logoutUrl.append("?id_token_hint=").append(idToken.getTokenValue()).append("&post_logout_redirect_uri=").append(originUrl);

--- a/generators/server/templates/src/main/java/_package_/web/rest/LogoutResource_reactive.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/web/rest/LogoutResource_reactive.java.ejs
@@ -18,6 +18,7 @@
 -%>
 package <%= packageName %>.web.rest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
@@ -28,15 +29,18 @@ import org.springframework.web.server.WebSession;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.core.publisher.Mono;
 import java.util.Map;
+import tech.jhipster.config.JHipsterProperties;
 
 /**
  * REST controller for managing global OIDC logout.
  */
 @RestController
 public class LogoutResource {
+    private final JHipsterProperties jhipsterProperties;
     private final Mono<ClientRegistration> registration;
 
-    public LogoutResource(ReactiveClientRegistrationRepository registrations) {
+    public LogoutResource(JHipsterProperties jhipsterProperties, ReactiveClientRegistrationRepository registrations) {
+        this.jhipsterProperties = jhipsterProperties;
         this.registration = registrations.findByRegistrationId("oidc");
     }
 
@@ -60,14 +64,14 @@ public class LogoutResource {
     private Map<String, String> prepareLogoutUri(ServerHttpRequest request, ClientRegistration clientRegistration, OidcIdToken idToken) {
         StringBuilder logoutUrl = new StringBuilder();
         String issuerUri = clientRegistration.getProviderDetails().getIssuerUri();
-        if (issuerUri.contains("auth0.com")) {
+        if (StringUtils.containsAny(issuerUri, jhipsterProperties.getSecurity().getOauth2().getAuth0IssuerUris().toArray(new String[]{}))) {
             logoutUrl.append(issuerUri.endsWith("/") ? issuerUri + "v2/logout" : issuerUri + "/v2/logout");
         } else {
             logoutUrl.append(clientRegistration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString());
         }
 
         String originUrl = request.getHeaders().getOrigin();
-        if (issuerUri.contains("auth0.com")) {
+        if (StringUtils.containsAny(issuerUri, jhipsterProperties.getSecurity().getOauth2().getAuth0IssuerUris().toArray(new String[]{}))) {
             logoutUrl.append("?client_id=").append(clientRegistration.getClientId()).append("&returnTo=").append(originUrl);
         } else {
             logoutUrl.append("?id_token_hint=").append(idToken.getTokenValue()).append("&post_logout_redirect_uri=").append(originUrl);

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -402,6 +402,8 @@ jhipster:
       audience:
         - account
         - api://default
+      auth0-issuer-uris:
+        - auth0.com  
 <%_ } _%>
 
 # ===================================================================


### PR DESCRIPTION
This makes the auth0 issuer uris configurable via `jhipster.security.oauth2.auth0-issuer-uris`. By default this is just `auth0.com`, such that have the same behaviour as today. In case one uses a custom domain, it can be added to the list quite easy, such that the generated code must not be changed.

updates #22020

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
