### PR TITLE
Reinstate webflux + mongodb tests

### DIFF
--- a/generators/server/generator.js
+++ b/generators/server/generator.js
@@ -403,6 +403,19 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
           (application.backendType ?? 'Java') === 'Java' &&
           (ADD_SPRING_MILESTONE_REPOSITORY || SPRING_BOOT_VERSION.includes('M') || SPRING_BOOT_VERSION.includes('RC'));
       },
+      blockhound({ application, source }) {
+        source.addAllowBlockingCallsInside = ({ classPath, method }) => {
+          if (!application.reactive) throw new Error('Blockhound is only supported by reactive applications');
+
+          this.editFile(
+            `${application.javaPackageTestDir}config/JHipsterBlockHoundIntegration.java`,
+            createNeedleCallback({
+              needle: 'blockhound-integration',
+              contentToAdd: `builder.allowBlockingCallsInside("${classPath}", "${method}");`,
+            }),
+          );
+        };
+      },
       registerSpringFactory({ source, application }) {
         source.addTestSpringFactory = ({ key, value }) => {
           const springFactoriesFile = `${application.srcTestResources}META-INF/spring.factories`;

--- a/generators/server/templates/src/test/java/_package_/IntegrationTest.java.ejs
+++ b/generators/server/templates/src/test/java/_package_/IntegrationTest.java.ejs
@@ -91,12 +91,7 @@ import java.lang.annotation.Target;
 public @interface IntegrationTest {
 <%_ if (reactive) { _%>
     // 5s is Spring's default https://github.com/spring-projects/spring-framework/blob/main/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java#L106
-  <%_ if (databaseTypeMongodb && reactive) { _%>
-    String DEFAULT_TIMEOUT = "PT10S";
-    String DEFAULT_ENTITY_TIMEOUT = "PT10S";
-  <%_ } else { _%>
     String DEFAULT_TIMEOUT = "PT5S";
     String DEFAULT_ENTITY_TIMEOUT = "PT5S";
-  <%_ } _%>
 <%_ } _%>
 }

--- a/generators/server/templates/src/test/java/_package_/config/JHipsterBlockHoundIntegration.java.ejs
+++ b/generators/server/templates/src/test/java/_package_/config/JHipsterBlockHoundIntegration.java.ejs
@@ -58,5 +58,6 @@ public class JHipsterBlockHoundIntegration implements BlockHoundIntegration {
         builder.allowBlockingCallsInside("org.springframework.web.reactive.result.method.InvocableHandlerMethod", "invoke");
         builder.allowBlockingCallsInside("org.springdoc.core.service.OpenAPIService", "build");
         builder.allowBlockingCallsInside("org.springdoc.core.service.AbstractRequestService", "build");
+        // jhipster-needle-blockhound-integration - JHipster will add additional gradle plugins here
     }
 }

--- a/generators/server/templates/src/test/resources/junit-platform.properties.ejs
+++ b/generators/server/templates/src/test/resources/junit-platform.properties.ejs
@@ -1,10 +1,5 @@
-<%_ if (databaseTypeMongodb) { _%>
-junit.jupiter.execution.timeout.default = 30 s
-junit.jupiter.execution.timeout.testable.method.default = 30 s
-<%_ } else { _%>
 junit.jupiter.execution.timeout.default = 15 s
 junit.jupiter.execution.timeout.testable.method.default = 15 s
-<%_ } _%>
 junit.jupiter.execution.timeout.beforeall.method.default = 60 s
 <%_ if (cucumberTests) { _%>
 cucumber.publish.enabled=true

--- a/generators/server/types.d.ts
+++ b/generators/server/types.d.ts
@@ -14,6 +14,7 @@ export type SpringBootSourceType = GradleSourceType &
     addLogbackMainLog?({ name, level }: { name: string; level: string }): void;
     addLogbackTestLog?({ name, level }: { name: string; level: string }): void;
     addIntegrationTestAnnotation?({ package, annotation }: { package?: string; annotation: string }): void;
+    addAllowBlockingCallsInside?({ classPath, method }: { classPath: string; method: string }): void;
   };
 
 type CacheProviderApplication = OptionWithDerivedProperties<

--- a/generators/spring-data-mongodb/generator.js
+++ b/generators/spring-data-mongodb/generator.js
@@ -92,6 +92,12 @@ export default class MongoDBGenerator extends BaseApplicationGenerator {
           }
         }
       },
+      blockhound({ application, source }) {
+        const { reactive } = application;
+        if (reactive) {
+          source.addAllowBlockingCallsInside({ classPath: 'com.mongodb.internal.Locks', method: 'checkedWithLock' });
+        }
+      },
     });
   }
 

--- a/test-integration/jdl-samples/ms-ng-consul-oauth2-mongodb-caffeine/blog-store.jdl
+++ b/test-integration/jdl-samples/ms-ng-consul-oauth2-mongodb-caffeine/blog-store.jdl
@@ -25,7 +25,7 @@ application {
     buildTool maven
     clientFramework angular
     creationTimestamp 1617901618886
-    // databaseType mongodb
+    databaseType mongodb
     jhiPrefix custom
     jwtSecretKey "ZjY4MTM4YjI5YzMwZjhjYjI2OTNkNTRjMWQ5Y2Q0Y2YwOWNmZTE2NzRmYzU3NTMwM2NjOTE3MTllOTM3MWRkMzcyYTljMjVmNmQ0Y2MxOTUzODc0MDhhMTlkMDIxMzI2YzQzZDM2ZDE3MmQ3NjVkODk3OTVmYzljYTQyZDNmMTQ="
     messageBroker kafka
@@ -86,7 +86,7 @@ application {
     baseName notification,
     buildTool gradle
     creationTimestamp 1617901618889
-    // databaseType mongodb
+    databaseType mongodb
     dtoSuffix Rest
     entitySuffix Entity
     jwtSecretKey "ZjY4MTM4YjI5YzMwZjhjYjI2OTNkNTRjMWQ5Y2Q0Y2YwOWNmZTE2NzRmYzU3NTMwM2NjOTE3MTllOTM3MWRkMzcyYTljMjVmNmQ0Y2MxOTUzODc0MDhhMTlkMDIxMzI2YzQzZDM2ZDE3MmQ3NjVkODk3OTVmYzljYTQyZDNmMTQ="

--- a/test-integration/workflow-samples/angular.json
+++ b/test-integration/workflow-samples/angular.json
@@ -70,13 +70,11 @@
     },
     {
       "name": "ng-webflux-mongodb",
-      "skip-backend-tests": "mongodb's reactive driver deadlocks with junit tests",
       "app-sample": "webflux-mongodb",
       "entity": "mongodb"
     },
     {
       "name": "ng-webflux-gradle-mongodb-oauth2",
-      "skip-backend-tests": "mongodb's reactive driver deadlocks with junit tests",
       "app-sample": "webflux-mongodb-oauth2",
       "entity": "mongodb",
       "node": "20",


### PR DESCRIPTION
- enable backend test for webflux + mongodb
- set mongodb workspaces sample to use mongodb database
- add needles for blockhound
- customize blockhound for mongodb
- use default test timeouts for mongodb

Closes https://github.com/jhipster/generator-jhipster/issues/17478.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
