### PR TITLE
Do not prompt for feign clients when creating a monolith 

### DIFF
--- a/generators/server/command.ts
+++ b/generators/server/command.ts
@@ -155,7 +155,10 @@ const command: JHipsterCommandDefinition = {
       prompt: {
         type: 'confirm',
         message: 'Do you want to generate a feign client?',
-        when: currentAnswer => currentAnswer.applicationType !== APPLICATION_TYPE_MONOLITH,
+        when: currentAnswer =>
+          currentAnswer.applicationType === APPLICATION_TYPE_MICROSERVICE &&
+          currentAnswer.reactive !== undefined &&
+          !currentAnswer.reactive,
       },
       default: false,
     },

--- a/generators/server/command.ts
+++ b/generators/server/command.ts
@@ -155,7 +155,7 @@ const command: JHipsterCommandDefinition = {
       prompt: {
         type: 'confirm',
         message: 'Do you want to generate a feign client?',
-        when: (currentAnswers) => currentAnswers.applicationType != APPLICATION_TYPE_MONOLITH,
+        when: (currentAnswer) => currentAnswer.applicationType != APPLICATION_TYPE_MONOLITH,
       },
       default: false,
     },

--- a/generators/server/command.ts
+++ b/generators/server/command.ts
@@ -155,7 +155,7 @@ const command: JHipsterCommandDefinition = {
       prompt: {
         type: 'confirm',
         message: 'Do you want to generate a feign client?',
-        when: currentAnswer => currentAnswer.applicationType != APPLICATION_TYPE_MONOLITH,
+        when: currentAnswer => currentAnswer.applicationType !== APPLICATION_TYPE_MONOLITH,
       },
       default: false,
     },

--- a/generators/server/command.ts
+++ b/generators/server/command.ts
@@ -155,7 +155,7 @@ const command: JHipsterCommandDefinition = {
       prompt: {
         type: 'confirm',
         message: 'Do you want to generate a feign client?',
-        when: (currentAnswer) => currentAnswer.applicationType != APPLICATION_TYPE_MONOLITH,
+        when: currentAnswer => currentAnswer.applicationType != APPLICATION_TYPE_MONOLITH,
       },
       default: false,
     },

--- a/generators/server/command.ts
+++ b/generators/server/command.ts
@@ -155,6 +155,7 @@ const command: JHipsterCommandDefinition = {
       prompt: {
         type: 'confirm',
         message: 'Do you want to generate a feign client?',
+        when: (currentAnswers) => currentAnswers.applicationType != APPLICATION_TYPE_MONOLITH,
       },
       default: false,
     },

--- a/generators/server/support/__snapshots__/needles.spec.ts.snap
+++ b/generators/server/support/__snapshots__/needles.spec.ts.snap
@@ -89,12 +89,6 @@ exports[`generator - server - support - needles generated project should match s
   "src/main/java/com/mycompany/myapp/aop/logging/package-info.java": {
     "stateCleared": "modified",
   },
-  "src/main/java/com/mycompany/myapp/client/UserFeignClientInterceptor.java": {
-    "stateCleared": "modified",
-  },
-  "src/main/java/com/mycompany/myapp/client/package-info.java": {
-    "stateCleared": "modified",
-  },
   "src/main/java/com/mycompany/myapp/config/ApplicationProperties.java": {
     "stateCleared": "modified",
   },
@@ -114,9 +108,6 @@ exports[`generator - server - support - needles generated project should match s
     "stateCleared": "modified",
   },
   "src/main/java/com/mycompany/myapp/config/DateTimeFormatConfiguration.java": {
-    "stateCleared": "modified",
-  },
-  "src/main/java/com/mycompany/myapp/config/FeignConfiguration.java": {
     "stateCleared": "modified",
   },
   "src/main/java/com/mycompany/myapp/config/JacksonConfiguration.java": {


### PR DESCRIPTION
Added a when to the feingClient command where it checks if the application type is not a Monolith

closes #24560


---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
