### PR TITLE
[Angular] Missing some translations for health.status.OUT_OF_SERVICE

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/al/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/al/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ar-ly/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ar-ly/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "تشتغل",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "عاطلة"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/az-Latn-az/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/az-Latn-az/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "AKTİV",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DEAKTİV"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/bg/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/bg/health.json.ejs
@@ -66,6 +66,9 @@
         "status": {
             "UNKNOWN": "НЕИЗВЕСТЕН",
             "UP": "АКТИВНА",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "НЕАКТИВНА"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/bn/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/by/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/by/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ca/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "ACTIU",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "INACTIU"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/cs/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "Spuštěno",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "Zastaveno"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/da/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/da/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "OP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "NED"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/de/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/de/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/el/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/el/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "ΠΑΝΩ",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "ΚΑΤΩ"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/es/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/es/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "DESCONOCIDO",
             "UP": "LEVANTADO",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "CAÍDO"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/et/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/et/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/fa/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/fi/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fi/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "Tuntematon",
             "UP": "Käynnissä",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "sammunut"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/fr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "INCONNU",
             "UP": "DISPONIBLE",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "HORS SERVICE"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/gl/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/health.json.ejs
@@ -63,6 +63,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "LEVANTADO",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "CAÍDO"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/hi/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "अज्ञात स्थिति",
             "UP": "ऊपर",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "नीचे"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/hr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hr/health.json.ejs
@@ -62,6 +62,9 @@
         "status": {
             "UNKNOWN": "NEPOZNAT",
             "UP": "DIGNUT",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "SPUŠTEN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/hu/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "MŰKÖDIK",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "NEM MŰKÖDIK"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/hy/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hy/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/id/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/id/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "BAIK",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "BERMASALAH"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/it/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/it/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "DISPONIBILE",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "NON DISPONIBILE"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ja/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ja/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ko/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "사용할 수",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "서비스 중"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/kr-Latn-kr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/kr-Latn-kr/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "Aktiv",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "Aktiv emes"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/mr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "वर",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "खाली"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/my/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/my/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/nl/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/pa/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pa/health.json.ejs
@@ -65,6 +65,9 @@
         "status": {
             "UNKNOWN": "ਅਣਜਾਣ",
             "UP": "ਚਾਲੂ",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "ਬੰਦ"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "DESCONHECIDO",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ro/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "Sus",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "Jos"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ru/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/si/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/si/health.json.ejs
@@ -65,6 +65,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/sk/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sk/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "Spustené",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "Zastavené"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/sr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sr/health.json.ejs
@@ -63,6 +63,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "AKTIVAN",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "NEAKTIVAN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/sv/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UPP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "NED"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ta/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "மேல்",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "கீழ்"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/te/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/te/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "UP",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DOWN"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/th/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/th/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "ขึ้น",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "ลง"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/tr/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "AKTİF",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "DEAKTİF"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/ua/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ua/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "ПРАЦЮЄ",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "НЕ ПРАЦЮЄ"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/health.json.ejs
@@ -62,7 +62,11 @@
             "status": "Ҳолат"
         },
         "status": {
+            "UNKNOWN": "UNKNOWN",
             "UP": "ФАОЛ",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "ФАОЛ ЭМАС"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "Faol",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "Faol emas"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/vi/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/vi/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "Đang hoạt động",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "Đã tắt"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "UNKNOWN",
             "UP": "正常",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "异常"
         }
     }

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/health.json.ejs
@@ -64,6 +64,9 @@
         "status": {
             "UNKNOWN": "不明",
             "UP": "正常",
+<%_ if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_ } _%>
             "DOWN": "異常"
         }
     }


### PR DESCRIPTION
Fix #24650 

Translations ok just for `en` and `pl`
https://github.com/jhipster/generator-jhipster/blob/c37ed378048db3eb551f093ad8463272cd92bab2/generators/languages/templates/src/main/webapp/i18n/en/health.json.ejs#L68
https://github.com/jhipster/generator-jhipster/blob/c37ed378048db3eb551f093ad8463272cd92bab2/generators/languages/templates/src/main/webapp/i18n/pl/health.json.ejs#L68


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
