### PR TITLE
expose test matrix through /testing folder

### DIFF
--- a/test/support/matrix-utils.ts
+++ b/test/support/matrix-utils.ts
@@ -7,7 +7,7 @@ const appendTitle = (title, config, value) => {
 
 export const fromMatrix = configMatrix => {
   const configEntries = Object.entries(configMatrix);
-  const samples = configEntries.reduce((previousValue, currentValue) => {
+  const samples = configEntries.reduce((previousValue: any, currentValue: [string, any]) => {
     const [config, configValues] = currentValue;
     if (previousValue.length === 0) {
       return configValues.map(value => [
@@ -37,7 +37,7 @@ export const fromMatrix = configMatrix => {
 const applyExtendedMatrix = (matrixEntries, configMatrix) => {
   const configEntries = Object.entries(configMatrix);
   const additionalMatrixTemp = configEntries.reduce(
-    (currentArray, [configName, configValues]) => {
+    (currentArray, [configName, configValues]: [string, any]) => {
       const currentConfigObjects = configValues.map(configValue => ({ [configName]: configValue }));
       return currentArray
         .map(existingConfig => currentConfigObjects.map(currentObject => ({ ...existingConfig, ...currentObject })))
@@ -45,7 +45,7 @@ const applyExtendedMatrix = (matrixEntries, configMatrix) => {
     },
     [{}],
   );
-  const additionalMatrix = [];
+  const additionalMatrix: any = [];
   while (additionalMatrixTemp.length > 0) {
     additionalMatrix.push(additionalMatrixTemp.shift());
     if (additionalMatrixTemp.length > 0) {
@@ -56,7 +56,7 @@ const applyExtendedMatrix = (matrixEntries, configMatrix) => {
     let matrixName = entry[0];
     const matrixConfig = entry[1];
     let newValues = additionalMatrix[matrixIndex % additionalMatrix.length];
-    Object.entries(newValues).forEach(([configName, configValue]) => {
+    Object.entries(newValues).forEach(([configName, configValue]: [string, any]) => {
       if (typeof configValue === 'object' && !Array.isArray(configValue)) {
         const additionalValues = configValue.additional;
         configValue = configValue.value;

--- a/testing/index.ts
+++ b/testing/index.ts
@@ -1,2 +1,11 @@
 export { default as getGenerator } from './get-generator.js';
 export * from './helpers.js';
+
+// test matrix
+export * from '../test/support/application-samples.js';
+export * from '../test/support/client-samples.js';
+export { default as checkEnforcements } from '../test/support/check-enforcements.js';
+export * from '../test/support/entity-samples.js';
+export * from '../test/support/matrix-utils.js';
+export * from '../test/support/matcher.js';
+export * from '../test/support/server-samples.js';


### PR DESCRIPTION
fixes #25384

With this change, blueprints will have access to test/support i.e. matrix.

**usage:**
import { clientSamples, buildClientSamples, buildServerMatrix } from 'generator-jhipster/testing';


---

Please make sure the below checklist is followed for Pull Requests.

- [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X] Tests are added where necessary
- [X] The JDL part is updated if necessary
- [X] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
