### PR TITLE
https is deprecated so --ssl is now passing a server type

### DIFF
--- a/generators/angular/templates/webpack/webpack.custom.js.ejs
+++ b/generators/angular/templates/webpack/webpack.custom.js.ejs
@@ -62,7 +62,7 @@ module.exports = async (config, options, targetOptions) => {
   }
 
   // configuring proxy for back end service
-  const tls = Boolean(config.devServer && config.devServer.https);
+  const tls = Boolean(config.devServer && config.devServer.server && config.devServer.server.type === 'https');
   if (config.devServer) {
     config.devServer.proxy = proxyConfig({ tls });
   }

--- a/generators/angular/templates/webpack/webpack.custom.js.ejs
+++ b/generators/angular/templates/webpack/webpack.custom.js.ejs
@@ -62,7 +62,7 @@ module.exports = async (config, options, targetOptions) => {
   }
 
   // configuring proxy for back end service
-  const tls = Boolean(config.devServer && config.devServer.server && config.devServer.server.type === 'https');
+  const tls = config.devServer?.server?.type === 'https';
   if (config.devServer) {
     config.devServer.proxy = proxyConfig({ tls });
   }


### PR DESCRIPTION
`config.devServer.https` is deprecated so `ng server --ssl` is now passing `config.devServer.server.type=https`.
