### PR TITLE
Add ip-address configuration for Consul discovery

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -109,6 +109,7 @@ spring:
         profile-separator: "-"
       discovery:
         prefer-ip-address: true
+        # ip-address: host.docker.internal # Uncomment this if service check fails when running apps without Docker
         tags:
           - profile=${spring.profiles.active}
           - version=#project.version#

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -113,6 +113,7 @@ spring:
     consul:
       discovery:
         prefer-ip-address: true
+        # ip-address: host.docker.internal # Uncomment this if service check fails when running apps without Docker
       host: localhost
       port: 8500
 <%_ } _%>


### PR DESCRIPTION
<!--
PR description.
-->

I addressed the issue #24377 reported by @mraible. The problem was related to service checks failing when running apps without Docker. By adding the `ip-address: host.docker.internal` configuration in the Consul discovery section, the service check issue should be resolved.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
