### PR TITLE
[internal] add support to disable blueprints

### DIFF
--- a/generators/base/__snapshots__/generator.spec.mts.snap
+++ b/generators/base/__snapshots__/generator.spec.mts.snap
@@ -17,6 +17,7 @@ Options:
   --skip-yo-resolve           Ignore .yo-resolve files (default: false)
   --skip-checks               Check the status of the required tools
   --experimental              Enable experimental features. Please note that these features may be unstable and may undergo breaking changes at any time
+  --disable-blueprints        Disable blueprints support
   -d, --debug                 Enable debugger
   --reproducible              Try to reproduce changelog
   --skip-prompts              Skip prompts

--- a/generators/base/api.d.mts
+++ b/generators/base/api.d.mts
@@ -33,6 +33,7 @@ export type JHipsterGeneratorOptions = BaseOptions & {
   skipPriorities?: string[];
   skipWriting?: boolean;
   entities?: string[];
+  disableBlueprints?: boolean;
 
   /* blueprint options */
   blueprints?: string;

--- a/generators/base/blueprints.spec.mts
+++ b/generators/base/blueprints.spec.mts
@@ -145,13 +145,34 @@ describe('generator - base - with scoped blueprint', () => {
     });
 
     it('should compose with blueprint', () => {
-      expect(runResult.mockedGenerators['@jhipster/jhipster-scoped-blueprint:test-blueprint'].called);
+      expect(runResult.mockedGenerators['@jhipster/jhipster-scoped-blueprint:test-blueprint'].called).toBe(true);
     });
 
     it('blueprint version is saved in .yo-rc.json', () => {
       runResult.assertJsonFileContent('.yo-rc.json', {
         'generator-jhipster': { blueprints: [{ name: '@jhipster/generator-jhipster-scoped-blueprint', version: '9.9.9' }] },
       });
+    });
+  });
+});
+
+describe('generator - base - with blueprints disabled', () => {
+  describe('should not compose with blueprint', () => {
+    let runResult: RunResult;
+    before(async () => {
+      runResult = await helpers
+        .runTestBlueprintGenerator()
+        .withFakeTestBlueprint('@jhipster/generator-jhipster-scoped-blueprint')
+        .withMockedGenerators(['@jhipster/jhipster-scoped-blueprint:test-blueprint'])
+        .withJHipsterConfig()
+        .withOptions({
+          blueprints: '@jhipster/generator-jhipster-scoped-blueprint',
+          disableBlueprints: true,
+        });
+    });
+
+    it('should compose with blueprint', () => {
+      expect(runResult.mockedGenerators['@jhipster/jhipster-scoped-blueprint:test-blueprint'].called).toBeFalsy;
     });
   });
 });
@@ -207,7 +228,7 @@ describe('generator - base - local blueprint', () => {
       constructor(args, opts, features) {
         super(args, opts, features);
       }
-  
+
       get [BaseGenerator.WRITING]() {
         return {
           write() {

--- a/generators/base/command.mts
+++ b/generators/base/command.mts
@@ -38,6 +38,10 @@ const command: JHipsterCommandDefinition = {
       type: Boolean,
       scope: 'generator',
     },
+    disableBlueprints: {
+      description: 'Disable blueprints support',
+      type: Boolean,
+    },
     debugEnabled: {
       name: 'debug',
       description: 'Enable debugger',

--- a/generators/base/generator.mts
+++ b/generators/base/generator.mts
@@ -448,6 +448,10 @@ export default class JHipsterBaseBlueprintGenerator<
   protected async composeWithBlueprints(subGen: string, options?: ComposeOptions) {
     this.delegateToBlueprint = false;
 
+    if (this.options.disableBlueprints) {
+      return [];
+    }
+
     const control = this.sharedData.getControl();
     if (!control.blueprintConfigured) {
       control.blueprintConfigured = true;


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/pull/24190.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
