### PR TITLE
refactor: add German translation keys for cache metrics

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/de/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/de/global.json.ejs
@@ -101,7 +101,7 @@
             }
         },
         "field": {
-            "id" : "ID"
+            "id":  "ID"
         },
         "ribbon": {
             "dev": "Entwicklung"
@@ -138,7 +138,8 @@
             "maxbytes": "Dieses Feld sollte nicht mehr als {{max}} bytes haben.",
             "pattern": "Dieses Feld muss das Muster {{pattern}} erfüllen.",
             "number": "Dieses Feld muss eine Zahl sein.",
-            "datetimelocal": "Dieses Feld muss eine Datums- und Zeitangabe enthalten."
+            "datetimelocal": "Dieses Feld muss eine Datums- und Zeitangabe enthalten.",
+            "patternLogin": "Dieses Feld darf nur Buchstaben, Ziffern und E-Mail-Adressen enthalten."
         },
         "filters": {
           "set": "Folgende Filter sind gesetzt",

--- a/generators/languages/templates/src/main/webapp/i18n/de/metrics.json
+++ b/generators/languages/templates/src/main/webapp/i18n/de/metrics.json
@@ -74,8 +74,16 @@
             "title": "Cache Statistiken",
             "cachename": "Cache Name",
             "hits": "Treffer",
-            "misses": "Keine Treffer",
-            "evictions": "Anzahl entfernter Objekte"
+            "misses": "Fehler",
+            "gets": "Anzahl gelesener Objekte",
+            "puts": "Anzahl geschriebener Objekte",
+            "removals": "Anzahl gelöschter Objekte",
+            "evictions": "Anzahl entfernter Objekte",
+            "hitPercent": "Trefferwahrscheinlichkeit %",
+            "missPercent": "Fehlerwahrscheinlichkeit %",
+            "averageGetTime": "Durchschnittliche Lesedauer (µs)",
+            "averagePutTime": "Durchschnittliche Schreibdauer (µs)",
+            "averageRemoveTime": "Durchschnittliche Löschdauer (µs)"
         },
         "datasource": {
             "usage": "Usage",


### PR DESCRIPTION
The German translation keys for Metrics is missing nine keys. Add the translation keys. Translations provided by Markus Bernhardt.

An additional key missing in the global.json is also provided.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
