### PR TITLE
Codec Update: SerializationCodec for Redis Fix

### DIFF
--- a/generators/spring-cache/templates/src/main/java/_package_/config/CacheConfiguration.java.ejs
+++ b/generators/spring-cache/templates/src/main/java/_package_/config/CacheConfiguration.java.ejs
@@ -736,7 +736,10 @@ public class CacheConfiguration {
         URI redisUri = URI.create(jHipsterProperties.getCache().getRedis().getServer()[0]);
 
         Config config = new Config();
+  <%_ if (databaseTypeSql) { _%>
+        // Fix Hibernate lazy initialization https://github.com/jhipster/generator-jhipster/issues/22889
         config.setCodec(new org.redisson.codec.SerializationCodec());
+  <%_ } _%>
         if (jHipsterProperties.getCache().getRedis().isCluster()) {
             ClusterServersConfig clusterServersConfig = config
                 .useClusterServers()

--- a/generators/spring-cache/templates/src/main/java/_package_/config/CacheConfiguration.java.ejs
+++ b/generators/spring-cache/templates/src/main/java/_package_/config/CacheConfiguration.java.ejs
@@ -736,6 +736,7 @@ public class CacheConfiguration {
         URI redisUri = URI.create(jHipsterProperties.getCache().getRedis().getServer()[0]);
 
         Config config = new Config();
+        config.setCodec(new org.redisson.codec.SerializationCodec());
         if (jHipsterProperties.getCache().getRedis().isCluster()) {
             ClusterServersConfig clusterServersConfig = config
                 .useClusterServers()


### PR DESCRIPTION
Breaking change in redisson-3.19.0:
Default codec updated to Kryo5Codec.
Switched codec to SerializationCodec to resolve
Redis failures.

Fixes https://github.com/jhipster/generator-jhipster/issues/22889
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
