### PR TITLE
Revert "build(deps): bump mongo from 7.0.6 to 7.0.7 in /generators/server/resources"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -192,6 +192,10 @@ updates:
       - 'theme: dependencies'
       - 'theme: docker :whale:'
       - 'skip-changelog'
+    ignore:
+      # https://github.com/jhipster/generator-jhipster/issues/25548
+      - dependency-name: 'mongo'
+        versions: ['>=7.0.6']
 
   - package-ecosystem: 'maven'
     directory: '/generators/server/resources/'

--- a/generators/server/resources/Dockerfile
+++ b/generators/server/resources/Dockerfile
@@ -20,7 +20,7 @@ FROM mysql:8.3.0
 
 FROM mariadb:11.3.2
 
-FROM mongo:7.0.7
+FROM mongo:7.0.6
 LABEL ALIAS=mongodb
 
 FROM couchbase/server:7.6.0


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#25532 to fix #25548. 