### PR TITLE
add compose to command definition.

### DIFF
--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -356,7 +356,7 @@ You can ignore this error by passing '--skip-checks' to jhipster command.`);
 
   /**
    * Compose the current JHipster command compose.
-   * Blueprints with command override takes precedence.
+   * Blueprints commands compose without generators will be composed.
    */
   async composeCurrentJHipsterCommand() {
     const generatorCommand = await this.getCurrentJHipsterCommand();

--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -138,7 +138,10 @@ export default class CoreGenerator extends YeomanGenerator<JHipsterGeneratorOpti
   blueprintStorage?: Storage;
   /** Allow to use a specific definition at current command operations */
   generatorCommand?: JHipsterCommandDefinition;
-  /** Additional commands to be considered */
+  /**
+   * @experimental
+   * Additional commands to be considered
+   */
   generatorsToCompose: string[] = [];
 
   private _jhipsterGenerator?: string;
@@ -355,6 +358,7 @@ You can ignore this error by passing '--skip-checks' to jhipster command.`);
   }
 
   /**
+   * @experimental
    * Compose the current JHipster command compose.
    * Blueprints commands compose without generators will be composed.
    */

--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -138,6 +138,8 @@ export default class CoreGenerator extends YeomanGenerator<JHipsterGeneratorOpti
   blueprintStorage?: Storage;
   /** Allow to use a specific definition at current command operations */
   generatorCommand?: JHipsterCommandDefinition;
+  /** Additional commands to be considered */
+  generatorsToCompose: string[] = [];
 
   private _jhipsterGenerator?: string;
   private _needleApi?: NeedleApi;
@@ -350,6 +352,21 @@ You can ignore this error by passing '--skip-checks' to jhipster command.`);
         context[name] = context[name] ?? this.blueprintStorage?.get(name);
       }
     });
+  }
+
+  /**
+   * Compose the current JHipster command compose.
+   * Blueprints with command override takes precedence.
+   */
+  async composeCurrentJHipsterCommand() {
+    const generatorCommand = await this.getCurrentJHipsterCommand();
+    for (const compose of generatorCommand.compose ?? []) {
+      await this.composeWithJHipster(compose);
+    }
+
+    for (const compose of this.generatorsToCompose) {
+      await this.composeWithJHipster(compose);
+    }
   }
 
   parseJHipsterCommand(commandDef: JHipsterCommandDefinition) {

--- a/generators/base/api.d.ts
+++ b/generators/base/api.d.ts
@@ -233,6 +233,11 @@ export type JHipsterCommandDefinition = {
    */
   import?: string[];
   /**
+   * Compose with generator.
+   * @example ['server', 'jhipster-blueprint:server']
+   */
+  compose?: string[];
+  /**
    * Override options from the generator been blueprinted.
    */
   override?: boolean;

--- a/generators/base/api.d.ts
+++ b/generators/base/api.d.ts
@@ -233,6 +233,7 @@ export type JHipsterCommandDefinition = {
    */
   import?: string[];
   /**
+   * @experimental
    * Compose with generator.
    * @example ['server', 'jhipster-blueprint:server']
    */

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -484,7 +484,7 @@ export default class JHipsterBaseBlueprintGenerator<
         const blueprintModule = (await blueprintGenerator._meta?.importModule?.()) as any;
         blueprintCommand = blueprintModule?.command;
       } else {
-        const generatorName = packageNameToNamespace(normalizeBlueprintName(blueprint));
+        const generatorName = packageNameToNamespace(normalizeBlueprintName(blueprint.name));
         const generatorNamespace = `${generatorName}:${subGen}`;
         const blueprintMeta = await this.env.findMeta(generatorNamespace);
         const blueprintModule = (await blueprintMeta?.importModule?.()) as any;

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -470,6 +470,7 @@ export default class JHipsterBaseBlueprintGenerator<
     const composedBlueprints: any[] = [];
     for (const blueprint of blueprints) {
       const blueprintGenerator = await this._composeBlueprint(blueprint.name, subGen, options);
+      let blueprintCommand;
       if (blueprintGenerator) {
         composedBlueprints.push(blueprintGenerator);
         if ((blueprintGenerator as any).sbsBlueprint) {
@@ -480,11 +481,24 @@ export default class JHipsterBaseBlueprintGenerator<
           this.delegateToBlueprint = true;
           this.checkBlueprintImplementsPriorities(blueprintGenerator);
         }
-        const blueprintModule: any = await blueprintGenerator._meta?.importModule?.();
-        // Use the blueprint command if it is set to override.
-        if (blueprintModule?.command?.override) {
-          this.generatorCommand = blueprintModule.command;
+        const blueprintModule = (await blueprintGenerator._meta?.importModule?.()) as any;
+        blueprintCommand = blueprintModule?.command;
+      } else {
+        const generatorName = packageNameToNamespace(normalizeBlueprintName(blueprint));
+        const generatorNamespace = `${generatorName}:${subGen}`;
+        const blueprintMeta = await this.env.findMeta(generatorNamespace);
+        const blueprintModule = (await blueprintMeta?.importModule?.()) as any;
+        blueprintCommand = blueprintModule?.command;
+        if (blueprintCommand?.compose) {
+          this.generatorsToCompose.push(...blueprintCommand.compose);
         }
+      }
+      if (blueprintCommand?.override) {
+        if (this.generatorCommand) {
+          this.log.warn('Command already set, multiple blueprints may be overriding the command. Unexpected behavior may occur.');
+        }
+        // Use the blueprint command if it is set to override.
+        this.generatorCommand = blueprintCommand;
       }
     }
     return composedBlueprints;

--- a/generators/server/generator.js
+++ b/generators/server/generator.js
@@ -188,6 +188,9 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
 
   get composing() {
     return this.asComposingTaskGroup({
+      async composeCommand() {
+        await this.composeCurrentJHipsterCommand();
+      },
       async composeBackendType() {
         if (!this.jhipsterConfig.backendType || ['spring-boot', 'java'].includes(this.jhipsterConfig.backendType.toLowerCase())) {
           await this.composeWithJHipster(GENERATOR_SPRING_BOOT);


### PR DESCRIPTION
Allow generator-less blueprints to specify generators to be composed.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
