### PR TITLE
build(generator): default maven-resources-plugin to the spring-boot-parent definition

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -167,14 +167,14 @@ processResources {
         }
 <%_ if (!serviceDiscoveryAny) { _%>
         filter {
-            it.replace("#spring.profiles.active#", springProfiles)
+            it.replace("@spring.profiles.active@", springProfiles)
         }
 <%_ } _%>
     }
 <%_ if (serviceDiscoveryEureka || serviceDiscoveryConsul) { _%>
     filesMatching("**/bootstrap.yml") {
         filter {
-            it.replace("#spring.profiles.active#", springProfiles)
+            it.replace("@spring.profiles.active@", springProfiles)
         }
     }
 <%_ } _%>

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -102,14 +102,14 @@ processResources {
         }
 <%_ if (!serviceDiscoveryAny) { _%>
         filter {
-            it.replace("#spring.profiles.active#", springProfiles)
+            it.replace("@spring.profiles.active@", springProfiles)
         }
 <%_ } _%>
     }
 <%_ if (serviceDiscoveryEureka || serviceDiscoveryConsul) { _%>
     filesMatching("**/bootstrap.yml") {
         filter {
-            it.replace("#spring.profiles.active#", springProfiles)
+            it.replace("@spring.profiles.active@", springProfiles)
         }
     }
 <%_ } _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -501,10 +501,6 @@
                             </goals>
                             <configuration>
                                 <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                                <useDefaultDelimiters>false</useDefaultDelimiters>
-                                <delimiters>
-                                    <delimiter>#</delimiter>
-                                </delimiters>
                                 <resources>
                                     <resource>
                                         <directory><%= SERVER_MAIN_RES_DIR %></directory>

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -245,7 +245,7 @@ spring:
     # The commented value for `active` can be replaced with valid Spring profiles to load.
     # Otherwise, it will be filled in by <%= buildTool %> when building the JAR file
     # Either way, it can be overridden by `--spring.profiles.active` value passed in the commandline or `-Dspring.profiles.active` set in `JAVA_OPTS`
-    active: #spring.profiles.active#
+    active: '@spring.profiles.active@'
     group:
       dev:
         - dev

--- a/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
@@ -30,7 +30,7 @@ spring:
     # The commented value for `active` can be replaced with valid Spring profiles to load.
     # Otherwise, it will be filled in by <%= buildTool %> when building the JAR file
     # Either way, it can be overridden by `--spring.profiles.active` value passed in the commandline or `-Dspring.profiles.active` set in `JAVA_OPTS`
-    active: #spring.profiles.active#
+    active: '@spring.profiles.active@'
   cloud:
 <%_ if (serviceDiscoveryConsul) { _%>
     consul:


### PR DESCRIPTION
Update the generator templates for Gradle and Maven to use the Spring default delimiter of the commercial-at sign (`@`). Remove the JHipster configuration of the delimiter and default to Spring Boot Parent's configuration and allow it to inherit. This will properly scope the `config/bootstrap*.yml` and allow Spring Boot's root resources definition to handle the `**/application*.yml` files.

Fixes #25979

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
