### PR TITLE
Keycloak: remove registration-profile-action

### DIFF
--- a/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
+++ b/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
@@ -2374,14 +2374,6 @@
           "autheticatorFlow": false
         },
         {
-          "authenticator": "registration-profile-action",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 40,
-          "userSetupAllowed": false,
-          "autheticatorFlow": false
-        },
-        {
           "authenticator": "registration-password-action",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",

--- a/generators/docker/templates/docker/realm-config/jhipster-realm.json.ejs
+++ b/generators/docker/templates/docker/realm-config/jhipster-realm.json.ejs
@@ -2372,14 +2372,6 @@
           "autheticatorFlow": false
         },
         {
-          "authenticator": "registration-profile-action",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 40,
-          "userSetupAllowed": false,
-          "autheticatorFlow": false
-        },
-        {
           "authenticator": "registration-password-action",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",

--- a/generators/kubernetes/__snapshots__/kubernetes.spec.ts.snap
+++ b/generators/kubernetes/__snapshots__/kubernetes.spec.ts.snap
@@ -4830,14 +4830,6 @@ data:
               "autheticatorFlow": false
             },
             {
-              "authenticator": "registration-profile-action",
-              "authenticatorFlow": false,
-              "requirement": "REQUIRED",
-              "priority": 40,
-              "userSetupAllowed": false,
-              "autheticatorFlow": false
-            },
-            {
               "authenticator": "registration-password-action",
               "authenticatorFlow": false,
               "requirement": "REQUIRED",
@@ -8273,14 +8265,6 @@ data:
               "authenticatorFlow": false,
               "requirement": "REQUIRED",
               "priority": 20,
-              "userSetupAllowed": false,
-              "autheticatorFlow": false
-            },
-            {
-              "authenticator": "registration-profile-action",
-              "authenticatorFlow": false,
-              "requirement": "REQUIRED",
-              "priority": 40,
               "userSetupAllowed": false,
               "autheticatorFlow": false
             },

--- a/generators/kubernetes/templates/keycloak/keycloak-configmap.yml.ejs
+++ b/generators/kubernetes/templates/keycloak/keycloak-configmap.yml.ejs
@@ -2315,14 +2315,6 @@ data:
               "autheticatorFlow": false
             },
             {
-              "authenticator": "registration-profile-action",
-              "authenticatorFlow": false,
-              "requirement": "REQUIRED",
-              "priority": 40,
-              "userSetupAllowed": false,
-              "autheticatorFlow": false
-            },
-            {
               "authenticator": "registration-password-action",
               "authenticatorFlow": false,
               "requirement": "REQUIRED",


### PR DESCRIPTION
Fix #25675 

I'm not an expert of Keycloak but it fixes the bug.

https://www.keycloak.org/docs/latest/upgrading/index.html#removed-registrationprofile-form-action

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
