### PR TITLE
add --apply-config support to upgrade

### DIFF
--- a/generators/upgrade/command.ts
+++ b/generators/upgrade/command.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 import { JHipsterCommandDefinition } from '../base/api.js';
+import { GENERATOR_APP } from '../generator-list.js';
 
 const command: JHipsterCommandDefinition = {
   options: {
@@ -26,7 +27,14 @@ const command: JHipsterCommandDefinition = {
       default: false,
       scope: 'generator',
     },
+    applyConfig: {
+      description: 'Apply configuration changes',
+      type: Boolean,
+      default: false,
+      scope: 'generator',
+    },
   },
+  import: [GENERATOR_APP],
 };
 
 export default command;

--- a/generators/upgrade/index.ts
+++ b/generators/upgrade/index.ts
@@ -17,3 +17,4 @@
  * limitations under the License.
  */
 export { default } from './generator.js';
+export { default as command } from './command.js';


### PR DESCRIPTION
This is quite useful to change configuration.
Like if it's needed to change database from mysql to postgres:
```
jhipster upgrade --apply-config --db postgresql
```
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
