### PR TITLE
Handle Angular navigation errors

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/app.config.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/app.config.ts.ejs
@@ -16,9 +16,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { ApplicationConfig, LOCALE_ID, importProvidersFrom } from '@angular/core';
+import { ApplicationConfig, LOCALE_ID, importProvidersFrom, inject } from '@angular/core';
 import { BrowserModule, Title } from '@angular/platform-browser';
-import { RouterFeatures, TitleStrategy, provideRouter, withComponentInputBinding, withDebugTracing } from '@angular/router';
+import { Router, RouterFeatures, TitleStrategy, provideRouter, withComponentInputBinding, withDebugTracing, withNavigationErrorHandler, NavigationError } from '@angular/router';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { HttpClientModule } from '@angular/common/http';
 
@@ -29,14 +29,26 @@ import './config/dayjs';
 <%_ if (enableTranslation) { _%>
 import { TranslationModule } from 'app/shared/language/translation.module';
 <%_ } _%>
-import { httpInterceptorProviders } from 'app/core/interceptor/index';
+import { httpInterceptorProviders } from './core/interceptor';
 import FindLanguageFromKeyPipe from 'app/shared/language/find-language-from-key.pipe';
 import routes from './app.routes';
 // jhipster-needle-angular-add-module-import JHipster will add new module here
 import { NgbDateDayjsAdapter } from './config/datepicker-adapter';
 import { AppPageTitleStrategy } from './app-page-title-strategy';
 
-const routerFeatures: Array<RouterFeatures> = [withComponentInputBinding()];
+const routerFeatures: Array<RouterFeatures> = [withComponentInputBinding(),
+  withNavigationErrorHandler((e: NavigationError) => {
+    const router = inject(Router);
+    if (e.error.status === 403) {
+      router.navigate(['/accessdenied'])
+    } else if (e.error.status === 404) {
+      router.navigate(['/404'])
+    } else if (e.error.status === 401) {
+      router.navigate(['/login']);
+    } else {
+      router.navigate(['/error']);
+    }
+  })];
 if (DEBUG_INFO_ENABLED) {
   routerFeatures.push(withDebugTracing());
 }


### PR DESCRIPTION
This PR uses https://angular.io/api/router/withNavigationErrorHandler to handle navigation error events, which can't be handled by our http interceptor error handlers. 

I tried to extract a dedicated class, but failed miserable to have that injected in the config.ts file. Either I got no injector defined or the injected class was wrong/not constructed such that it failed with `... has not method ...`. Looks like I need to refresh my angular skills :(

updates #24396


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
