### PR TITLE
Replace `husky install` with `husky`

### DIFF
--- a/generators/common/__snapshots__/generator.spec.js.snap
+++ b/generators/common/__snapshots__/generator.spec.js.snap
@@ -135,7 +135,7 @@ This application was generated using JHipster JHIPSTER_VERSION, you can find doc
     "prettier-plugin-java": "PRETTIER_PLUGIN_JAVA_VERSION"
   },
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky init"
   }
 }
 ",

--- a/generators/common/__snapshots__/generator.spec.js.snap
+++ b/generators/common/__snapshots__/generator.spec.js.snap
@@ -135,7 +135,7 @@ This application was generated using JHipster JHIPSTER_VERSION, you can find doc
     "prettier-plugin-java": "PRETTIER_PLUGIN_JAVA_VERSION"
   },
   "scripts": {
-    "prepare": "husky init"
+    "prepare": "husky"
   }
 }
 ",

--- a/generators/common/generator.js
+++ b/generators/common/generator.js
@@ -248,7 +248,7 @@ export default class CommonGenerator extends BaseApplicationGenerator {
         if (application.skipCommitHook) return;
         this.packageJson.merge({
           scripts: {
-            prepare: 'husky install',
+            prepare: 'husky init',
           },
           devDependencies: {
             husky: application.nodeDependencies.husky,

--- a/generators/common/generator.js
+++ b/generators/common/generator.js
@@ -248,7 +248,7 @@ export default class CommonGenerator extends BaseApplicationGenerator {
         if (application.skipCommitHook) return;
         this.packageJson.merge({
           scripts: {
-            prepare: 'husky init',
+            prepare: 'husky',
           },
           devDependencies: {
             husky: application.nodeDependencies.husky,

--- a/generators/init/generator.js
+++ b/generators/init/generator.js
@@ -132,7 +132,7 @@ export default class InitGenerator extends BaseApplicationGenerator {
         if (application.skipCommitHook) return;
         this.packageJson.merge({
           scripts: {
-            prepare: 'husky init',
+            prepare: 'husky',
           },
           devDependencies: {
             husky: application.nodeDependencies.husky,

--- a/generators/init/generator.js
+++ b/generators/init/generator.js
@@ -132,7 +132,7 @@ export default class InitGenerator extends BaseApplicationGenerator {
         if (application.skipCommitHook) return;
         this.packageJson.merge({
           scripts: {
-            prepare: 'husky install',
+            prepare: 'husky init',
           },
           devDependencies: {
             husky: application.nodeDependencies.husky,


### PR DESCRIPTION
Fix deprecated command. 
Fixes https://github.com/jhipster/generator-jhipster/issues/25544. 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
