### PR TITLE
finalize angular/react/vue workflows migration to jhipster/actions

### DIFF
--- a/.github/actions/setup-generator-jhipster-jit/action.yml
+++ b/.github/actions/setup-generator-jhipster-jit/action.yml
@@ -23,6 +23,9 @@ inputs:
   generator-path:
     description: Generator folder relative to workspace, git checkout, npm remove, install, and link will be executed in the folder.
     required: true
+  command:
+    description: Command
+    default: jh
 runs:
   using: composite
   steps:
@@ -30,10 +33,10 @@ runs:
       shell: bash
       run: |
         set -x
-        npm install
         mkdir -p "${HOME}/.bin"
         echo "${HOME}/.bin" >> $GITHUB_PATH
-        ln -s "${{ github.workspace }}/${{ inputs.generator-path }}/bin/jhipster.cjs" "${HOME}/.bin/jh"
-        ls -la "${HOME}/.bin/jh"
-        "${{ github.workspace }}/${{ inputs.generator-path }}/bin/jhipster.cjs" --install-path
+        ln -s "${{ github.workspace }}/${{ inputs.generator-path }}/bin/jhipster.cjs" "${HOME}/.bin/${{ inputs.command }}"
+        ls -la "${HOME}/.bin/${{ inputs.command }}"
       working-directory: ${{ github.workspace }}/${{ inputs.generator-path }}
+    - run: ${{ inputs.command }} --install-path
+      shell: bash

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -89,47 +89,27 @@ jobs:
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
-        id: setup
-        uses: ./generator-jhipster/.github/actions/setup
-        with:
-          application-sample: ${{ matrix.setup-application-sample }}
-          entities-sample: ${{ matrix.setup-entities-sample }}
-          jdl-entities-sample: ${{ matrix.setup-jdl-entities-sample }}
-          jdl-sample: ${{ matrix.setup-jdl-sample }}
-          application-environment: ${{ matrix.setup-application-environment }}
-          application-packaging: ${{ matrix.setup-application-packaging }}
-      - uses: actions/setup-node@v4
+      - uses: jhipster/actions/setup-runner@v0
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: jhipster/actions/restore-cache@v0
-        with:
-          npm: true
-          maven: true
-          gradle: ${{ matrix.workspaces == 'true' || matrix.gradle == 1 || contains(matrix.name, 'gradle') }}
-      - uses: jhipster/actions/setup-keycloak-hostname@v0
-      - uses: jhipster/actions/setup-git@v0
-      # Update global NPM for workspaces support
-      - name: 'Install required NPM version'
-        if: matrix.workspaces == 'true'
-        run: npm install -g npm@${{ matrix.npm }} || true
+          npm-version: ${{ matrix.npm-version }}
+          maven-cache: true
+          gradle-cache: ${{ matrix.gradle-cache }}
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
-        run: $JHI_SCRIPTS/10-install-jhipster.sh
+      - run: npm ci --ignore-scripts
+        working-directory: ${{ github.workspace }}/generator-jhipster
+      - uses: ./generator-jhipster/.github/actions/setup-generator-jhipster-jit
+        with:
+          generator-path: generator-jhipster
       - name: 'GENERATION: project'
-        run: jhipster generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
-      - name: 'GENERATION: workspace git'
-        if: matrix.workspaces == 'true'
-        run: |
-          git add .
-          git commit --allow-empty -m "Commit workspaces"
-      - run: jhipster info
+        run: jh generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
+        env:
+          JHI_FOLDER_APP: ${{ github.workspace }}/app
+          JHIPSTER_DEPENDENCIES_VERSION: ${{ matrix.jhipster-bom-cicd-version }}
+      - run: jh info
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
@@ -137,13 +117,18 @@ jobs:
         id: compare
         with:
           generator-path: generator-jhipster
-          cmd: ${{ github.workspace }}/generator-jhipster/bin/jhipster.cjs generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
+          cmd: jh generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
         env:
           # generate-sample uses JHI_FOLDER_APP to generate the application.
           JHI_FOLDER_APP: ${{ github.workspace }}/base/app
