### PR TITLE
allow custom entrypoint generator

### DIFF
--- a/cli/program.mjs
+++ b/cli/program.mjs
@@ -33,6 +33,7 @@ import { CLI_NAME, logger, getCommand, done } from './utils.mjs';
 import { packageJson } from '../lib/index.js';
 import { packageNameToNamespace } from '../generators/base/support/index.js';
 import command from '../generators/base/command.js';
+import { GENERATOR_APP, GENERATOR_BOOTSTRAP, GENERATOR_JDL, GENERATOR_WORKSPACES } from '../generators/generator-list.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -41,6 +42,7 @@ const { version: JHIPSTER_VERSION } = packageJson;
 const JHIPSTER_NS = CLI_NAME;
 
 const moreInfo = `\n  For more info visit ${chalk.blue('https://www.jhipster.tech')}\n`;
+const alternativeEntrypoints = [GENERATOR_JDL, GENERATOR_WORKSPACES];
 
 export const printJHipsterLogo = () => {
   // eslint-disable-next-line no-console
@@ -160,7 +162,7 @@ export const createProgram = ({ executableName = CLI_NAME, executableVersion } =
 const rejectExtraArgs = ({ program, command, extraArgs }) => {
   // if extraArgs exists: Unknown commands or unknown argument.
   const first = extraArgs[0];
-  if (command.name() !== 'app') {
+  if (command.name() !== GENERATOR_APP) {
     logger.fatal(
       `${chalk.yellow(command.name())} command doesn't take ${chalk.yellow(first)} argument. See '${chalk.white(
         `${program.name()} ${command.name()} --help`,
@@ -184,7 +186,8 @@ export const buildCommands = async ({
   envBuilder,
   env,
   loadCommand,
-  defaultCommand = 'app',
+  defaultCommand = GENERATOR_APP,
+  entrypointGenerator,
   printLogo = printJHipsterLogo,
   printBlueprintLogo = () => {},
   createEnvBuilder,
@@ -242,7 +245,13 @@ export const buildCommands = async ({
           await addCommandRootGeneratorOptions(command, generatorMeta);
 
           // Add bootstrap options, may be dropped if every generator is migrated to new structure and correctly depends on bootstrap.
-          const boostrapGen = ['bootstrap', generator];
+          const boostrapGen = [GENERATOR_BOOTSTRAP, generator];
+          if (!entrypointGenerator && blueprint && alternativeEntrypoints.includes(cmdName)) {
+            entrypointGenerator = `${packageNameToNamespace(blueprint)}:${defaultCommand}`;
+          }
+          if (cmdName === GENERATOR_JDL) {
+            boostrapGen.push(entrypointGenerator ?? GENERATOR_APP);
+          }
           const allDependencies = await buildAllDependencies(boostrapGen, {
             env,
             blueprintNamespaces: envBuilder.getBlueprintsNamespaces(),
@@ -272,6 +281,7 @@ export const buildCommands = async ({
           ...cmdOptions,
           ...useOptions,
           commandName: cmdName,
+          entrypointGenerator,
           blueprints: envBuilder.getBlueprintsOption(),
           positionalArguments: args,
         };

--- a/cli/program.mjs
+++ b/cli/program.mjs
@@ -33,7 +33,7 @@ import { CLI_NAME, logger, getCommand, done } from './utils.mjs';
 import { packageJson } from '../lib/index.js';
 import { packageNameToNamespace } from '../generators/base/support/index.js';
 import command from '../generators/base/command.js';
-import { GENERATOR_APP, GENERATOR_BOOTSTRAP, GENERATOR_JDL, GENERATOR_WORKSPACES } from '../generators/generator-list.js';
+import { GENERATOR_APP, GENERATOR_BOOTSTRAP, GENERATOR_JDL } from '../generators/generator-list.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -42,7 +42,6 @@ const { version: JHIPSTER_VERSION } = packageJson;
 const JHIPSTER_NS = CLI_NAME;
 
 const moreInfo = `\n  For more info visit ${chalk.blue('https://www.jhipster.tech')}\n`;
-const alternativeEntrypoints = [GENERATOR_JDL, GENERATOR_WORKSPACES];
 
 export const printJHipsterLogo = () => {
   // eslint-disable-next-line no-console
@@ -246,9 +245,6 @@ export const buildCommands = async ({
 
           // Add bootstrap options, may be dropped if every generator is migrated to new structure and correctly depends on bootstrap.
           const boostrapGen = [GENERATOR_BOOTSTRAP, generator];
-          if (!entrypointGenerator && blueprint && defaultCommand !== GENERATOR_APP && alternativeEntrypoints.includes(cmdName)) {
-            entrypointGenerator = `${packageNameToNamespace(blueprint)}:${defaultCommand}`;
-          }
           if (cmdName === GENERATOR_JDL) {
             boostrapGen.push(entrypointGenerator ?? GENERATOR_APP);
           }
@@ -338,6 +334,7 @@ export const buildJHipster = async ({
     return command;
   },
   defaultCommand,
+  entrypointGenerator,
 } = {}) => {
   // eslint-disable-next-line chai-friendly/no-unused-expressions
   createEnvBuilder =
@@ -346,7 +343,18 @@ export const buildJHipster = async ({
   env = env ?? envBuilder.getEnvironment();
   commands = commands ?? { ...SUB_GENERATORS, ...(await envBuilder.getBlueprintCommands()) };
 
-  await buildCommands({ program, commands, envBuilder, env, loadCommand, defaultCommand, printLogo, printBlueprintLogo, createEnvBuilder });
+  await buildCommands({
+    program,
+    commands,
+    envBuilder,
+    env,
+    loadCommand,
+    defaultCommand,
+    entrypointGenerator,
+    printLogo,
+    printBlueprintLogo,
+    createEnvBuilder,
+  });
 
   return program;
 };

--- a/cli/program.mjs
+++ b/cli/program.mjs
@@ -246,7 +246,7 @@ export const buildCommands = async ({
 
           // Add bootstrap options, may be dropped if every generator is migrated to new structure and correctly depends on bootstrap.
           const boostrapGen = [GENERATOR_BOOTSTRAP, generator];
-          if (!entrypointGenerator && blueprint && alternativeEntrypoints.includes(cmdName)) {
+          if (!entrypointGenerator && blueprint && defaultCommand !== GENERATOR_APP && alternativeEntrypoints.includes(cmdName)) {
             entrypointGenerator = `${packageNameToNamespace(blueprint)}:${defaultCommand}`;
           }
           if (cmdName === GENERATOR_JDL) {

--- a/generators/jdl/__snapshots__/generator.spec.ts.snap
+++ b/generators/jdl/__snapshots__/generator.spec.ts.snap
@@ -172,6 +172,10 @@ Options:
   --skip-install                           Do not automatically install dependencies (default: false)
   --force-install                          Fail on install dependencies error (default: false)
   --ask-answered                           Show prompts for already configured options (default: false)
+  --workspaces-folders <value...>          Folders to use as monorepository workspace
+  --workspaces                             Generate workspaces for multiples applications
+  --skip-git                               Skip git repository initialization
+  --monorepository                         Use monorepository
   --defaults                               Execute jhipster with default config
   --skip-client                            Skip the client-side application generation
   --skip-server                            Skip the server-side application generation
@@ -217,16 +221,12 @@ Options:
   --microfrontends <value>                 Microfrontends to load
   --with-admin-ui                          Generate administrative user interface
   --client-root-dir <value>                Client root
-  --skip-git                               Skip git repository initialization
-  --monorepository                         Use monorepository
   --cypress-coverage                       Enable Cypress code coverage report generation
   --cypress-audit                          Enable cypress-audit/lighthouse report generation
   --enable-translation                     Enable translation
   -l, --language <value...>                Language to be added to application (existing languages are not removed)
   -n, --native-language [value]            Set application native language
   --regenerate-languages                   Regenerate languages
-  --workspaces-folders <value...>          Folders to use as monorepository workspace
-  --workspaces                             Generate workspaces for multiples applications
   -h, --help                               display help for command
 "
 `;

--- a/generators/jdl/command.ts
+++ b/generators/jdl/command.ts
@@ -1,5 +1,5 @@
 import { JHipsterCommandDefinition } from '../base/api.js';
-import { GENERATOR_APP, GENERATOR_WORKSPACES } from '../generator-list.js';
+import { GENERATOR_WORKSPACES } from '../generator-list.js';
 
 const command: JHipsterCommandDefinition = {
   arguments: {
@@ -8,6 +8,12 @@ const command: JHipsterCommandDefinition = {
     },
   },
   options: {
+    entrypointGenerator: {
+      description: 'Entrypoint generator to be used',
+      type: String,
+      scope: 'generator',
+      hide: true,
+    },
     interactive: {
       description:
         'Generate multiple applications in series so that questions can be interacted with. This is the default when there is an existing application configuration in any of the folders',
@@ -45,7 +51,7 @@ const command: JHipsterCommandDefinition = {
       scope: 'generator',
     },
   },
-  import: [GENERATOR_APP, GENERATOR_WORKSPACES],
+  import: [GENERATOR_WORKSPACES],
 };
 
 export default command;

--- a/generators/jdl/generator.spec.ts
+++ b/generators/jdl/generator.spec.ts
@@ -488,4 +488,25 @@ entity Bar
       });
     });
   });
+  describe('with entrypointGenerator', () => {
+    const jdl = `
+application { config { baseName gatewayApp applicationType gateway } }
+`;
+    describe('generating application', () => {
+      before(async () => {
+        await helpers
+          .runJHipster(GENERATOR_JDL)
+          .withMockedGenerators([...mockedGenerators, 'foo:bar'])
+          .withOptions({
+            inline: jdl,
+            entrypointGenerator: 'foo:bar',
+          });
+      });
+
+      it('should generate expected config', () => {
+        const mock = runResult.mockedGenerators['foo:bar'] as SinonSpy;
+        expect(mock.callCount).toBe(1);
+      });
+    });
+  });
 });

