### PR TITLE
extract gradle jib config to dedicated conventions plugin

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -311,12 +311,12 @@ export const baseServerFiles = {
         'build.gradle',
         'settings.gradle',
         'gradle.properties',
-        'gradle/docker.gradle',
         'gradle/profile_dev.gradle',
         'gradle/profile_prod.gradle',
         'gradle/war.gradle',
         'gradle/zipkin.gradle',
         `${GRADLE_BUILD_SRC_MAIN_DIR}/jhipster.code-quality-conventions.gradle`,
+        `${GRADLE_BUILD_SRC_MAIN_DIR}/jhipster.docker-conventions.gradle`,
       ],
     },
     {

--- a/generators/server/generator.js
+++ b/generators/server/generator.js
@@ -772,6 +772,11 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
           name: 'nohttp-plugin',
           version: application.javaDependencies?.['nohttp-checkstyle'],
         });
+        source.addGradleDependencyCatalogVersion?.({ name: 'jib-plugin', version: application.javaDependencies?.['jib-maven-plugin'] });
+        source.addGradleBuildSrcDependencyCatalogVersion?.({
+          name: 'jib-plugin',
+          version: application.javaDependencies?.['jib-maven-plugin'],
+        });
         source.addGradleBuildSrcDependency?.({
           groupId: 'org.sonarsource.scanner.gradle',
           artifactId: 'sonarqube-gradle-plugin',
@@ -800,7 +805,15 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
           version: '${libs.versions.nohttp.plugin.get()}',
           scope: 'implementation',
         });
+        source.addGradleBuildSrcDependency?.({
+          groupId: 'com.google.cloud.tools',
+          artifactId: 'jib-gradle-plugin',
+          // eslint-disable-next-line no-template-curly-in-string
+          version: '${libs.versions.jib.plugin.get()}',
+          scope: 'implementation',
+        });
         source.addGradlePlugin?.({ id: 'jhipster.code-quality-conventions' });
+        source.addGradlePlugin?.({ id: 'jhipster.docker-conventions ' });
       },
       packageJsonScripts({ application }) {
         const packageJsonConfigStorage = this.packageJson.createStorage('config').createProxy();

--- a/generators/server/generator.js
+++ b/generators/server/generator.js
@@ -813,7 +813,7 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
           scope: 'implementation',
         });
         source.addGradlePlugin?.({ id: 'jhipster.code-quality-conventions' });