+          JHIPSTER_DEPENDENCIES_VERSION: ${{ matrix.jhipster-bom-cicd-version }}
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
+      - uses: jhipster/actions/build-jhipster-bom@v0
+        if: matrix.build-jhipster-bom && steps.compare.outputs.equals != 'true'
+        with:
+          jhipster-bom-ref: ${{ matrix.jhipster-bom-branch }}
       - name: 'TESTS: backend'
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 'true' && needs.build-matrix.outputs.server != 'false'

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -89,47 +89,27 @@ jobs:
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
-        id: setup
-        uses: ./generator-jhipster/.github/actions/setup
-        with:
-          application-sample: ${{ matrix.setup-application-sample }}
-          entities-sample: ${{ matrix.setup-entities-sample }}
-          jdl-entities-sample: ${{ matrix.setup-jdl-entities-sample }}
-          jdl-sample: ${{ matrix.setup-jdl-sample }}
-          application-environment: ${{ matrix.setup-application-environment }}
-          application-packaging: ${{ matrix.setup-application-packaging }}
-      - uses: actions/setup-node@v4
+      - uses: jhipster/actions/setup-runner@v0
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: jhipster/actions/restore-cache@v0
-        with:
-          npm: true
-          maven: true
-          gradle: ${{ matrix.workspaces == 'true' || matrix.gradle == 1 || contains(matrix.name, 'gradle') }}
-      - uses: jhipster/actions/setup-keycloak-hostname@v0
-      - uses: jhipster/actions/setup-git@v0
-      # Update global NPM for workspaces support
-      - name: 'Install required NPM version'
-        if: matrix.workspaces == 'true'
-        run: npm install -g npm@${{ matrix.npm }} || true
+          npm-version: ${{ matrix.npm-version }}
+          maven-cache: true
+          gradle-cache: ${{ matrix.gradle-cache }}
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
-        run: $JHI_SCRIPTS/10-install-jhipster.sh
+      - run: npm ci --ignore-scripts
+        working-directory: ${{ github.workspace }}/generator-jhipster
+      - uses: ./generator-jhipster/.github/actions/setup-generator-jhipster-jit
+        with:
+          generator-path: generator-jhipster
       - name: 'GENERATION: project'
-        run: jhipster generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
-      - name: 'GENERATION: workspace git'
-        if: matrix.workspaces == 'true'
-        run: |
-          git add .
-          git commit --allow-empty -m "Commit workspaces"
-      - run: jhipster info
+        run: jh generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
+        env:
+          JHI_FOLDER_APP: ${{ github.workspace }}/app
+          JHIPSTER_DEPENDENCIES_VERSION: ${{ matrix.jhipster-bom-cicd-version }}
+      - run: jh info
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
@@ -137,13 +117,18 @@ jobs:
         id: compare
         with:
           generator-path: generator-jhipster
-          cmd: ${{ github.workspace }}/generator-jhipster/bin/jhipster.cjs generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
+          cmd: jh generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
         env:
           # generate-sample uses JHI_FOLDER_APP to generate the application.
           JHI_FOLDER_APP: ${{ github.workspace }}/base/app
+          JHIPSTER_DEPENDENCIES_VERSION: ${{ matrix.jhipster-bom-cicd-version }}
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
+      - uses: jhipster/actions/build-jhipster-bom@v0
+        if: matrix.build-jhipster-bom && steps.compare.outputs.equals != 'true'
+        with:
+          jhipster-bom-ref: ${{ matrix.jhipster-bom-branch }}
       - name: 'TESTS: backend'
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 'true' && needs.build-matrix.outputs.server != 'false'

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -89,47 +89,27 @@ jobs:
         with:
           path: generator-jhipster
           fetch-depth: 2
-      - name: 'SETUP: environment'
-        id: setup
-        uses: ./generator-jhipster/.github/actions/setup
-        with:
-          application-sample: ${{ matrix.setup-application-sample }}
-          entities-sample: ${{ matrix.setup-entities-sample }}
-          jdl-entities-sample: ${{ matrix.setup-jdl-entities-sample }}
-          jdl-sample: ${{ matrix.setup-jdl-sample }}
-          application-environment: ${{ matrix.setup-application-environment }}
-          application-packaging: ${{ matrix.setup-application-packaging }}
-      - uses: actions/setup-node@v4
+      - uses: jhipster/actions/setup-runner@v0
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: jhipster/actions/restore-cache@v0
-        with:
-          npm: true
-          maven: true
-          gradle: ${{ matrix.workspaces == 'true' || matrix.gradle == 1 || contains(matrix.name, 'gradle') }}
-      - uses: jhipster/actions/setup-keycloak-hostname@v0
-      - uses: jhipster/actions/setup-git@v0
-      # Update global NPM for workspaces support
-      - name: 'Install required NPM version'
-        if: matrix.workspaces == 'true'
-        run: npm install -g npm@${{ matrix.npm }} || true
+          npm-version: ${{ matrix.npm-version }}
+          maven-cache: true
+          gradle-cache: ${{ matrix.gradle-cache }}
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------
-      - name: 'GENERATION: install JHipster'
-        run: $JHI_SCRIPTS/10-install-jhipster.sh
+      - run: npm ci --ignore-scripts
+        working-directory: ${{ github.workspace }}/generator-jhipster
+      - uses: ./generator-jhipster/.github/actions/setup-generator-jhipster-jit
+        with:
+          generator-path: generator-jhipster
       - name: 'GENERATION: project'