--- a/generators/jdl/generator.ts
+++ b/generators/jdl/generator.ts
@@ -55,6 +55,9 @@ export default class JdlGenerator extends BaseGenerator {
   jdlFiles?: string[];
   inline?: string;
   jdlContents: string[] = [];
+  entrypointGenerator = `${CLI_NAME}:${GENERATOR_APP}`;
+  entitiesGenerator = GENERATOR_ENTITIES;
+  workspacesGenerator = GENERATOR_WORKSPACES;
 
   interactive?: boolean;
   jsonOnly?: boolean;
@@ -204,13 +207,13 @@ export default class JdlGenerator extends BaseGenerator {
         if (this.ignoreApplication || this.applications.length === 0) {
           if (this.applications.length === 0) {
             const entities = this.exportedEntities;
-            await this.composeWithJHipster(GENERATOR_ENTITIES, {
+            await this.composeWithJHipster(this.entitiesGenerator, {
               generatorArgs: entities.map(entity => entity.name),
               generatorOptions,
             });
           } else {
             for (const app of this.applications) {
-              await this.composeWithJHipster(GENERATOR_ENTITIES, {
+              await this.composeWithJHipster(this.entitiesGenerator, {
                 generatorArgs: app.entities.map(entity => entity.name),
                 generatorOptions: {
                   ...generatorOptions,
@@ -221,10 +224,10 @@ export default class JdlGenerator extends BaseGenerator {
           }
         } else if (this.applications.length === 1) {
           this.log.info('Generating 1 application');
-          await this.composeWithJHipster(GENERATOR_APP, { generatorOptions });
+          await this.composeWithJHipster(this.entrypointGenerator, { generatorOptions });
         } else {
           this.log.info(`Generating ${this.applications.length} applications`);
-          await this.composeWithJHipster(GENERATOR_WORKSPACES, {
+          await this.composeWithJHipster(this.workspacesGenerator, {
             generatorOptions: {
               workspacesFolders: this.applications.map(app => app.folder),
               generateApplications: async () => this.runNonInteractive(this.applications, generatorOptions),
@@ -291,7 +294,7 @@ export default class JdlGenerator extends BaseGenerator {
         }
         const envBuilder = await this.createEnvBuilder(envOptions);
         const env = envBuilder.getEnvironment();
-        await env.run([`${CLI_NAME}:${GENERATOR_APP}`], generatorOptions);
+        await env.run([this.entrypointGenerator], generatorOptions);
       }),
     );
   }

--- a/generators/workspaces/command.ts
+++ b/generators/workspaces/command.ts
@@ -10,6 +10,12 @@ const command: JHipsterCommandDefinition = {
       default: [],
       scope: 'generator',
     },
+    entrypointGenerator: {
+      description: 'Entrypoint generator to be used',
+      type: String,
+      scope: 'generator',
+      hide: true,
+    },
     workspaces: {
       type: Boolean,
       description: 'Generate workspaces for multiples applications',

--- a/generators/workspaces/generator.js
+++ b/generators/workspaces/generator.js
@@ -34,6 +34,7 @@ export default class WorkspacesGenerator extends BaseWorkspacesGenerator {
   workspaces;
   generateApplications;
   generateWith;
+  entrypointGenerator;
 
   generateWorkspaces;
 
@@ -102,7 +103,9 @@ export default class WorkspacesGenerator extends BaseWorkspacesGenerator {
           await this.generateApplications.call(this);
         } else {
           for (const appName of this.appsFolders) {
-            await this.composeWithJHipster(this.generateWith, { generatorOptions: { destinationRoot: this.destinationPath(appName) } });
+            await this.composeWithJHipster(this.entrypointGenerator ?? this.generateWith, {
+              generatorOptions: { destinationRoot: this.destinationPath(appName) },
+            });
           }
         }
       },


### PR DESCRIPTION
jdl and workspaces generators will compose with the entrypoint generator.
Allows to run jdl in react-native and ionic without backend
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
