### PR TITLE
don't use self reference

### DIFF
--- a/generators/server/templates/src/main/java/_package_/service/MailService.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/service/MailService.java.ejs
@@ -33,15 +33,25 @@ import org.springframework.context.MessageSource;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
+<%_ if (reactive) { _%>
+import reactor.core.publisher.Mono;
+<%_ } else { _%>
+import org.springframework.scheduling.annotation.Async;
+<%_ } _%>
+<%_
+    const localSendEmailFromTemplateApi = reactive ? 'sendEmailFromTemplate' : 'sendEmailFromTemplateSync';
+_%>
+
 
 /**
- * Service for sending emails.
+ * Service for sending emails asynchronously.
+<%_ if (!reactive) { _%>
  * <p>
  * We use the {@link Async} annotation to send emails asynchronously.
+<%_ } _%>
  */
 @Service
 public class MailService {
@@ -69,12 +79,21 @@ public class MailService {
         this.templateEngine = templateEngine;
     }
 
+<%_ if (!reactive) { _%>
     @Async
+<%_ } _%>
     public void sendEmail(String to, String subject, String content, boolean isMultipart, boolean isHtml) {
-        this.internalSendEmail(to, subject, content, isMultipart, isHtml);
+<%_ if (reactive) { _%>
+        Mono.defer(() -> {
+            this.sendEmailSync(to, subject, content, isMultipart, isHtml);
+            return Mono.empty();
+        }).subscribe();
+<%_ } else { _%>
+        this.sendEmailSync(to, subject, content, isMultipart, isHtml);
+<%_ } _%>
     }
 
-    private void internalSendEmail(String to, String subject, String content, boolean isMultipart, boolean isHtml) {
+    private void sendEmailSync(String to, String subject, String content, boolean isMultipart, boolean isHtml) {
         log.debug("Send email[multipart '{}' and html '{}'] to '{}' with subject '{}' and content={}",
             isMultipart, isHtml, to, subject, content);
 
@@ -93,12 +112,21 @@ public class MailService {
         }
     }
 
+<%_ if (!reactive) { _%>
     @Async
+<%_ } _%>
     public void sendEmailFromTemplate(<%= user.persistClass %> user, String templateName, String titleKey) {
-        this.internalSendEmailFromTemplate(user, templateName, titleKey);
+<%_ if (reactive) { _%>
+        Mono.defer(() -> {
+            this.sendEmailFromTemplateSync(user, templateName, titleKey);
+            return Mono.empty();
+        }).subscribe();
+<%_ } else { _%>
+        this.sendEmailFromTemplateSync(user, templateName, titleKey);
+<%_ } _%>
     }
 
-    private void internalSendEmailFromTemplate(<%= user.persistClass %> user, String templateName, String titleKey) {
+    private void sendEmailFromTemplateSync(<%= user.persistClass %> user, String templateName, String titleKey) {
         if (user.getEmail() == null) {
             log.debug("Email doesn't exist for user '{}'", user.getLogin());
             return;
@@ -109,26 +137,32 @@ public class MailService {
         context.setVariable(BASE_URL, jHipsterProperties.getMail().getBaseUrl());
         String content = templateEngine.process(templateName, context);
         String subject = messageSource.getMessage(titleKey, null, locale);
-        this.internalSendEmail(user.getEmail(), subject, content, false, true);
+        this.sendEmailSync(user.getEmail(), subject, content, false, true);
     }
 <%_ if (!authenticationTypeOauth2) { _%>
 
+<%_ if (!reactive) { _%>
     @Async
+<%_ } _%>
     public void sendActivationEmail(<%= user.persistClass %> user) {
         log.debug("Sending activation email to '{}'", user.getEmail());
-        this.internalSendEmailFromTemplate(user, "mail/activationEmail", "email.activation.title");
+        this.<%- localSendEmailFromTemplateApi %>(user, "mail/activationEmail", "email.activation.title");
     }
 
+<%_ if (!reactive) { _%>
     @Async
+<%_ } _%>
     public void sendCreationEmail(<%= user.persistClass %> user) {
         log.debug("Sending creation email to '{}'", user.getEmail());
-        this.internalSendEmailFromTemplate(user, "mail/creationEmail", "email.activation.title");
+        this.<%- localSendEmailFromTemplateApi %>(user, "mail/creationEmail", "email.activation.title");
     }
 
+<%_ if (!reactive) { _%>
     @Async
+<%_ } _%>
     public void sendPasswordResetMail(<%= user.persistClass %> user) {
         log.debug("Sending password reset email to '{}'", user.getEmail());
-        this.internalSendEmailFromTemplate(user, "mail/passwordResetEmail", "email.reset.title");
+        this.<%- localSendEmailFromTemplateApi %>(user, "mail/passwordResetEmail", "email.reset.title");
     }
 <%_ } _%>
 }

--- a/generators/server/templates/src/main/java/_package_/service/MailService.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/service/MailService.java.ejs
@@ -29,9 +29,7 @@ import jakarta.mail.internet.MimeMessage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -62,10 +60,6 @@ public class MailService {
 
     private final SpringTemplateEngine templateEngine;
 
-    @Autowired
-    @Lazy
-    private MailService self;
-
     public MailService(JHipsterProperties jHipsterProperties, JavaMailSender javaMailSender,
             MessageSource messageSource, SpringTemplateEngine templateEngine) {
 
@@ -77,6 +71,10 @@ public class MailService {
 
     @Async
     public void sendEmail(String to, String subject, String content, boolean isMultipart, boolean isHtml) {
+        this.internalSendEmail(to, subject, content, isMultipart, isHtml);
+    }
+
+    private void internalSendEmail(String to, String subject, String content, boolean isMultipart, boolean isHtml) {
         log.debug("Send email[multipart '{}' and html '{}'] to '{}' with subject '{}' and content={}",
             isMultipart, isHtml, to, subject, content);
 
@@ -97,6 +95,10 @@ public class MailService {
 
     @Async
     public void sendEmailFromTemplate(<%= user.persistClass %> user, String templateName, String titleKey) {
+        this.internalSendEmailFromTemplate(user, templateName, titleKey);
+    }
+
+    private void internalSendEmailFromTemplate(<%= user.persistClass %> user, String templateName, String titleKey) {
         if (user.getEmail() == null) {
             log.debug("Email doesn't exist for user '{}'", user.getLogin());
             return;
@@ -107,26 +109,26 @@ public class MailService {
         context.setVariable(BASE_URL, jHipsterProperties.getMail().getBaseUrl());
         String content = templateEngine.process(templateName, context);
         String subject = messageSource.getMessage(titleKey, null, locale);
-        self.sendEmail(user.getEmail(), subject, content, false, true);
+        this.internalSendEmail(user.getEmail(), subject, content, false, true);
     }
 <%_ if (!authenticationTypeOauth2) { _%>
 
     @Async
     public void sendActivationEmail(<%= user.persistClass %> user) {
         log.debug("Sending activation email to '{}'", user.getEmail());
-        self.sendEmailFromTemplate(user, "mail/activationEmail", "email.activation.title");
+        this.internalSendEmailFromTemplate(user, "mail/activationEmail", "email.activation.title");
     }
 
     @Async
     public void sendCreationEmail(<%= user.persistClass %> user) {
         log.debug("Sending creation email to '{}'", user.getEmail());
-        self.sendEmailFromTemplate(user, "mail/creationEmail", "email.activation.title");
+        this.internalSendEmailFromTemplate(user, "mail/creationEmail", "email.activation.title");
     }
 
     @Async
     public void sendPasswordResetMail(<%= user.persistClass %> user) {
         log.debug("Sending password reset email to '{}'", user.getEmail());
-        self.sendEmailFromTemplate(user, "mail/passwordResetEmail", "email.reset.title");
+        this.internalSendEmailFromTemplate(user, "mail/passwordResetEmail", "email.reset.title");
     }
 <%_ } _%>
 }


### PR DESCRIPTION
Calling a `@Async` without been proxied is reported by sonar as a code smell.
Add a non async internal method since calling a `@Async` method from a `@Async` method creates an unnecessary twice async.

Fixes https://github.com/jhipster/generator-jhipster-native/issues/101
Implement https://github.com/jhipster/generator-jhipster/pull/24034#pullrequestreview-1702797684
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
