### PR TITLE
[gradle] add gradle cucumber convention plugin

### DIFF
--- a/generators/cucumber/__snapshots__/generator.spec.ts.snap
+++ b/generators/cucumber/__snapshots__/generator.spec.ts.snap
@@ -148,3 +148,194 @@ public class UserStepDefs extends StepDefs {
   },
 }
 `;
+
+exports[`generator - cucumber with gradle build tool should match files snapshot 1`] = `
+{
+  ".yo-rc.json": {
+    "contents": "{
+  "generator-jhipster": {
+    "baseName": "jhipster",
+    "buildTool": "gradle",
+    "creationTimestamp": 1577836800000,
+    "entities": [],
+    "testFrameworks": [
+      "cucumber"
+    ]
+  }
+}
+",
+    "stateCleared": "modified",
+  },
+  "buildSrc/src/main/groovy/jhipster.cucumber-conventions.gradle": {
+    "contents": "dependencies {
+    testImplementation "io.cucumber:cucumber-junit-platform-engine"
+    testImplementation "io.cucumber:cucumber-java"
+    testImplementation "io.cucumber:cucumber-spring"
+    testImplementation "org.junit.platform:junit-platform-console"
+    testImplementation "org.testng:testng"
+}
+
+tasks.register('consoleLauncherTest', JavaExec) {
+    dependsOn(testClasses)
+    String cucumberReportsDir = file("$buildDir/reports/tests")
+    outputs.dir(reportsDir)
+    classpath = sourceSets["test"].runtimeClasspath
+    main = "org.junit.platform.console.ConsoleLauncher"
+    args("--scan-classpath")
+    args("--include-engine", "cucumber")
+    args("--reports-dir", cucumberReportsDir)
+}
+
+tasks.register('cucumberTest', Test) {
+    dependsOn(consoleLauncherTest)
+    description = "Execute cucumber BDD tests."
+    group = "verification"
+    include "**/*CucumberIT*"
+
+    // uncomment if the tests reports are not generated
+    // see https://github.com/jhipster/generator-jhipster/pull/2771 and https://github.com/jhipster/generator-jhipster/pull/4484
+    // ignoreFailures true
+    reports.html.required = false
+}
+
+tasks.register('cucumberTestReport', TestReport) {
+    destinationDirectory = file("$buildDir/reports/tests")
+    testResults.from(cucumberTest)
+}
+
+check.dependsOn cucumberTest
+",
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/cucumber/CucumberIT.java": {
+    "contents": "package com.mycompany.myapp.cucumber;
+
+import com.mycompany.myapp.IntegrationTest;
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+@IntegrationTest
+class CucumberIT {
+
+}
+",
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/cucumber/CucumberTestContextConfiguration.java": {
+    "contents": "package com.mycompany.myapp.cucumber;
+
+import com.mycompany.myapp.IntegrationTest;
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@CucumberContextConfiguration
+@IntegrationTest
+@WebAppConfiguration
+public class CucumberTestContextConfiguration {
+
+}
+",
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/cucumber/stepdefs/StepDefs.java": {
+    "contents": "package com.mycompany.myapp.cucumber.stepdefs;
+
+import org.springframework.test.web.servlet.ResultActions;
+
+public abstract class StepDefs {
+
+    protected ResultActions actions;
+
+}
+",
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/cucumber/stepdefs/UserStepDefs.java": {
+    "contents": "package com.mycompany.myapp.cucumber.stepdefs;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+import com.mycompany.myapp.web.rest.UserResource;
+import com.mycompany.myapp.security.AuthoritiesConstants;
+
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class UserStepDefs extends StepDefs {
+
+    @Autowired
+    private UserResource userResource;
+
+    private MockMvc userResourceMock;
+
+    @Before
+    public void setup() {
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority(AuthoritiesConstants.ADMIN));
+        User principal = new User("admin", "", true, true, true, true, grantedAuthorities);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+            principal,
+            principal.getPassword(),
+            principal.getAuthorities()
+        );
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+        this.userResourceMock = MockMvcBuilders.standaloneSetup(userResource).build();
+    }
+
+    @When("I search user {string}")
+    public void i_search_user(String userId) throws Throwable {
+        actions = userResourceMock.perform(get("/api/admin/users/" + userId).accept(MediaType.APPLICATION_JSON));
+    }
+
+    @Then("the user is found")
+    public void the_user_is_found() throws Throwable {
+        actions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @Then("his last name is {string}")
+    public void his_last_name_is(String lastName) throws Throwable {
+        actions.andExpect(jsonPath("$.lastName").value(lastName));
+    }
+
+}
+",
+    "stateCleared": "modified",
+  },
+  "src/test/resources/com/mycompany/myapp/cucumber/gitkeep": {
+    "contents": "",
+    "stateCleared": "modified",
+  },
+  "src/test/resources/com/mycompany/myapp/cucumber/user.feature": {
+    "contents": "Feature: User management
+
+    Scenario: Retrieve administrator user
+        When I search user 'admin'
+        Then the user is found
+        And his last name is 'Administrator'
+",
+    "stateCleared": "modified",
+  },
+}
+`;

--- a/generators/cucumber/files.ts
+++ b/generators/cucumber/files.ts
@@ -18,7 +18,7 @@
  */
 import Generator from './generator.js';
 import { moveToJavaPackageTestDir } from '../server/support/index.js';
-import { SERVER_TEST_SRC_DIR, SERVER_TEST_RES_DIR } from '../generator-constants.js';
+import { SERVER_TEST_SRC_DIR, SERVER_TEST_RES_DIR, GRADLE_BUILD_SRC_MAIN_DIR } from '../generator-constants.js';
 import { WriteFileSection } from '../base/api.js';
 import { CommonClientServerApplication } from '../base-application/types.js';
 
@@ -50,6 +50,11 @@ const cucumberFiles: WriteFileSection<Generator, CommonClientServerApplication> 
       path: `${SERVER_TEST_RES_DIR}_package_/`,
       renameTo: (data, filename) => `${data.srcTestResources}${data.packageFolder}${filename}`,
       templates: ['cucumber/user.feature'],
+    },
+    {
+      condition: generator => generator.buildToolGradle,
+      path: GRADLE_BUILD_SRC_MAIN_DIR,
+      templates: ['jhipster.cucumber-conventions.gradle'],
     },
   ],
 };

--- a/generators/cucumber/generator.spec.ts
+++ b/generators/cucumber/generator.spec.ts
@@ -32,4 +32,14 @@ describe(`generator - ${generator}`, () => {
       expect(result.getSnapshot()).toMatchSnapshot();
     });
   });
+
+  describe('with gradle build tool', () => {
+    before(async () => {
+      await helpers.runJHipster(GENERATOR_CUCUMBER).withJHipsterConfig({ buildTool: 'gradle', testFrameworks: ['cucumber'] });
+    });
+
+    it('should match files snapshot', () => {
+      expect(result.getSnapshot()).toMatchSnapshot();
+    });
+  });
 });

--- a/generators/cucumber/generator.ts
+++ b/generators/cucumber/generator.ts
@@ -98,6 +98,10 @@ export default class CucumberGenerator extends BaseApplicationGenerator {
             ],
           });
         }
+
+        if (application.buildToolGradle) {
+          source.addGradlePlugin?.({ id: 'jhipster.cucumber-conventions' });
+        }
       },
     });
   }

--- a/generators/cucumber/templates/buildSrc/src/main/groovy/jhipster.cucumber-conventions.gradle.ejs
+++ b/generators/cucumber/templates/buildSrc/src/main/groovy/jhipster.cucumber-conventions.gradle.ejs
@@ -1,0 +1,37 @@
+dependencies {
+    testImplementation "io.cucumber:cucumber-junit-platform-engine"
+    testImplementation "io.cucumber:cucumber-java"
+    testImplementation "io.cucumber:cucumber-spring"
+    testImplementation "org.junit.platform:junit-platform-console"
+    testImplementation "org.testng:testng"
+}
+
+tasks.register('consoleLauncherTest', JavaExec) {
+    dependsOn(testClasses)
+    String cucumberReportsDir = file("$buildDir/reports/tests")
+    outputs.dir(reportsDir)
+    classpath = sourceSets["test"].runtimeClasspath
+    main = "org.junit.platform.console.ConsoleLauncher"
+    args("--scan-classpath")
+    args("--include-engine", "cucumber")
+    args("--reports-dir", cucumberReportsDir)
+}
+
+tasks.register('cucumberTest', Test) {
+    dependsOn(consoleLauncherTest)
+    description = "Execute cucumber BDD tests."
+    group = "verification"
+    include "**/*CucumberIT*"
+
+    // uncomment if the tests reports are not generated
+    // see https://github.com/jhipster/generator-jhipster/pull/2771 and https://github.com/jhipster/generator-jhipster/pull/4484
+    // ignoreFailures true
+    reports.html.required = false
+}
+
+tasks.register('cucumberTestReport', TestReport) {
+    destinationDirectory = file("$buildDir/reports/tests")
+    testResults.from(cucumberTest)
+}
+
+check.dependsOn cucumberTest

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -149,35 +149,6 @@ modernizer {
     includeTestClasses = true
 }
 
-
-<%_ if (cucumberTests) { _%>
-
-task consoleLauncherTest(type: JavaExec) {
-    dependsOn(testClasses)
-    String cucumberReportsDir = file("$buildDir/reports/tests")
-    outputs.dir(reportsDir)
-    classpath = sourceSets["test"].runtimeClasspath
-    main = "org.junit.platform.console.ConsoleLauncher"
-    args("--scan-classpath")
-    args("--include-engine", "cucumber")
-    args("--reports-dir", cucumberReportsDir)
-}
-
-task cucumberTest(type: Test) {
-    dependsOn(consoleLauncherTest)
-    description = "Execute cucumber BDD tests."
-    group = "verification"
-    include "**/*CucumberIT*"
-
-    // uncomment if the tests reports are not generated
-    // see https://github.com/jhipster/generator-jhipster/pull/2771 and https://github.com/jhipster/generator-jhipster/pull/4484
-    // ignoreFailures true
-    reports.html.required = false
-}
-
-check.dependsOn cucumberTest
-<%_ } _%>
-
 check.dependsOn integrationTest
 task testReport(type: TestReport) {
     destinationDirectory = file("$buildDir/reports/tests")
@@ -189,13 +160,6 @@ task integrationTestReport(type: TestReport) {
     testResults.from(integrationTest)
 }
 
-<%_ if (cucumberTests) { _%>
-task cucumberTestReport(type: TestReport) {
-    destinationDirectory = file("$buildDir/reports/tests")
-    testResults.from(cucumberTest)
-}
-
-<%_ } _%>
 gitProperties {
     failOnNoGitDirectory = false
     keys = ["git.branch", "git.commit.id.abbrev", "git.commit.id.describe"]
@@ -428,13 +392,6 @@ if (addSpringMilestoneRepository) { _%>
     implementation "io.dropwizard.metrics:metrics-core"
 <%_ if (communicationSpringWebsocket) { _%>
     implementation "org.springframework.security:spring-security-messaging"
-<%_ } _%>
-<%_ if (cucumberTests) { _%>
-    testImplementation "io.cucumber:cucumber-junit-platform-engine"
-    testImplementation "io.cucumber:cucumber-java"
-    testImplementation "io.cucumber:cucumber-spring"
-    testImplementation "org.junit.platform:junit-platform-console"
-    testImplementation "org.testng:testng"
 <%_ } _%>
 <%_ if (databaseTypeCassandra) { _%>
     annotationProcessor "com.datastax.oss:java-driver-mapper-processor:${cassandraDriverVersion}"


### PR DESCRIPTION
This uses the newly introduced convention plugin mechanism and creates a cucumber convention plugin (instead of if constructs and direct configuration in the main `build.gradle`).

updates #19615


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
