### PR TITLE
use /**/ for template comments

### DIFF
--- a/generators/languages/templates/entity/i18n/entity_pt-br.json.ejs
+++ b/generators/languages/templates/entity/i18n/entity_pt-br.json.ejs
@@ -18,7 +18,7 @@
 -%><%
 let helpBlocks = 0; %>
 {
-    <%_ // Male (default) variant
+    <%_ /* Male (default) variant */
     let Um = 'Um';
     let novo = 'novo';
     let criado = 'criado';

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -266,7 +266,7 @@ dependencies {
     // to use a SNAPSHOT release instead of a stable release
     implementation "tech.jhipster:jhipster-framework"
     implementation "jakarta.annotation:jakarta.annotation-api"
-<%_ // This is useful for major Spring Boot migration
+<%_ /* This is useful for major Spring Boot migration */
 if (addSpringMilestoneRepository) { _%>
     runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
 <%_ } _%>

--- a/generators/server/templates/src/main/java/_package_/_entityPackage_/service/mapper/_entityClass_Mapper.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/_entityPackage_/service/mapper/_entityClass_Mapper.java.ejs
@@ -63,7 +63,7 @@ import java.util.UUID;
 @Mapper(componentModel = "spring")
 public interface <%= entityClass %>Mapper extends EntityMapper<<%= dtoClass %>, <%= persistClass %>> {
 <%_ if (!embedded) { _%>
-  <%_ var renMapAnotEnt = false; //Render Mapping Annotation during Entity to DTO conversion? _%>
+  <%_ var renMapAnotEnt = false; /*Render Mapping Annotation during Entity to DTO conversion?*/ _%>
   <%_ for (relationship of dtoRelationships) { _%>
     <%_
       renMapAnotEnt = true;
@@ -80,7 +80,7 @@ public interface <%= entityClass %>Mapper extends EntityMapper<<%= dtoClass %>, 
     <%= dtoClass %> toDto(<%= persistClass %> s);
   <%_ } _%>
 
-  <%_ var renMapAnotDto = false;  //Render Mapping Annotation during DTO to Entity conversion? _%>
+  <%_ var renMapAnotDto = false;  /*Render Mapping Annotation during DTO to Entity conversion?*/ _%>
   <%_ if(primaryKey.ids.length > 1) { _%>
     <%_ renMapAnotDto = true; _%>
     <%_ for (const id of primaryKey.ids) { _%>

--- a/generators/spring-data-elasticsearch/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.elastic_search.ejs
+++ b/generators/spring-data-elasticsearch/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.elastic_search.ejs
@@ -45,7 +45,7 @@
 
 <%_ for (const relationship of relationships) { -%>
   <&_ if (fragment.relationship<%- relationship.relationshipNameCapitalized %>AnnotationSection) { -&>
-    <% // just break the cycle // in the reactive area, we already have the annotation in place
+    <% /* just break the cycle in the reactive area, we already have the annotation in place */
       if (!relationship.ownerSide && !reactive) { %>
         @org.springframework.data.annotation.Transient
     <% } %>


### PR DESCRIPTION
Syntax coloring in IDE (i.e. yeoman IJ plugin) are broken when comments are made with //, this PR aligns template comments using /**/ which makes it accurate again
---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
