### PR TITLE
Update `@AuthorizedFeignClient` to use `dismiss404` instead of deprecated `decode404`

### DIFF
--- a/generators/feign-client/templates/src/main/java/_package_/client/AuthorizedFeignClient.java.ejs
+++ b/generators/feign-client/templates/src/main/java/_package_/client/AuthorizedFeignClient.java.ejs
@@ -55,7 +55,7 @@ public @interface AuthorizedFeignClient {
      * Whether 404s should be decoded instead of throwing FeignExceptions.
      * @return true if 404s will be decoded; false otherwise.
      */
-    boolean decode404() default false;
+    boolean dismiss404() default false;
 
     /**
      * Fallback class for the specified Feign client interface. The fallback class must


### PR DESCRIPTION
<!--
PR description.
-->

### Description

The `decode404` attribute has been deprecated and replaced with `dismiss404` in the **Spring Cloud OpenFeign** library version `4.0.0-RC1` Milestone.

### Reference

- **Spring Cloud OpenFeign** - Remove deprecations and outdated API usage. [#768](https://github.com/spring-cloud/spring-cloud-openfeign/pull/768)

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
