### PR TITLE
Fix: bump io.gatling.gradle from 3.10.5.1 to 3.11.1

### DIFF
--- a/generators/gatling/__snapshots__/generator.spec.ts.snap
+++ b/generators/gatling/__snapshots__/generator.spec.ts.snap
@@ -210,7 +210,7 @@ sourceSets {
 }
 
 gatling {
-    simulations = { include "**/*Test*.java" }
+    includes = ["**/*Test*.java"]
 }",
     "stateCleared": "modified",
   },

--- a/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
+++ b/generators/gatling/templates/buildSrc/src/main/groovy/jhipster.gatling-conventions.gradle.ejs
@@ -13,5 +13,5 @@ sourceSets {
 }
 
 gatling {
-    simulations = { include "**/*Test*.java" }
+    includes = ["**/*Test*.java"]
 }

--- a/generators/server/resources/gradle/libs.versions.toml
+++ b/generators/server/resources/gradle/libs.versions.toml
@@ -33,4 +33,4 @@ gradle-enterprise = { id = 'com.gradle.enterprise', version = '3.17.2' }
 
 common-custom-user-data-gradle-plugin = { id = 'com.gradle.common-custom-user-data-gradle-plugin', version = '2.0.1' }
 
-gatling-gradle = { id = 'io.gatling.gradle', version = '3.10.5.1' }
+gatling-gradle = { id = 'io.gatling.gradle', version = '3.11.1' }


### PR DESCRIPTION
Fix #25952 

https://github.com/gatling/gatling-gradle-plugin/commit/41a43f4d2074f28571556ba86dd0cee7d1409774

<img width="1081" alt="image" src="https://github.com/jhipster/generator-jhipster/assets/9989211/9050be24-d14d-4649-b30d-5031724552d8">

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
