### PR TITLE
Simplify MSSQL Server testcontainer setup for integration tests

### DIFF
--- a/generators/spring-data-relational/templates/src/test/java/_package_/config/MsSqlTestContainer.java.ejs
+++ b/generators/spring-data-relational/templates/src/test/java/_package_/config/MsSqlTestContainer.java.ejs
@@ -42,7 +42,9 @@ public class MsSqlTestContainer implements SqlTestContainer {
     public void afterPropertiesSet() {
         if (null == mSSQLServerContainer) {
             mSSQLServerContainer = new MSSQLServerContainer<>("<%- dockerContainers.mssql %>")
-                .acceptLicense()
+                // You are required to accept EULA license for SQL server containers
+                // Refer to https://java.testcontainers.org/modules/databases/mssqlserver/
+                //.acceptLicense()
                 .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"))
                 .withLogConsumer(new Slf4jLogConsumer(log))
                 .withReuse(true);

--- a/generators/spring-data-relational/templates/src/test/java/_package_/config/MsSqlTestContainer.java.ejs
+++ b/generators/spring-data-relational/templates/src/test/java/_package_/config/MsSqlTestContainer.java.ejs
@@ -42,6 +42,7 @@ public class MsSqlTestContainer implements SqlTestContainer {
     public void afterPropertiesSet() {
         if (null == mSSQLServerContainer) {
             mSSQLServerContainer = new MSSQLServerContainer<>("<%- dockerContainers.mssql %>")
+                .acceptLicense()
                 .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"))
                 .withLogConsumer(new Slf4jLogConsumer(log))
                 .withReuse(true);

--- a/generators/spring-data-relational/templates/src/test/resources/config/application-testdev.yml.ejs
+++ b/generators/spring-data-relational/templates/src/test/resources/config/application-testdev.yml.ejs
@@ -24,11 +24,6 @@
 # To activate this configuration launch integration tests with the 'testcontainers' profile
 #
 # More information on database containers: https://www.testcontainers.org/modules/databases/
-<%_ if (devDatabaseTypeMssql) { _%>
-#
-# You are required to accept EULA license for SQL server containers.
-# Follow the instructions at https://www.testcontainers.org/modules/databases/mssqlserver/
-<%_ } _%>
 <%_ if (devDatabaseTypeOracle) { _%>
 #
 # You have to specify an Oracle image name in a classpath file named testcontainers.properties.


### PR DESCRIPTION
<!--
PR description.
-->

### Description

- **Explicitly accepting the license programmatically**: This eliminates the need for users to manually create a `container-license-acceptance.txt` file, streamlining setup.

- **Removing outdated comments**: The configuration file has been updated to remove comments about manual license acceptance, as this is now handled automatically.

### Additional notes

- This change is aligned with the official Testcontainers documentation for [MSSQL Server modules](https://java.testcontainers.org/modules/databases/mssqlserver/#:~:text=test%20as%20normal-,EULA%20Acceptance,-Due%20to%20licencing).
- The documentation states that license acceptance can be done either programmatically or via a resource file, and this PR adopts the programmatic approach for a more streamlined experience.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