-        run: jhipster generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
-      - name: 'GENERATION: workspace git'
-        if: matrix.workspaces == 'true'
-        run: |
-          git add .
-          git commit --allow-empty -m "Commit workspaces"
-      - run: jhipster info
+        run: jh generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
+        env:
+          JHI_FOLDER_APP: ${{ github.workspace }}/app
+          JHIPSTER_DEPENDENCIES_VERSION: ${{ matrix.jhipster-bom-cicd-version }}
+      - run: jh info
       #----------------------------------------------------------------------
       # Detect changes against base commit
       #----------------------------------------------------------------------
@@ -137,13 +117,18 @@ jobs:
         id: compare
         with:
           generator-path: generator-jhipster
-          cmd: ${{ github.workspace }}/generator-jhipster/bin/jhipster.cjs generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
+          cmd: jh generate-sample ${{ matrix.name }} --skip-jhipster-dependencies --skip-checks --skip-install --no-insight
         env:
           # generate-sample uses JHI_FOLDER_APP to generate the application.
           JHI_FOLDER_APP: ${{ github.workspace }}/base/app
+          JHIPSTER_DEPENDENCIES_VERSION: ${{ matrix.jhipster-bom-cicd-version }}
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
+      - uses: jhipster/actions/build-jhipster-bom@v0
+        if: matrix.build-jhipster-bom && steps.compare.outputs.equals != 'true'
+        with:
+          jhipster-bom-ref: ${{ matrix.jhipster-bom-branch }}
       - name: 'TESTS: backend'
         id: backend
         if: steps.compare.outputs.equals != 'true' && matrix.skip-backend-tests != 'true' && needs.build-matrix.outputs.server != 'false'

