### PR TITLE
FakerJS 8.4.0: faker.number.float({ precision }) is deprecated

### DIFF
--- a/generators/base-application/support/prepare-field.js
+++ b/generators/base-application/support/prepare-field.js
@@ -137,7 +137,7 @@ function generateFakeDataForField(field, faker, changelogDate, type = 'csv') {
     data = faker.number.float({
       max: field.fieldValidateRulesMax ? parseInt(field.fieldValidateRulesMax, 10) : 32767,
       min: field.fieldValidateRulesMin ? parseInt(field.fieldValidateRulesMin, 10) : 0,
-      precision: 0.01,
+      multipleOf: 0.01,
     });
   } else if ([INTEGER, LONG, DURATION].includes(field.fieldType)) {
     data = faker.number.int({


### PR DESCRIPTION
Fix warnings

![image](https://github.com/jhipster/generator-jhipster/assets/9989211/145de925-a479-4746-90b7-8a91793fffb0)


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
