### PR TITLE
[internal] Use the quibble for dependency mock in tests

### DIFF
--- a/.github/actions/build-matrix/action.yml
+++ b/.github/actions/build-matrix/action.yml
@@ -88,9 +88,9 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 18.19.0
     - name: 'Check changes'
       id: build-changes
       run: |

--- a/.github/actions/setup-default-node-java/action.yml
+++ b/.github/actions/setup-default-node-java/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 18.19.0
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.2
+          node-version: 18.19.0
       - name: 'SETUP: load npm cache'
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/lock-maintenance.yml
+++ b/.github/workflows/lock-maintenance.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm install -g npm@latest
       - uses: actions/checkout@v4
       - uses: jhipster/actions/restore-cache@v0

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,3 +1,11 @@
+const Module = require('module');
+const process = require('process');
+
+if (!Module.register) {
+  console.log('JHipster test requires node >=18.19.0 || >= 20.6.0\n');
+  process.exit(1);
+}
+
 module.exports = {
   recursive: true,
   reporter: 'spec',

--- a/generators/java/support/checks/check-java.spec.ts
+++ b/generators/java/support/checks/check-java.spec.ts
@@ -1,7 +1,8 @@
-import { before, it, describe, expect, mock, resetAllMocks } from 'esmocha';
+import { after, before, it, describe, expect, resetAllMocks, esmocha } from 'esmocha';
 import { ExecaSyncReturnValue } from 'execa';
+import quibble from 'quibble';
 
-const execa = await mock<typeof import('execa')>('execa');
+const execa = { execa: esmocha.fn(), execaSync: esmocha.fn(), execaCommandSync: esmocha.fn(), execaCommand: esmocha.fn() };
 
 const baseResult: ExecaSyncReturnValue<string> = {
   command: 'java',
@@ -15,6 +16,13 @@ const baseResult: ExecaSyncReturnValue<string> = {
 };
 
 describe('generator - server - checkJava', () => {
+  before(async () => {
+    await quibble.esm('execa', execa);
+  });
+  after(() => {
+    quibble.reset();
+  });
+
   afterEach(() => {
     resetAllMocks();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
         "octokit": "3.1.2",
         "open-cli": "7.2.0",
         "prettier2": "npm:prettier@2.8.8",
+        "quibble": "0.9.1",
         "rimraf": "5.0.5",
         "sinon": "17.0.1",
         "sinon-chai": "3.7.0",
@@ -12623,6 +12624,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
+    "node_modules/quibble": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.9.1.tgz",
+      "integrity": "sha512-2EkLLm3CsBhbHfYEgBWHSJZZRpVHUZLeuJVEQoU/lsCqxcOvVkgVlF4nWv2ACWKkb0lgxgMh3m8vq9rhx9LTIg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">= 0.14.0"
+      }
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "octokit": "3.1.2",
     "open-cli": "7.2.0",
     "prettier2": "npm:prettier@2.8.8",
+    "quibble": "0.9.1",
     "rimraf": "5.0.5",
     "sinon": "17.0.1",
     "sinon-chai": "3.7.0",


### PR DESCRIPTION
- node 18.19.0 backported dynamic loader register
Use dynamic register and drop support for test using node < 18.19.0
- bump node to 18.19.0
- switch to quibble for dependencies mocking

related to https://github.com/jhipster/generator-jhipster/pull/23980
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