-        source.addGradlePlugin?.({ id: 'jhipster.docker-conventions ' });
+        source.addGradlePlugin?.({ id: 'jhipster.docker-conventions' });
       },
       packageJsonScripts({ application }) {
         const packageJsonConfigStorage = this.packageJson.createStorage('config').createProxy();

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -22,7 +22,6 @@ plugins {
     id "idea"
     id "eclipse"
     id "org.springframework.boot"
-    id "com.google.cloud.tools.jib"
     id "com.gorylenko.gradle-git-properties"
 <%_ if (enableSwaggerCodegen) { _%>
     id "org.openapi.generator"
@@ -52,7 +51,6 @@ ext {
     }
 }
 
-apply from: "gradle/docker.gradle"
 <%_ if (enableSwaggerCodegen) { _%>
 apply from: "gradle/swagger.gradle"
 <%_ } _%>

--- a/generators/server/templates/buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle.ejs
+++ b/generators/server/templates/buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle.ejs
@@ -1,3 +1,21 @@
+<%#
+ Copyright 2013-2023 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 plugins {
     id "jacoco"
     id "org.sonarqube"

--- a/generators/server/templates/buildSrc/src/main/groovy/jhipster.docker-conventions.gradle.ejs
+++ b/generators/server/templates/buildSrc/src/main/groovy/jhipster.docker-conventions.gradle.ejs
@@ -16,6 +16,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+plugins {
+    id "com.google.cloud.tools.jib"
+}
+
 jib {
     from {
         image = "<%- dockerContainers.javaJre %>"
@@ -47,4 +51,3 @@ jib {
       permissions = ["/entrypoint.sh": "755"]
     }
 }
-

--- a/generators/spring-data-cassandra/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-data-cassandra/__snapshots__/generator.spec.ts.snap
@@ -23,13 +23,13 @@ exports[`generator - cassandra gateway-jwt-gradle-enableTranslation(true)-com.pa
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -828,13 +828,13 @@ exports[`generator - cassandra microservice-jwt-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1181,13 +1181,13 @@ exports[`generator - cassandra microservice-oauth2-reactive(true)-gradle-enableT
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1995,13 +1995,13 @@ exports[`generator - cassandra monolith-jwt-reactive(true)-gradle-enableTranslat
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2725,13 +2725,13 @@ exports[`generator - cassandra monolith-oauth2-reactive(true)-gradle-enableTrans
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -3548,13 +3548,13 @@ exports[`generator - cassandra monolith-session-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {

--- a/generators/spring-data-couchbase/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-data-couchbase/__snapshots__/generator.spec.ts.snap
@@ -23,13 +23,13 @@ exports[`generator - couchbase gateway-jwt-gradle-enableTranslation(true)-com.pa
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -852,13 +852,13 @@ exports[`generator - couchbase microservice-jwt-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1208,13 +1208,13 @@ exports[`generator - couchbase microservice-oauth2-reactive(true)-gradle-enableT
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2037,13 +2037,13 @@ exports[`generator - couchbase monolith-jwt-reactive(true)-gradle-enableTranslat
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2773,13 +2773,13 @@ exports[`generator - couchbase monolith-oauth2-reactive(true)-gradle-enableTrans
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -3617,13 +3617,13 @@ exports[`generator - couchbase monolith-session-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {

--- a/generators/spring-data-elasticsearch/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-data-elasticsearch/__snapshots__/generator.spec.ts.snap
@@ -29,13 +29,13 @@ exports[`generator - elasticsearch gateway-jwt-gradle-enableTranslation(true)-co
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -945,13 +945,13 @@ exports[`generator - elasticsearch microservice-jwt-reactive(true)-gradle-enable
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1358,13 +1358,13 @@ exports[`generator - elasticsearch microservice-oauth2-reactive(true)-gradle-ena
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2274,13 +2274,13 @@ exports[`generator - elasticsearch monolith-jwt-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -3145,13 +3145,13 @@ exports[`generator - elasticsearch monolith-oauth2-reactive(true)-gradle-enableT
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -4121,13 +4121,13 @@ exports[`generator - elasticsearch monolith-session-reactive(true)-gradle-enable
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {

--- a/generators/spring-data-mongodb/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-data-mongodb/__snapshots__/generator.spec.ts.snap
@@ -23,13 +23,13 @@ exports[`generator - mongodb gateway-jwt-gradle-enableTranslation(true)-com.pack
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -810,13 +810,13 @@ exports[`generator - mongodb microservice-jwt-reactive(true)-gradle-enableTransl
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1151,13 +1151,13 @@ exports[`generator - mongodb microservice-oauth2-reactive(true)-gradle-enableTra
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1944,13 +1944,13 @@ exports[`generator - mongodb monolith-jwt-reactive(true)-gradle-enableTranslatio
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2650,13 +2650,13 @@ exports[`generator - mongodb monolith-oauth2-reactive(true)-gradle-enableTransla
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -3452,13 +3452,13 @@ exports[`generator - mongodb monolith-session-reactive(true)-gradle-enableTransl
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {

--- a/generators/spring-data-neo4j/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-data-neo4j/__snapshots__/generator.spec.ts.snap
@@ -23,13 +23,13 @@ exports[`generator - neo4j gateway-jwt-gradle-enableTranslation(true)-com.packag
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -810,13 +810,13 @@ exports[`generator - neo4j microservice-jwt-reactive(true)-gradle-enableTranslat
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1148,13 +1148,13 @@ exports[`generator - neo4j microservice-oauth2-reactive(true)-gradle-enableTrans
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1944,13 +1944,13 @@ exports[`generator - neo4j monolith-jwt-reactive(true)-gradle-enableTranslation(
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2644,13 +2644,13 @@ exports[`generator - neo4j monolith-oauth2-reactive(true)-gradle-enableTranslati
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -3449,13 +3449,13 @@ exports[`generator - neo4j monolith-session-reactive(true)-gradle-enableTranslat
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {

--- a/generators/spring-data-relational/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-data-relational/__snapshots__/generator.spec.ts.snap
@@ -17,13 +17,13 @@ exports[`generator - sql gateway-jwt-mysql-gradle-enableTranslation(true)-com.pa
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -466,13 +466,13 @@ exports[`generator - sql gateway-jwt-oracle-gradle-enableTranslation(true)-com.p
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -915,13 +915,13 @@ exports[`generator - sql gateway-jwt-postgresql-gradle-enableTranslation(true)-c
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1343,13 +1343,13 @@ exports[`generator - sql gateway-oauth2-mariadb-gradle-enableTranslation(true)-c
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -1720,13 +1720,13 @@ exports[`generator - sql gateway-oauth2-mssql-gradle-enableTranslation(true)-com
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2100,13 +2100,13 @@ exports[`generator - sql microservice-jwt-mariadb-reactive(true)-gradle-enableTr
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2366,13 +2366,13 @@ exports[`generator - sql microservice-jwt-mssql-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -2907,13 +2907,13 @@ exports[`generator - sql microservice-jwt-mysql-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -3439,13 +3439,13 @@ exports[`generator - sql microservice-jwt-oracle-reactive(true)-gradle-enableTra
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -3953,13 +3953,13 @@ exports[`generator - sql microservice-jwt-postgresql-reactive(true)-gradle-enabl
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -4479,13 +4479,13 @@ exports[`generator - sql microservice-oauth2-mariadb-reactive(true)-gradle-enabl
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -4990,13 +4990,13 @@ exports[`generator - sql microservice-oauth2-mssql-reactive(true)-gradle-enableT
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -5247,13 +5247,13 @@ exports[`generator - sql microservice-oauth2-mysql-reactive(true)-gradle-enableT
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -5516,13 +5516,13 @@ exports[`generator - sql microservice-oauth2-oracle-reactive(true)-gradle-enable
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -5779,13 +5779,13 @@ exports[`generator - sql microservice-oauth2-postgresql-reactive(true)-gradle-en
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -6443,13 +6443,13 @@ exports[`generator - sql monolith-jwt-mariadb-reactive(true)-gradle-enableTransl
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -7173,13 +7173,13 @@ exports[`generator - sql monolith-jwt-mssql-reactive(true)-gradle-enableTranslat
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -7897,13 +7897,13 @@ exports[`generator - sql monolith-jwt-mysql-reactive(true)-gradle-enableTranslat
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -8600,13 +8600,13 @@ exports[`generator - sql monolith-jwt-oracle-reactive(true)-gradle-enableTransla
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -9327,13 +9327,13 @@ exports[`generator - sql monolith-jwt-postgresql-reactive(true)-gradle-enableTra
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -9931,13 +9931,13 @@ exports[`generator - sql monolith-oauth2-mariadb-reactive(true)-gradle-enableTra
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -10517,13 +10517,13 @@ exports[`generator - sql monolith-oauth2-mssql-reactive(true)-gradle-enableTrans
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -11127,13 +11127,13 @@ exports[`generator - sql monolith-oauth2-mysql-reactive(true)-gradle-enableTrans
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -11728,13 +11728,13 @@ exports[`generator - sql monolith-oauth2-oracle-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -12311,13 +12311,13 @@ exports[`generator - sql monolith-oauth2-postgresql-reactive(true)-gradle-enable
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -13005,13 +13005,13 @@ exports[`generator - sql monolith-session-mariadb-reactive(true)-gradle-enableTr
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -13663,13 +13663,13 @@ exports[`generator - sql monolith-session-mssql-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -14321,13 +14321,13 @@ exports[`generator - sql monolith-session-mysql-reactive(true)-gradle-enableTran
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -14976,13 +14976,13 @@ exports[`generator - sql monolith-session-oracle-reactive(true)-gradle-enableTra
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {
@@ -15631,13 +15631,13 @@ exports[`generator - sql monolith-session-postgresql-reactive(true)-gradle-enabl
   "buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle": {
     "stateCleared": "modified",
   },
+  "buildSrc/src/main/groovy/jhipster.docker-conventions.gradle": {
+    "stateCleared": "modified",
+  },
   "checkstyle.xml": {
     "stateCleared": "modified",
   },
   "gradle.properties": {
-    "stateCleared": "modified",
-  },
-  "gradle/docker.gradle": {
     "stateCleared": "modified",
   },
   "gradle/profile_dev.gradle": {


### PR DESCRIPTION
the next PR which extracts functions into a dedicated gradle convention plugin instead "apply from" in main build file.

updates #19615


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
