### PR TITLE
gradle gatling convention plugin

### DIFF
--- a/generators/gatling/__snapshots__/generator.spec.ts.snap
+++ b/generators/gatling/__snapshots__/generator.spec.ts.snap
@@ -179,3 +179,204 @@ gatling {
   },
 }
 `;
+
+exports[`generator - gatling with gradle build tool should match files snapshot 1`] = `
+{
+  ".yo-rc.json": {
+    "contents": "{
+  "generator-jhipster": {
+    "baseName": "jhipster",
+    "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
+    "entities": []
+  }
+}
+",
+    "stateCleared": "modified",
+  },
+  "buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle": {
+    "contents": "plugins {
+    id "io.gatling.gradle"
+}
+
+dependencies {
+    testImplementation "io.gatling.highcharts:gatling-charts-highcharts:\${libs.versions.gatling.highcharts.get()}"
+}
+sourceSets {
+    gatling {
+        java.srcDirs = ["src/test/java/gatling/simulations"]
+        resources.srcDirs = ["src/test/gatling/conf"]
+    }
+}
+
+gatling {
+    simulations = { include "**/*Test*.java" }
+}",
+    "stateCleared": "modified",
+  },
+  "src/test/gatling/conf/gatling.conf": {
+    "contents": "#########################
+# Gatling Configuration #
+#########################
+
+# This file contains all the settings configurable for Gatling with their default values
+
+gatling {
+  core {
+    #outputDirectoryBaseName = "" # The prefix for each simulation result folder (then suffixed by the report generation timestamp)
+    #runDescription = ""          # The description for this simulation run, displayed in each report
+    #encoding = "utf-8"           # Encoding to use throughout Gatling for file and string manipulation
+    #simulationClass = ""         # The FQCN of the simulation to run (when used in conjunction with noReports, the simulation for which assertions will be validated)
+    #mute = false                 # When set to true, don't ask for simulation name nor run description (currently only used by Gatling SBT plugin)
+    #elFileBodiesCacheMaxCapacity = 200        # Cache size for request body EL templates, set to 0 to disable
+    #rawFileBodiesCacheMaxCapacity = 200       # Cache size for request body Raw templates, set to 0 to disable
+    #rawFileBodiesInMemoryMaxSize = 1000       # Below this limit, raw file bodies will be cached in memory
+
+    extract {
+      regex {
+        #cacheMaxCapacity = 200 # Cache size for the compiled regexes, set to 0 to disable caching
+      }
+      xpath {
+        #cacheMaxCapacity = 200 # Cache size for the compiled XPath queries,  set to 0 to disable caching
+      }
+      jsonPath {
+        #cacheMaxCapacity = 200 # Cache size for the compiled jsonPath queries, set to 0 to disable caching
+        #preferJackson = false  # When set to true, prefer Jackson over Boon for JSON-related operations
+      }
+      css {
+        #cacheMaxCapacity = 200 # Cache size for the compiled CSS selectors queries,  set to 0 to disable caching
+      }
+    }
+
+    directory {
+      #data = user-files/data               # Folder where user's data (e.g. files used by Feeders) is located
+      #bodies = user-files/bodies           # Folder where bodies are located
+      #simulations = user-files/simulations # Folder where the bundle's simulations are located
+      #reportsOnly = ""                     # If set, name of report folder to look for in order to generate its report
+      #binaries = ""                        # If set, name of the folder where compiles classes are located: Defaults to GATLING_HOME/target.
+      #results = results                    # Name of the folder where all reports folder are located
+    }
+  }
+  charting {
+    #noReports = false       # When set to true, don't generate HTML reports
+    #maxPlotPerSeries = 1000 # Number of points per graph in Gatling reports
+    #useGroupDurationMetric = false  # Switch group timings from cumulated response time to group duration.
+    indicators {
+      #lowerBound = 800      # Lower bound for the requests' response time to track in the reports and the console summary
+      #higherBound = 1200    # Higher bound for the requests' response time to track in the reports and the console summary
+      #percentile1 = 50      # Value for the 1st percentile to track in the reports, the console summary and Graphite
+      #percentile2 = 75      # Value for the 2nd percentile to track in the reports, the console summary and Graphite
+      #percentile3 = 95      # Value for the 3rd percentile to track in the reports, the console summary and Graphite
+      #percentile4 = 99      # Value for the 4th percentile to track in the reports, the console summary and Graphite
+    }
+  }
+  http {
+    #fetchedCssCacheMaxCapacity = 200          # Cache size for CSS parsed content, set to 0 to disable
+    #fetchedHtmlCacheMaxCapacity = 200         # Cache size for HTML parsed content, set to 0 to disable
+    #perUserCacheMaxCapacity = 200             # Per virtual user cache size, set to 0 to disable
+    #warmUpUrl = "http://gatling.io"           # The URL to use to warm-up the HTTP stack (blank means disabled)
+    #enableGA = true                           # Very light Google Analytics, please support
+    ssl {
+      keyStore {
+        #type = ""      # Type of SSLContext's KeyManagers store
+        #file = ""      # Location of SSLContext's KeyManagers store
+        #password = ""  # Password for SSLContext's KeyManagers store
+        #algorithm = "" # Algorithm used SSLContext's KeyManagers store
+      }
+      trustStore {
+        #type = ""      # Type of SSLContext's TrustManagers store
+        #file = ""      # Location of SSLContext's TrustManagers store
+        #password = ""  # Password for SSLContext's TrustManagers store
+        #algorithm = "" # Algorithm used by SSLContext's TrustManagers store
+      }
+    }
+    ahc {
+      #keepAlive = true                                # Allow pooling HTTP connections (keep-alive header automatically added)
+      #connectTimeout = 10000                          # Timeout when establishing a connection
+      #handshakeTimeout = 10000                        # Timeout when performing TLS hashshake
+      #pooledConnectionIdleTimeout = 60000             # Timeout when a connection stays unused in the pool
+      #readTimeout = 60000                             # Timeout when a used connection stays idle
+      #maxRetry = 2                                    # Number of times that a request should be tried again
+      #requestTimeout = 60000                          # Timeout of the requests
+      #acceptAnyCertificate = true                     # When set to true, doesn't validate SSL certificates
+      #httpClientCodecMaxInitialLineLength = 4096      # Maximum length of the initial line of the response (e.g. "HTTP/1.0 200 OK")
+      #httpClientCodecMaxHeaderSize = 8192             # Maximum size, in bytes, of each request's headers
+      #httpClientCodecMaxChunkSize = 8192              # Maximum length of the content or each chunk
+      #webSocketMaxFrameSize = 10240000                # Maximum frame payload size
+      #sslEnabledProtocols = [TLSv1.2, TLSv1.1, TLSv1] # Array of enabled protocols for HTTPS, if empty use the JDK defaults
+      #sslEnabledCipherSuites = []                     # Array of enabled cipher suites for HTTPS, if empty use the AHC defaults
+      #sslSessionCacheSize = 0                         # SSLSession cache size, set to 0 to use JDK's default
+      #sslSessionTimeout = 0                           # SSLSession timeout in seconds, set to 0 to use JDK's default (24h)
+      #useOpenSsl = false                              # if OpenSSL should be used instead of JSSE (requires tcnative jar)
+      #useNativeTransport = false                      # if native transport should be used instead of Java NIO (requires netty-transport-native-epoll, currently Linux only)
+      #tcpNoDelay = true
+      #soReuseAddress = false
+      #soLinger = -1
+      #soSndBuf = -1
+      #soRcvBuf = -1
+      #allocator = "pooled"                            # switch to unpooled for unpooled ByteBufAllocator
+      #maxThreadLocalCharBufferSize = 200000           # Netty's default is 16k
+    }
+    dns {
+      #queryTimeout = 5000                             # Timeout of each DNS query in millis
+      #maxQueriesPerResolve = 6                        # Maximum allowed number of DNS queries for a given name resolution
+    }
+  }
+  jms {
+    #acknowledgedMessagesBufferSize = 5000             # size of the buffer used to tracked acknowledged messages and protect against duplicate receives
+  }
+  data {
+    #writers = [console, file]      # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite, jdbc)
+    console {
+      #light = false                # When set to true, displays a light version without detailed request stats
+    }
+    file {
+      #bufferSize = 8192            # FileDataWriter's internal data buffer size, in bytes
+    }
+    leak {
+      #noActivityTimeout = 30  # Period, in seconds, for which Gatling may have no activity before considering a leak may be happening
+    }
+    graphite {
+      #light = false              # only send the all* stats
+      #host = "localhost"         # The host where the Carbon server is located
+      #port = 2003                # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
+      #protocol = "tcp"           # The protocol used to send data to Carbon (currently supported : "tcp", "udp")
+      #rootPathPrefix = "gatling" # The common prefix of all metrics sent to Graphite
+      #bufferSize = 8192          # GraphiteDataWriter's internal data buffer size, in bytes
+      #writeInterval = 1          # GraphiteDataWriter's write interval, in seconds
+    }
+  }
+}
+",
+    "stateCleared": "modified",
+  },
+  "src/test/gatling/conf/logback.xml": {
+    "contents": "<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+            <immediateFlush>false</immediateFlush>
+        </encoder>
+    </appender>
+
+    <!-- Uncomment for logging ALL HTTP request and responses -->
+    <!--    <logger name="io.gatling.http.ahc" level="TRACE" /> -->
+    <!--    <logger name="io.gatling.http.response" level="TRACE" /> -->
+    <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
+    <!--    <logger name="io.gatling.http.ahc" level="DEBUG" /> -->
+    <!--    <logger name="io.gatling.http.response" level="DEBUG" /> -->
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>
+",
+    "stateCleared": "modified",
+  },
+}
+`;

--- a/generators/gatling/files.ts
+++ b/generators/gatling/files.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import Generator from './generator.js';
-import { TEST_DIR } from '../generator-constants.js';
+import { TEST_DIR, GRADLE_BUILD_SRC_MAIN_DIR } from '../generator-constants.js';
 import { WriteFileSection } from '../base/api.js';
 import { SpringBootApplication } from '../server/types.js';
 
@@ -25,6 +25,11 @@ const gatlingFiles: WriteFileSection<Generator, SpringBootApplication> = {
   gatlingFiles: [
     {
       templates: ['README.md.jhi.gatling'],
+    },
+    {
+      condition: generator => generator.buildToolGradle,
+      path: GRADLE_BUILD_SRC_MAIN_DIR,
+      templates: ['jhipster.gatling-conventions.gradle'],
     },
     {
       path: TEST_DIR,

--- a/generators/gatling/generator.spec.ts
+++ b/generators/gatling/generator.spec.ts
@@ -32,4 +32,13 @@ describe(`generator - ${generator}`, () => {
       expect(result.getSnapshot()).toMatchSnapshot();
     });
   });
+  describe('with gradle build tool', () => {
+    before(async () => {
+      await helpers.runJHipster(GENERATOR_GATLING).withJHipsterConfig({ buildTool: 'gradle' });
+    });
+
+    it('should match files snapshot', () => {
+      expect(result.getSnapshot()).toMatchSnapshot();
+    });
+  });
 });

--- a/generators/gatling/generator.ts
+++ b/generators/gatling/generator.ts
@@ -86,6 +86,9 @@ export default class GatlingGenerator extends BaseApplicationGenerator {
             ],
           });
         }
+        if (application.buildToolGradle) {
+          source.addGradlePlugin?.({ id: 'jhipster.gatling-conventions' });
+        }
       },
     });
   }

--- a/generators/gatling/generator.ts
+++ b/generators/gatling/generator.ts
@@ -92,6 +92,7 @@ export default class GatlingGenerator extends BaseApplicationGenerator {
           source.addGradleBuildSrcDependency?.({
             groupId: 'gradle.plugin.io.gatling.gradle',
             artifactId: 'gatling-gradle-plugi',
+            // eslint-disable-next-line no-template-curly-in-string
             version: '${libs.versions.gatling.plugin.get()}',
             scope: 'implementation',
           });

--- a/generators/gatling/generator.ts
+++ b/generators/gatling/generator.ts
@@ -87,6 +87,13 @@ export default class GatlingGenerator extends BaseApplicationGenerator {
           });
         }
         if (application.buildToolGradle) {
+          source.addGradleBuildSrcCatalogVersion?.({ name: 'gatling-plugin', version: javaDependencies?.['gatling-gradle'] });
+          source.addGradleBuildSrcDependency?.({
+            groupId: 'gradle.plugin.io.gatling.gradle',
+            artifactId: 'gatling-gradle-plugi',
+            version: '${libs.versions.gatling.plugin.get()}',
+            scope: 'implementation',
+          });
           source.addGradlePlugin?.({ id: 'jhipster.gatling-conventions' });
         }
       },

--- a/generators/gatling/generator.ts
+++ b/generators/gatling/generator.ts
@@ -88,6 +88,7 @@ export default class GatlingGenerator extends BaseApplicationGenerator {
         }
         if (application.buildToolGradle) {
           source.addGradleBuildSrcCatalogVersion?.({ name: 'gatling-plugin', version: javaDependencies?.['gatling-gradle'] });
+          source.addGradleBuildSrcCatalogVersion?.({ name: 'gatling', version: javaDependencies?.gatling });
           source.addGradleBuildSrcDependency?.({
             groupId: 'gradle.plugin.io.gatling.gradle',
             artifactId: 'gatling-gradle-plugi',

--- a/generators/gatling/generator.ts
+++ b/generators/gatling/generator.ts
@@ -87,8 +87,10 @@ export default class GatlingGenerator extends BaseApplicationGenerator {
           });
         }
         if (application.buildToolGradle) {
-          source.addGradleBuildSrcCatalogVersion?.({ name: 'gatling-plugin', version: javaDependencies?.['gatling-gradle'] });
-          source.addGradleBuildSrcCatalogVersion?.({ name: 'gatling', version: javaDependencies?.gatling });
+          source.addGradleDependencyCatalogVersion?.({ name: 'gatling-plugin', version: javaDependencies?.['gatling-gradle'] });
+          source.addGradleDependencyCatalogVersion?.({ name: 'gatling-highcharts', version: javaDependencies?.gatling });
+          source.addGradleBuildSrcDependencyCatalogVersion?.({ name: 'gatling-plugin', version: javaDependencies?.['gatling-gradle'] });
+          source.addGradleBuildSrcDependencyCatalogVersion?.({ name: 'gatling-highcharts', version: javaDependencies?.gatling });
           source.addGradleBuildSrcDependency?.({
             groupId: 'gradle.plugin.io.gatling.gradle',
             artifactId: 'gatling-gradle-plugin',

--- a/generators/gatling/generator.ts
+++ b/generators/gatling/generator.ts
@@ -91,7 +91,7 @@ export default class GatlingGenerator extends BaseApplicationGenerator {
           source.addGradleBuildSrcCatalogVersion?.({ name: 'gatling', version: javaDependencies?.gatling });
           source.addGradleBuildSrcDependency?.({
             groupId: 'gradle.plugin.io.gatling.gradle',
-            artifactId: 'gatling-gradle-plugi',
+            artifactId: 'gatling-gradle-plugin',
             // eslint-disable-next-line no-template-curly-in-string
             version: '${libs.versions.gatling.plugin.get()}',
             scope: 'implementation',

--- a/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
+++ b/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation "io.gatling.highcharts:gatling-charts-highcharts:${gatlingVersion}"
+    testImplementation "io.gatling.highcharts:gatling-charts-highcharts:${libs.versions.gatling.get()}"
 }
 sourceSets {
     gatling {

--- a/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
+++ b/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation "io.gatling.highcharts:gatling-charts-highcharts:${libs.versions.gatling.get()}"
+    testImplementation "io.gatling.highcharts:gatling-charts-highcharts:${libs.versions.gatling.highcharts.get()}"
 }
 sourceSets {
     gatling {

--- a/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
+++ b/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
@@ -1,0 +1,17 @@
+plugins {
+    id "io.gatling.gradle"
+}
+
+dependencies {
+    testImplementation "io.gatling.highcharts:gatling-charts-highcharts:${gatlingVersion}"
+}
+sourceSets {
+    gatling {
+        java.srcDirs = ["src/test/java/gatling/simulations"]
+        resources.srcDirs = ["src/test/gatling/conf"]
+    }
+}
+
+gatling {
+    simulations = { include "**/*Test*.java" }
+}

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -98,6 +98,9 @@ export const JHIPSTER_DOCUMENTATION_ARCHIVE_PATH = '/documentation-archive/';
 export const MAIN_DIR = 'src/main/';
 export const TEST_DIR = 'src/test/';
 
+export const GRADLE_BUILD_SRC_DIR = 'buildSrc/';
+export const GRADLE_BUILD_SRC_MAIN_DIR = 'buildSrc/src/main/groovy';
+
 // Note: this will be prepended with 'target/classes' for Maven, or with 'build/resources/main' for Gradle.
 export const CLIENT_DIST_DIR = 'static/';
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -99,7 +99,7 @@ export const MAIN_DIR = 'src/main/';
 export const TEST_DIR = 'src/test/';
 
 export const GRADLE_BUILD_SRC_DIR = 'buildSrc/';
-export const GRADLE_BUILD_SRC_MAIN_DIR = 'buildSrc/src/main/groovy';
+export const GRADLE_BUILD_SRC_MAIN_DIR = `${GRADLE_BUILD_SRC_DIR}/src/main/groovy/`;
 
 // Note: this will be prepended with 'target/classes' for Maven, or with 'build/resources/main' for Gradle.
 export const CLIENT_DIST_DIR = 'static/';

--- a/generators/gradle/__snapshots__/generator.spec.js.snap
+++ b/generators/gradle/__snapshots__/generator.spec.js.snap
@@ -35,7 +35,7 @@ exports[`generator - gradle with valid configuration should generate only gradle
     "stateCleared": "modified",
   },
   "buildSrc/gradle/libs.versions.toml": {
-     "stateCleared": "modified",
+    "stateCleared": "modified",
   },
   "gradle/wrapper/gradle-wrapper.jar": {
     "stateCleared": "modified",

--- a/generators/gradle/__snapshots__/generator.spec.js.snap
+++ b/generators/gradle/__snapshots__/generator.spec.js.snap
@@ -8,6 +8,9 @@ exports[`generator - gradle with empty configuration should generate only gradle
   "buildSrc/build.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/gradle/libs.versions.toml": {
+    "stateCleared": "modified",
+  },
   "gradle/wrapper/gradle-wrapper.jar": {
     "stateCleared": "modified",
   },
@@ -30,6 +33,9 @@ exports[`generator - gradle with valid configuration should generate only gradle
   },
   "buildSrc/build.gradle": {
     "stateCleared": "modified",
+  },
+  "buildSrc/gradle/libs.versions.toml": {
+     "stateCleared": "modified",
   },
   "gradle/wrapper/gradle-wrapper.jar": {
     "stateCleared": "modified",

--- a/generators/gradle/__snapshots__/generator.spec.js.snap
+++ b/generators/gradle/__snapshots__/generator.spec.js.snap
@@ -11,6 +11,9 @@ exports[`generator - gradle with empty configuration should generate only gradle
   "buildSrc/gradle/libs.versions.toml": {
     "stateCleared": "modified",
   },
+  "gradle/libs.versions.toml": {
+    "stateCleared": "modified",
+  },
   "gradle/wrapper/gradle-wrapper.jar": {
     "stateCleared": "modified",
   },
@@ -35,6 +38,9 @@ exports[`generator - gradle with valid configuration should generate only gradle
     "stateCleared": "modified",
   },
   "buildSrc/gradle/libs.versions.toml": {
+    "stateCleared": "modified",
+  },
+  "gradle/libs.versions.toml": {
     "stateCleared": "modified",
   },
   "gradle/wrapper/gradle-wrapper.jar": {

--- a/generators/gradle/files.ts
+++ b/generators/gradle/files.ts
@@ -20,7 +20,12 @@
 export default {
   gradle: [
     {
-      templates: ['.prettierignore.jhi.gradle', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/build.gradle'],
+      templates: [
+        '.prettierignore.jhi.gradle',
+        'gradle/wrapper/gradle-wrapper.properties',
+        'buildSrc/build.gradle',
+        'buildSrc/gradle/libs.versions.toml',
+      ],
     },
     {
       transform: false,

--- a/generators/gradle/files.ts
+++ b/generators/gradle/files.ts
@@ -25,6 +25,7 @@ export default {
         'gradle/wrapper/gradle-wrapper.properties',
         'buildSrc/build.gradle',
         'buildSrc/gradle/libs.versions.toml',
+        'gradle/libs.versions.toml',
       ],
     },
     {

--- a/generators/gradle/generator.ts
+++ b/generators/gradle/generator.ts
@@ -33,6 +33,7 @@ import {
   addGradlePluginManagementCallback,
   addGradlePropertyCallback,
   addGradleBuildSrcDependencyCallback,
+  addGradleBuildSrcCatalogVersionCallback,
 } from './internal/needles.js';
 
 export default class GradleGenerator extends BaseApplicationGenerator {
@@ -76,6 +77,8 @@ export default class GradleGenerator extends BaseApplicationGenerator {
         source.addGradleProperty = property => this.editFile('gradle.properties', addGradlePropertyCallback(property));
         source.addGradleBuildSrcDependency = dependency =>
           this.editFile('buildSrc/build.gradle', addGradleBuildSrcDependencyCallback(dependency));
+        source.addGradleBuildSrcCatalogVersion = version =>
+          this.editFile('buildSrc/gradle/libs.versions.toml', addGradleBuildSrcCatalogVersionCallback(version));
       },
     });
   }

--- a/generators/gradle/generator.ts
+++ b/generators/gradle/generator.ts
@@ -24,6 +24,7 @@ import BaseApplicationGenerator from '../base-application/index.js';
 import { GENERATOR_GRADLE, GENERATOR_BOOTSTRAP_APPLICATION_SERVER } from '../generator-list.js';
 import files from './files.js';
 import { GRADLE } from './constants.js';
+import { GRADLE_BUILD_SRC_DIR } from '../generator-constants.js';
 import cleanupOldServerFilesTask from './cleanup.js';
 import {
   applyFromGradleCallback,
@@ -33,7 +34,8 @@ import {
   addGradlePluginManagementCallback,
   addGradlePropertyCallback,
   addGradleBuildSrcDependencyCallback,
-  addGradleBuildSrcCatalogVersionCallback,
+  addGradleDependencyCatalogVersionCallback,
+  addGradleBuildSrcDependencyCatalogVersionCallback,
 } from './internal/needles.js';
 
 export default class GradleGenerator extends BaseApplicationGenerator {
@@ -76,9 +78,11 @@ export default class GradleGenerator extends BaseApplicationGenerator {
         source.addGradlePluginManagement = plugin => this.editFile('settings.gradle', addGradlePluginManagementCallback(plugin));
         source.addGradleProperty = property => this.editFile('gradle.properties', addGradlePropertyCallback(property));
         source.addGradleBuildSrcDependency = dependency =>
-          this.editFile('buildSrc/build.gradle', addGradleBuildSrcDependencyCallback(dependency));
-        source.addGradleBuildSrcCatalogVersion = version =>
-          this.editFile('buildSrc/gradle/libs.versions.toml', addGradleBuildSrcCatalogVersionCallback(version));
+          this.editFile(`${GRADLE_BUILD_SRC_DIR}/build.gradle`, addGradleBuildSrcDependencyCallback(dependency));
+        source.addGradleDependencyCatalogVersion = version =>
+          this.editFile('gradle/libs.versions.toml', addGradleDependencyCatalogVersionCallback(version));
+        source.addGradleBuildSrcDependencyCatalogVersion = version =>
+          this.editFile(`${GRADLE_BUILD_SRC_DIR}/gradle/libs.versions.toml`, addGradleBuildSrcDependencyCatalogVersionCallback(version));
       },
     });
   }

--- a/generators/gradle/internal/needles.ts
+++ b/generators/gradle/internal/needles.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { createNeedleCallback } from '../../base/support/index.js';
-import { GradleScript, GradleDependency, GradlePlugin, GradleProperty, GradleRepository } from '../types.js';
+import { GradleScript, GradleDependency, GradlePlugin, GradleProperty, GradleRepository, GradleTomlVersion } from '../types.js';
 
 export const applyFromGradleCallback = ({ script }: GradleScript) =>
   createNeedleCallback({
@@ -35,6 +35,12 @@ export const addGradleBuildSrcDependencyCallback = ({ groupId, artifactId, versi
   createNeedleCallback({
     needle: 'gradle-build-src-dependency',
     contentToAdd: `${scope} "${groupId}:${artifactId}${version ? `:${version}` : ''}"`,
+  });
+
+export const addGradleBuildSrcCatalogVersionCallback = ({ name, version }: GradleTomlVersion) =>
+  createNeedleCallback({
+    needle: 'gradle-build-src-catalog-version',
+    contentToAdd: `${name} = "${version}"`,
   });
 
 export const addGradlePluginCallback = ({ id, version }: GradlePlugin) =>

--- a/generators/gradle/internal/needles.ts
+++ b/generators/gradle/internal/needles.ts
@@ -37,12 +37,17 @@ export const addGradleBuildSrcDependencyCallback = ({ groupId, artifactId, versi
     contentToAdd: `${scope} "${groupId}:${artifactId}${version ? `:${version}` : ''}"`,
   });
 
-export const addGradleBuildSrcCatalogVersionCallback = ({ name, version }: GradleTomlVersion) =>
+export const addGradleDependencyCatalogVersionCallback = ({ name, version }: GradleTomlVersion) =>
   createNeedleCallback({
-    needle: 'gradle-build-src-catalog-version',
+    needle: 'gradle-dependency-catalog-version',
     contentToAdd: `${name} = "${version}"`,
   });
 
+export const addGradleBuildSrcDependencyCatalogVersionCallback = ({ name, version }: GradleTomlVersion) =>
+  createNeedleCallback({
+    needle: 'gradle-build-src-dependency-catalog-version',
+    contentToAdd: `${name} = "${version}"`,
+  });
 export const addGradlePluginCallback = ({ id, version }: GradlePlugin) =>
   createNeedleCallback({
     needle: 'gradle-plugins',

--- a/generators/gradle/needles.spec.ts
+++ b/generators/gradle/needles.spec.ts
@@ -20,6 +20,7 @@ class mockBlueprintSubGen extends BaseApplicationGenerator {
         source.applyFromGradle?.({ script: 'name.gradle' });
         source.addGradleMavenRepository?.({ url: 'url', username: 'username', password: 'password' });
         source.addGradleBuildSrcDependency?.({ scope: 'scope5', groupId: 'group5', artifactId: 'name5', version: 'version5' });
+        source.addGradleBuildSrcCatalogVersion?.({ name: 'version-name', version: 'version' });
       },
     });
   }
@@ -76,5 +77,9 @@ describe('needle API server gradle: JHipster server generator with blueprint', (
 
   it('Assert buildSrc/build.gradle has the Dependency with version added', () => {
     runResult.assertFileContent('buildSrc/build.gradle', 'scope5 "group5:name5:version5"');
+  });
+
+  it('Assert buildSrc/gradle/libs.versions.toml has the version added', () => {
+    runResult.assertFileContent('buildSrc/gradle/libs.versions.toml', 'version-name = "version"');
   });
 });

--- a/generators/gradle/needles.spec.ts
+++ b/generators/gradle/needles.spec.ts
@@ -20,7 +20,8 @@ class mockBlueprintSubGen extends BaseApplicationGenerator {
         source.applyFromGradle?.({ script: 'name.gradle' });
         source.addGradleMavenRepository?.({ url: 'url', username: 'username', password: 'password' });
         source.addGradleBuildSrcDependency?.({ scope: 'scope5', groupId: 'group5', artifactId: 'name5', version: 'version5' });
-        source.addGradleBuildSrcCatalogVersion?.({ name: 'version-name', version: 'version' });
+        source.addGradleDependencyCatalogVersion?.({ name: 'version-name', version: 'version' });
+        source.addGradleBuildSrcDependencyCatalogVersion?.({ name: 'version-name', version: 'version' });
       },
     });
   }
@@ -77,6 +78,10 @@ describe('needle API server gradle: JHipster server generator with blueprint', (
 
   it('Assert buildSrc/build.gradle has the Dependency with version added', () => {
     runResult.assertFileContent('buildSrc/build.gradle', 'scope5 "group5:name5:version5"');
+  });
+
+  it('Assert gradle/libs.versions.toml has the version added', () => {
+    runResult.assertFileContent('gradle/libs.versions.toml', 'version-name = "version"');
   });
 
   it('Assert buildSrc/gradle/libs.versions.toml has the version added', () => {

--- a/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
+++ b/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
@@ -1,2 +1,2 @@
 [versions]
-#jhipster-needle-gradle-build-src-catalog-version - JHipster will add additional versions for convention plugins here
+# jhipster-needle-gradle-build-src-catalog-version - JHipster will add additional versions for convention plugins here

--- a/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
+++ b/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
@@ -1,2 +1,2 @@
 [versions]
-# jhipster-needle-gradle-build-src-catalog-version - JHipster will add additional versions for convention plugins here
+# jhipster-needle-gradle-build-src-dependency-catalog-version - JHipster will add additional versions for convention plugins here

--- a/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
+++ b/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
@@ -1,2 +1,2 @@
 [versions]
-// jhipster-needle-gradle-build-src-catalog-version - JHipster will add additional versions for convention plugins here
+#jhipster-needle-gradle-build-src-catalog-version - JHipster will add additional versions for convention plugins here

--- a/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
+++ b/generators/gradle/templates/buildSrc/gradle/libs.versions.toml.ejs
@@ -1,0 +1,2 @@
+[versions]
+// jhipster-needle-gradle-build-src-catalog-version - JHipster will add additional versions for convention plugins here

--- a/generators/gradle/templates/gradle/libs.versions.toml.ejs
+++ b/generators/gradle/templates/gradle/libs.versions.toml.ejs
@@ -1,0 +1,2 @@
+[versions]
+# jhipster-needle-gradle-dependency-catalog-version - JHipster will add additional versions for convention plugins here

--- a/generators/gradle/types.d.ts
+++ b/generators/gradle/types.d.ts
@@ -8,7 +8,7 @@ export type GradleProperty = { property: string; value: string };
 
 export type GradleRepository = { url: string; username?: string; password?: string };
 
-export type GradleTomlVersion = { name: string; version: string };
+export type GradleTomlVersion = { name: string; version?: string };
 
 export type GradleSourceType = {
   applyFromGradle?(script: GradleScript): void;

--- a/generators/gradle/types.d.ts
+++ b/generators/gradle/types.d.ts
@@ -18,5 +18,6 @@ export type GradleSourceType = {
   addGradleProperty?(property: GradleProperty): void;
   addGradleMavenRepository?(repository: GradleRepository): void;
   addGradleBuildSrcDependency?(dependency: GradleDependency): void;
-  addGradleBuildSrcCatalogVersion?(catalogVersion: GradleTomlVersion): void;
+  addGradleDependencyCatalogVersion?(catalogVersion: GradleTomlVersion): void;
+  addGradleBuildSrcDependencyCatalogVersion?(catalogVersion: GradleTomlVersion): void;
 };

--- a/generators/gradle/types.d.ts
+++ b/generators/gradle/types.d.ts
@@ -8,6 +8,8 @@ export type GradleProperty = { property: string; value: string };
 
 export type GradleRepository = { url: string; username?: string; password?: string };
 
+export type GradleTomlVersion = { name: string; version: string };
+
 export type GradleSourceType = {
   applyFromGradle?(script: GradleScript): void;
   addGradleDependency?(dependency: GradleDependency): void;
@@ -16,4 +18,5 @@ export type GradleSourceType = {
   addGradleProperty?(property: GradleProperty): void;
   addGradleMavenRepository?(repository: GradleRepository): void;
   addGradleBuildSrcDependency?(dependency: GradleDependency): void;
+  addGradleBuildSrcCatalogVersion?(catalogVersion: GradleTomlVersion): void;
 };

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -35,9 +35,6 @@ plugins {
     id "com.diffplug.spotless"
     id "io.spring.nohttp"
     id "com.github.andygoossens.gradle-modernizer-plugin"
-<%_ if (gatlingTests) { _%>
-    id "io.gatling.gradle"
-<%_ } _%>
     // jhipster-needle-gradle-plugins - JHipster will add additional gradle plugins here
 }
 
@@ -147,19 +144,6 @@ test {
 <%_ } _%>
 }
 
-<%_ if (gatlingTests) { _%>
-sourceSets {
-    gatling {
-        java.srcDirs = ["src/test/java/gatling/simulations"]
-        resources.srcDirs = ["src/test/gatling/conf"]
-    }
-}
-
-gatling {
-    simulations = { include "**/*Test*.java" }
-}
-
-<%_ } _%>
 modernizer {
     failOnViolations = true
     includeTestClasses = true
@@ -451,9 +435,6 @@ if (addSpringMilestoneRepository) { _%>
     testImplementation "io.cucumber:cucumber-spring"
     testImplementation "org.junit.platform:junit-platform-console"
     testImplementation "org.testng:testng"
-<%_ } _%>
-<%_ if (gatlingTests) { _%>
-    testImplementation "io.gatling.highcharts:gatling-charts-highcharts:${gatlingVersion}"
 <%_ } _%>
 <%_ if (databaseTypeCassandra) { _%>
     annotationProcessor "com.datastax.oss:java-driver-mapper-processor:${cassandraDriverVersion}"

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -84,10 +84,6 @@ gradleCommonCustomUserDataPluginVersion=<%- javaDependencies['common-custom-user
 <%_ if (searchEngineElasticsearch) { _%>
 awaitilityVersion=<%- javaDependencies.awaitility %>
 <%_ } _%>
-<%_ if (gatlingTests) { _%>
-gatlingVersion=<%- javaDependencies.gatling %>
-gatlingPluginVersion=<%- javaDependencies['gatling-gradle'] %>
-<%_ } _%>
 
 # jhipster-needle-gradle-property - JHipster will add additional properties here
 

--- a/generators/server/templates/settings.gradle.ejs
+++ b/generators/server/templates/settings.gradle.ejs
@@ -44,9 +44,6 @@ pluginManagement {
         id "com.gradle.enterprise" version "${gradleEnterprisePluginVersion}"
         id "com.gradle.common-custom-user-data-gradle-plugin" version "${gradleCommonCustomUserDataPluginVersion}"
 <%_ } _%>
-<%_ if (gatlingTests) { _%>
-        id "io.gatling.gradle" version "${gatlingPluginVersion}"
-<%_ } _%>
         // jhipster-needle-gradle-plugin-management-plugins - JHipster will add additional entries here
     }
 }


### PR DESCRIPTION
This is the first and initial part to use gradle convention plugins and mostly replace the current apply from approach.

The gatling generator now creates a convention plugin in `buildSrc` and applied it to main `build.gradle`. Dependencies and configurations are encapsulated in the convention plugin.

Open points I would like to fix are mostly (snapshot) tests

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
