### PR TITLE
drop v8 from stale exempt labels.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -40,6 +40,6 @@ jobs:
           days-before-issue-stale: 180
           days-before-pr-stale: 360
           days-before-close: 7
-          exempt-issue-labels: 'area: bug :bug:,status: work in progress,v8,$$ bug-bounty $$'
+          exempt-issue-labels: 'area: bug :bug:,status: work in progress,$$ bug-bounty $$'
           exempt-pr-labels: 'pr: bug-fix,status: work in progress'
-          operations-per-run: 20
+          operations-per-run: 60


### PR DESCRIPTION
v8 label is a feature request. Not goals anymore.
Drop from stale.

Increase stale operations since it already did a triage in every issue.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