--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -349,10 +349,13 @@ You can ignore this error by passing '--skip-checks' to jhipster command.`);
     const config = (this as any).jhipsterConfigWithDefaults;
     Object.entries(generatorCommand.configs).forEach(([name, def]) => {
       if (def.scope === 'storage') {
-        context[name] = context[name] ?? config?.[name] ?? this.config.get(name);
+        context[name] = context[name] ?? config?.[name] ?? this.config.get(name) ?? def.default;
+      }
+      if (def.scope === 'generator') {
+        context[name] = context[name] ?? this[name] ?? def.default;
       }
       if (def.scope === 'blueprint') {
-        context[name] = context[name] ?? this.blueprintStorage?.get(name);
+        context[name] = context[name] ?? this.blueprintStorage?.get(name) ?? def.default;
       }
     });
   }

--- a/generators/base/api.d.ts
+++ b/generators/base/api.d.ts
@@ -205,7 +205,7 @@ export type ConfigSpec = {
   description?: string;
   choices?: JHispterChoices;
 
-  cli?: SetOptional<CliOptionSpec, 'name'>;
+  cli?: SetOptional<CliOptionSpec, 'name'> & { env?: string };
   argument?: JHipsterArgumentConfig;
   prompt?: PromptSpec | ((CoreGenerator) => PromptSpec);
   scope?: 'storage' | 'blueprint' | 'generator';

--- a/generators/client/__workflow/devserver-angular.json
+++ b/generators/client/__workflow/devserver-angular.json
@@ -3,8 +3,7 @@
     {
       "app-sample": "ng-default",
       "cache": "angular",
-      "entity": "sqllight",
-      "environment": "prod"
+      "entity": "sqllight"
     }
   ]
 }

--- a/generators/client/__workflow/devserver-react.json
+++ b/generators/client/__workflow/devserver-react.json
@@ -3,10 +3,7 @@
     {
       "app-sample": "react-default",
       "cache": "react",
-      "entity": "sqllight",
-      "environment": "prod",
-      "war": 0,
-      "e2e": 1
+      "entity": "sqllight"
     }
   ]
 }

--- a/generators/client/__workflow/devserver-vue.json
+++ b/generators/client/__workflow/devserver-vue.json
@@ -3,8 +3,7 @@
     {
       "app-sample": "vue-default",
       "cache": "vue",
-      "entity": "sqllight",
-      "environment": "prod"
+      "entity": "sqllight"
     }
   ]
 }

--- a/generators/client/generator.js
+++ b/generators/client/generator.js
@@ -251,11 +251,6 @@ export default class JHipsterClientGenerator extends BaseApplicationGenerator {
         const packageJsonStorage = this.createStorage(this.destinationPath(application.clientRootDir, 'package.json'));
         const scriptsStorage = packageJsonStorage.createStorage('scripts');
 
-        const packageJsonConfigStorage = packageJsonStorage.createStorage('config').createProxy();
-        if (process.env.JHI_PROFILE) {
-          packageJsonConfigStorage.default_environment = process.env.JHI_PROFILE.includes('dev') ? 'dev' : 'prod';
-        }
-
         const devDependencies = packageJsonStorage.createStorage('devDependencies');
         devDependencies.set('wait-on', application.nodeDependencies['wait-on']);
         devDependencies.set('concurrently', application.nodeDependencies.concurrently);

--- a/generators/common/__snapshots__/generator.spec.js.snap
+++ b/generators/common/__snapshots__/generator.spec.js.snap
@@ -126,6 +126,9 @@ This application was generated using JHipster JHIPSTER_VERSION, you can find doc
   },
   "package.json": {
     "contents": "{
+  "config": {
+    "default_environment": "prod"
+  },
   "devDependencies": {
     "generator-jhipster": "JHIPSTER_VERSION",
     "husky": "HUSKY_VERSION",

--- a/generators/common/command.ts
+++ b/generators/common/command.ts
@@ -32,6 +32,19 @@ const command: JHipsterCommandDefinition = {
       scope: 'storage',
     },
   },
+  configs: {
+    defaultEnvironment: {
+      description: 'Default environment for the application',
+      cli: {
+        type: String,
+        hide: true,
+        env: 'JHI_PROFILE',
+      },
+      choices: ['prod', 'dev'],
+      default: 'prod',
+      scope: 'storage',
+    },
+  },
   import: [GENERATOR_BOOTSTRAP_APPLICATION_BASE],
 };
 

--- a/generators/common/generator.js
+++ b/generators/common/generator.js
@@ -54,8 +54,8 @@ export default class CommonGenerator extends BaseApplicationGenerator {
 
   get initializing() {
     return this.asInitializingTaskGroup({
-      loadOptions() {
-        this.parseJHipsterCommand(this.command);
+      async loadOptions() {
+        await this.parseCurrentJHipsterCommand();
       },
     });
   }
@@ -68,7 +68,7 @@ export default class CommonGenerator extends BaseApplicationGenerator {
     return this.asPromptingTaskGroup({
       async prompting({ control }) {
         if (control.existingProject && this.options.askAnswered !== true) return;
-        await this.prompt(this.prepareQuestions(this.command.configs));
+        await this.promptCurrentJHipsterCommand();
       },
     });
   }
@@ -136,6 +136,9 @@ export default class CommonGenerator extends BaseApplicationGenerator {
   // Public API method used by the getter and also by Blueprints
   get loading() {
     return this.asLoadingTaskGroup({
+      async loadCommand({ application }) {
+        await this.loadCurrentJHipsterCommandConfig(application);
+      },
       loadPackageJson({ application }) {
         this.loadNodeDependenciesFromPackageJson(
           application.nodeDependencies,
@@ -234,6 +237,12 @@ export default class CommonGenerator extends BaseApplicationGenerator {
 
   get postWriting() {
     return this.asPostWritingTaskGroup({
+      setConfig({ application }) {
+        const packageJsonConfigStorage = this.packageJson.createStorage('config').createProxy();
+        if (application.defaultEnvironment) {
+          packageJsonConfigStorage.default_environment = application.defaultEnvironment;
+        }
+      },
       addJHipsterDependencies({ application }) {
         if (application.skipJhipsterDependencies) return;
 

--- a/generators/spring-boot/command.ts
+++ b/generators/spring-boot/command.ts
@@ -58,6 +58,16 @@ const command: JHipsterCommandDefinition = {
       }),
       default: false,
     },
+    defaultPackaging: {
+      description: 'Default packaging for the application',
+      cli: {
+        type: String,
+        hide: true,
+      },
+      choices: ['jar', 'war'],
+      default: 'jar',
+      scope: 'storage',
+    },
   },
   import: [GENERATOR_JAVA, GENERATOR_LIQUIBASE, GENERATOR_SPRING_DATA_RELATIONAL],
 };

--- a/generators/spring-boot/generator.ts
+++ b/generators/spring-boot/generator.ts
@@ -223,6 +223,9 @@ export default class SpringBootGenerator extends BaseApplicationGenerator {
 
   get preparing() {
     return this.asPreparingTaskGroup({
+      async loadCommand({ application }) {
+        await this.loadCurrentJHipsterCommandConfig(application);
+      },
       checksWebsocket({ application }) {
         const { websocket } = application as any;
         if (websocket && websocket !== NO_WEBSOCKET) {

--- a/test-integration/scripts/99-write-matrix.js
+++ b/test-integration/scripts/99-write-matrix.js
@@ -34,22 +34,25 @@ writeFileSync(
             try {
               return JSON.parse(readFileSync(file).toString())
                 .include.filter(sample => !sample.disabled)
-                .map(sample => ({
-                  ...sample,
+                .map(({ generatorOptions, ...sample }) => ({
+                  workspaces: generatorOptions?.workspaces ? 'true' : undefined,
+                  'extra-args': `${generatorOptions?.workspaces ? ' --workspaces' : ''}${generatorOptions?.monorepository ? ' --monorepository' : ''}`,
                   'skip-backend-tests': sample['skip-backend-tests'] ? 'true' : 'false',
                   'skip-frontend-tests': sample['skip-frontend-tests'] ? 'true' : 'false',
                   'setup-application-sample': sample['jhi-app-sample'] || sample['app-sample'] || 'jdl',
-                  'setup-application-environment': sample.environment ?? 'prod',
-                  'setup-application-packaging': sample.packaging ?? 'jar',
+                  'setup-application-environment': generatorOptions?.defaultEnvironment ?? 'prod',
+                  'setup-application-packaging': generatorOptions?.defaultPackaging ?? 'jar',
                   'setup-entities-sample': sample.entity ?? 'none',
                   'setup-jdl-entities-sample': sample['jdl-entity'] ?? '',
                   'setup-jdl-sample': sample['jdl-samples'] ?? '',
-                  java: sample['java'] ?? JAVA_VERSION,
-                  node: sample['node'] ?? NODE_VERSION,
-                  npm: NPM_VERSION,
+                  java: JAVA_VERSION,
+                  node: NODE_VERSION,
+                  'npm-version': generatorOptions?.workspaces ? NPM_VERSION : undefined,
                   'build-jhipster-bom': BUILD_JHIPSTER_BOM,
-                  'jhipster-bom-branch': BUILD_JHIPSTER_BOM ? JHIPSTER_BOM_BRANCH : '',
-                  'jhipster-bom-cicd-version': BUILD_JHIPSTER_BOM ? JHIPSTER_BOM_CICD_VERSION : '',
+                  'jhipster-bom-branch': BUILD_JHIPSTER_BOM ? JHIPSTER_BOM_BRANCH : undefined,
+                  'jhipster-bom-cicd-version': BUILD_JHIPSTER_BOM ? JHIPSTER_BOM_CICD_VERSION : undefined,
+                  'gradle-cache': generatorOptions?.workspaces || sample.name.includes('gradle') ? true : undefined,
+                  ...sample,
                 }));
             } catch (error) {
               console.log(`File ${file} not found`, error);

--- a/test-integration/workflow-samples/angular.json
+++ b/test-integration/workflow-samples/angular.json
@@ -24,14 +24,18 @@
       "name": "ng-mongodb-kafka-cucumber",
       "app-sample": "ng-mongodb-kafka-cucumber",
       "entity": "mongodb",
-      "environment": "dev",
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      },
       "java": "21"
     },
     {
       "name": "ng-h2mem-ws-nol2",
       "app-sample": "ng-h2mem-ws-nol2",
       "entity": "sql",
-      "environment": "dev"
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      }
     },
     {
       "name": "ng-couchbase",
@@ -56,16 +60,19 @@
       "name": "ng-gradle-mariadb-oauth2-infinispan",
       "app-sample": "ng-gradle-mariadb-oauth2-infinispan",
       "entity": "sql",
-      "environment": "dev",
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      },
       "node": "20"
     },
     {
       "name": "ng-gradle-h2disk-ws-nocache",
       "app-sample": "ng-gradle-h2disk-ws-nocache",
       "entity": "sql",
-      "environment": "dev",
-      "packaging": "war",
-      "testcontainers": "false",
+      "generatorOptions": {
+        "defaultEnvironment": "dev",
+        "defaultPackaging": "war"
+      },
       "java": "21"
     },
     {
@@ -94,7 +101,9 @@
     {
       "name": "ng-webflux-gradle-session-h2mem-es",
       "app-sample": "webflux-gradle-session-h2mem-es",
-      "environment": "dev",
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      },
       "entity": "sqllight",
       "node": "20"
     },
@@ -108,22 +117,28 @@
     {
       "name": "ms-ng-consul-oauth2-mongodb-caffeine",
       "jdl-samples": "ms-ng-consul-oauth2-mongodb-caffeine",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true"
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      }
     },
     {
       "name": "mf-ng-eureka-jwt-psql-ehcache",
       "jdl-samples": "mf-ng-eureka-jwt-psql-ehcache",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true",
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      },
       "node": "20",
       "java": "21"
     },
     {
       "name": "ms-mf-ng-consul-oauth2-neo4j",
       "jdl-samples": "ms-mf-ng-consul-oauth2-neo4j",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true",
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      },
       "node": "20"
     }
   ]

--- a/test-integration/workflow-samples/react.json
+++ b/test-integration/workflow-samples/react.json
@@ -9,7 +9,9 @@
       "name": "react-maven-h2mem-memcached",
       "app-sample": "react-maven-h2mem-memcached",
       "entity": "sql",
-      "environment": "dev",
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      },
       "node": "20",
       "java": "21"
     },
@@ -28,15 +30,19 @@
     {
       "name": "ms-react-consul-jwt-cassandra-redis",
       "jdl-samples": "ms-react-consul-jwt-cassandra-redis",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true",
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      },
       "java": "21"
     },
     {
       "name": "ms-mf-react-eureka-oauth2-mariadb-infinispan",
       "jdl-samples": "ms-mf-react-eureka-oauth2-mariadb-infinispan",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true"
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      }
     }
   ]
 }

--- a/test-integration/workflow-samples/vue.json
+++ b/test-integration/workflow-samples/vue.json
@@ -30,40 +30,52 @@
       "name": "vue-gradle-h2mem-ws-session",
       "app-sample": "vue-gradle-ws-session",
       "entity": "sql",
-      "environment": "dev",
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      },
       "java": "21"
     },
     {
       "name": "vue-h2disk-ws-theme",
       "app-sample": "vue-ws-theme",
       "entity": "sql",
-      "environment": "dev"
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      }
     },
     {
       "name": "vue-session-cassandra-fr",
       "app-sample": "vue-session-cassandra-fr",
       "entity": "cassandra",
-      "environment": "dev"
+      "generatorOptions": {
+        "defaultEnvironment": "dev"
+      }
     },
     {
       "name": "ms-vue-eureka-jwt-couchbase-hazelcast",
       "disabled": "needs adjusts for sb3",
       "jdl-samples": "ms-vue-eureka-jwt-couchbase-hazelcast",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true"
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      }
     },
     {
       "name": "ms-mf-vue-consul-oauth2-mysql-memcached",
       "jdl-samples": "ms-mf-vue-consul-oauth2-mysql-memcached",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true"
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      }
     },
     {
       "name": "stack-vue-no-db",
       "jdl-samples": "stack-vue-no-db",
       "skip-frontend-tests": "backend tests only",
-      "extra-args": "--workspaces --monorepository",
-      "workspaces": "true"
+      "generatorOptions": {
+        "workspaces": true,
+        "monorepository": true
+      }
     }
   ]
 }


### PR DESCRIPTION
- workflows samples allow generic generatorOptions
- remove generator-jhipster/.github/actions/setup
- add defaultEvironment and defaultPacking to command
- keep matrix backward compatibility for jhipster-bom workflow for now.

Related to https://github.com/jhipster/generator-jhipster/issues/24135
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
