### PR TITLE
[Angular] The signature '(error: any): Observable<never>' of 'throwError' is deprecated

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
@@ -63,11 +63,9 @@ describe('PasswordResetInitComponent', () => {
   }));
 
   it('no notification of success upon error response', inject([PasswordResetInitService], (service: PasswordResetInitService) => {
+    const err = { status: 503, data: 'something else' };
     jest.spyOn(service, 'save').mockReturnValue(
-      throwError({
-        status: 503,
-        data: 'something else',
-      })
+      throwError(() => err)
     );
     comp.resetRequestForm.patchValue({
       email: 'user@domain.com',

--- a/generators/angular/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
@@ -97,11 +97,9 @@ describe('RegisterComponent', () => {
   it('should notify of user existence upon 400/login already in use', inject(
     [RegisterService],
     fakeAsync((service: RegisterService) => {
+      const err = { status: 400, error: { type: LOGIN_ALREADY_USED_TYPE } };
       jest.spyOn(service, 'save').mockReturnValue(
-        throwError({
-          status: 400,
-          error: { type: LOGIN_ALREADY_USED_TYPE },
-        })
+        throwError(() => err)
       );
       comp.registerForm.patchValue({
         password: 'password',
@@ -120,11 +118,9 @@ describe('RegisterComponent', () => {
   it('should notify of email existence upon 400/email address already in use', inject(
     [RegisterService],
     fakeAsync((service: RegisterService) => {
+      const err = { status: 400, error: { type: EMAIL_ALREADY_USED_TYPE } };
       jest.spyOn(service, 'save').mockReturnValue(
-        throwError({
-          status: 400,
-          error: { type: EMAIL_ALREADY_USED_TYPE },
-        })
+        throwError(() => err)
       );
       comp.registerForm.patchValue({
         password: 'password',
@@ -143,10 +139,9 @@ describe('RegisterComponent', () => {
   it('should notify of generic error', inject(
     [RegisterService],
     fakeAsync((service: RegisterService) => {
+      const err = { status: 503 };
       jest.spyOn(service, 'save').mockReturnValue(
-        throwError({
-          status: 503,
-        })
+        throwError(() => err)
       );
       comp.registerForm.patchValue({
         password: 'password',

--- a/generators/angular/templates/src/main/webapp/app/account/sessions/sessions.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/sessions/sessions.component.spec.ts.ejs
@@ -92,7 +92,7 @@ describe('SessionsComponent', () => {
     fakeAsync((mockAccountService: AccountService, service: SessionsService) => {
       mockAccountService.identity = jest.fn(() => of(account));
       jest.spyOn(service, 'findAll').mockReturnValue(of(sessions));
-      jest.spyOn(service, 'delete').mockReturnValue(throwError({}));
+      jest.spyOn(service, 'delete').mockReturnValue(throwError(() => {}));
 
       comp.ngOnInit();
       comp.invalidate('xyz');

--- a/generators/angular/templates/src/main/webapp/app/login/login.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/login/login.component.spec.ts.ejs
@@ -159,7 +159,7 @@ describe('LoginComponent', () => {
 
     it('should stay on login form and show error message on login error', () => {
       // GIVEN
-      mockLoginService.login = jest.fn(() => throwError({}));
+      mockLoginService.login = jest.fn(() => throwError(() => {}));
 
       // WHEN
       comp.login();


### PR DESCRIPTION
The signature '(error: any): Observable<never>' of 'throwError' is deprecated

Fix
![image](https://github.com/jhipster/generator-jhipster/assets/9989211/ef880b16-1aec-4dc2-b65f-c615d8bd5f4a)

Deprecated
![image](https://github.com/jhipster/generator-jhipster/assets/9989211/c8b50bef-7b92-4bc5-b958-3cf745abbe99)


<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
