### PR TITLE
Fix Maven build so there are no warnings

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -98,6 +98,7 @@
         <properties-maven-plugin.version><%- javaDependencies['properties-maven-plugin'] %></properties-maven-plugin.version>
         <sonar-maven-plugin.version><%- javaDependencies['sonar-maven-plugin'] %></sonar-maven-plugin.version>
         <spotless-maven-plugin.version><%- javaDependencies['spotless-maven-plugin'] %></spotless-maven-plugin.version>
+        <spring-boot.version><%- javaDependencies['spring-boot'] %></spring-boot.version>
     </properties>
 
     <dependencies>
@@ -339,11 +340,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -830,6 +826,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Fixes the following warnings with Maven builds:

<code>Warning:  Some problems were encountered while building the effective model for com.okta.developer.gateway:gateway:jar:8.1.0-git
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework.boot:spring-boot-configuration-processor:jar -> duplicate declaration of version (?) @ line 95, column 21
Warning:  'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 321, column 21</code>


Closes https://github.com/jhipster/generator-jhipster/pull/25522