### PR TITLE
use customized `SpaCsrfTokenRequestHandler` to handle CSRF token

### DIFF
--- a/generators/server/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
@@ -173,7 +173,6 @@ public class SecurityConfiguration {
             .csrf(csrf -> csrf
 <%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                // See https://stackoverflow.com/q/74447118/65681 and https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
                 .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
 <%_ } else { _%>
                 .disable())
@@ -372,8 +371,16 @@ public class SecurityConfiguration {
 
         return jwtDecoder;
     }
-  <%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
+<%_ } _%>
+<%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
 
+    /**
+     * Custom CSRF handler to provide BREACH protection.
+     *
+     * @see <a href="https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa">Spring Security Documentation - Integrating with CSRF Protection</a>
+     * @see <a href="https://github.com/jhipster/generator-jhipster/pull/25907">JHipster - use customized SpaCsrfTokenRequestHandler to handle CSRF token</a>
+     * @see <a href="https://stackoverflow.com/q/74447118/65681">CSRF protection not working with Spring Security 6</a>
+     */
     static final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
         private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
 
@@ -406,6 +413,5 @@ public class SecurityConfiguration {
             return this.delegate.resolveCsrfTokenValue(request, csrfToken);
         }
     }
-  <%_ } _%>
 <%_ } _%>
 }

--- a/generators/server/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
+++ b/generators/server/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
@@ -54,6 +54,10 @@ import tech.jhipster.web.filter.CookieCsrfFilter;
 <%_ if (!skipClient) { _%>
 import <%= packageName %>.web.filter.SpaWebFilter;
 <%_ } _%>
+<%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+<%_ } _%>
 <%_ if (authenticationTypeJwt || (authenticationTypeOauth2 && applicationTypeMicroservice)) { _%>
 import org.springframework.security.config.http.SessionCreationPolicy;
 <%_ } _%>
@@ -84,6 +88,9 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
   <%_ } _%>
 import java.util.*;
 <%_ } _%>
+<%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
+import java.util.function.Supplier;
+<%_ } _%>
 <%_ if (authenticationTypeSession) { _%>
 import org.springframework.http.HttpStatus;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
@@ -94,8 +101,7 @@ import org.springframework.security.web.authentication.RememberMeServices;
   <%_ } _%>
 <%_ } _%>
 <%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.*;
 <%_ } _%>
 <%_ if (authenticationTypeOauth2) { _%>
 import <%= packageName %>.security.oauth2.JwtGrantedAuthorityConverter;
@@ -112,6 +118,9 @@ import <%= packageName %>.security.oauth2.CustomClaimConverter;
 <%_ if(!skipClient) { _%>
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 <%_ } _%>
+<%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
+import org.springframework.util.StringUtils;
+<%_ } _%>
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
@@ -126,7 +135,7 @@ public class SecurityConfiguration {
 
     private final Environment env;
 <%_ } _%>
-    
+
     private final JHipsterProperties jHipsterProperties;
 <%_ if (authenticationTypeSession && generateUserManagement) { _%>
 
@@ -141,7 +150,7 @@ public class SecurityConfiguration {
     public SecurityConfiguration(<% if (devDatabaseTypeH2Any) { %>Environment env, <% } %><% if (authenticationTypeSession && generateUserManagement) { %>RememberMeServices rememberMeServices, <% } %> JHipsterProperties jHipsterProperties) {
 <%_ if (devDatabaseTypeH2Any) { _%>
         this.env = env;
-<%_ } _%>       
+<%_ } _%>
 <%_ if (authenticationTypeSession && generateUserManagement) { _%>
         this.rememberMeServices = rememberMeServices;
 <%_ } _%>
@@ -164,8 +173,8 @@ public class SecurityConfiguration {
             .csrf(csrf -> csrf
 <%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                // See https://stackoverflow.com/q/74447118/65681
-                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()))
+                // See https://stackoverflow.com/q/74447118/65681 and https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
+                .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
 <%_ } else { _%>
                 .disable())
 <%_ } _%>
@@ -363,5 +372,40 @@ public class SecurityConfiguration {
 
         return jwtDecoder;
     }
+  <%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
+
+    static final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
+        private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
+
+        @Override
+        public void handle(HttpServletRequest request, HttpServletResponse response, Supplier<CsrfToken> csrfToken) {
+            /*
+             * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection of
+             * the CsrfToken when it is rendered in the response body.
+             */
+            this.delegate.handle(request, response, csrfToken);
+        }
+
+        @Override
+        public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+            /*
+             * If the request contains a request header, use CsrfTokenRequestAttributeHandler
+             * to resolve the CsrfToken. This applies when a single-page application includes
+             * the header value automatically, which was obtained via a cookie containing the
+             * raw CsrfToken.
+             */
+            if (StringUtils.hasText(request.getHeader(csrfToken.getHeaderName()))) {
+                return super.resolveCsrfTokenValue(request, csrfToken);
+            }
+            /*
+             * In all other cases (e.g. if the request contains a request parameter), use
+             * XorCsrfTokenRequestAttributeHandler to resolve the CsrfToken. This applies
+             * when a server-side rendered form includes the _csrf request parameter as a
+             * hidden input.
+             */
+            return this.delegate.resolveCsrfTokenValue(request, csrfToken);
+        }
+    }
+  <%_ } _%>
 <%_ } _%>
 }


### PR DESCRIPTION
## Description

In the production configuration, the server has enabled the compression feature (as shown below):

```yaml
server:
  port: 8080
  shutdown: graceful # see https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-graceful-shutdown
  compression:
    enabled: true
    mime-types: text/html,text/xml,text/plain,text/css,application/javascript,application/json,image/svg+xml
    min-response-size: 1024
```

This implies that the server might be vulnerable to [BREACH](https://en.wikipedia.org/wiki/BREACH) attacks. Currently, in the `SecurityConfiguration`, we're using `CsrfTokenRequestAttributeHandler` to manage Csrf Tokens. However, according to the official documentation, "[The primary use of CsrfTokenRequestAttributeHandler is to opt-out of BREACH protection of the CsrfToken](https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-token-request-handler-plain)" because the value of `X-Xsrf-Token` in the response headers remains constant for every request.

Following the guidance from the Spring Security official documentation, I found the following section:

[Integrating with CSRF Protection > JavaScript Applications > Single-Page Applications](https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa)

In fact, for single-page applications (SPAs), we can use `XorCsrfTokenRequestAttributeHandler` in conjunction with `CsrfTokenRequestAttributeHandler`. By employing different implementations in various contexts to manage Csrf Tokens, we can leverage the capabilities of `XorCsrfTokenRequestAttributeHandler` to shield against BREACH attacks.

Therefore, I've submitted this pull request in alignment with the recommendations provided in the official documentation.