### PR TITLE
Missing field in status in Spanish health.json fixed. Setting the pri…

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/es/health.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/es/health.json.ejs
@@ -64,8 +64,9 @@
         "status": {
             "UNKNOWN": "DESCONOCIDO",
             "UP": "LEVANTADO",
-<%_ if (clientFrameworkAngular) { _%>
-            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+<%_
+    if (clientFrameworkAngular) { _%>
+            "OUT_OF_SERVICE":  "FUERA_DE_SERVICIO",
 <%_ } _%>
             "DOWN": "CAÍDO"
         }


### PR DESCRIPTION
…mary language to Spanish now works for creating a new app.

<!--
Missing field in status in Spanish health.json fixed. Setting the primary language to Spanish when creating an application now works. 
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
