### PR TITLE
move syncUserWithIdp to bootstrap-application-base

### DIFF
--- a/generators/angular/__snapshots__/generator.spec.ts.snap
+++ b/generators/angular/__snapshots__/generator.spec.ts.snap
@@ -1006,6 +1006,69 @@ exports[`generator - angular gateway-oauth2-withAdminUi(true)-skipJhipsterDepend
   "clientRoot/src/main/webapp/app/core/util/parse-links.service.ts": {
     "stateCleared": "modified",
   },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/authority.model.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/authority.routes.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/authority.test-samples.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/delete/authority-delete-dialog.component.html": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/delete/authority-delete-dialog.component.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/delete/authority-delete-dialog.component.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/detail/authority-detail.component.html": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/detail/authority-detail.component.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/detail/authority-detail.component.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/list/authority.component.html": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/list/authority.component.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/list/authority.component.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/route/authority-routing-resolve.service.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/route/authority-routing-resolve.service.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/service/authority.service.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/service/authority.service.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/update/authority-form.service.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/update/authority-form.service.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/update/authority-update.component.html": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/update/authority-update.component.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/admin/authority/update/authority-update.component.ts": {
+    "stateCleared": "modified",
+  },
   "clientRoot/src/main/webapp/app/entities/entity-navbar-items.ts": {
     "stateCleared": "modified",
   },
@@ -1199,6 +1262,18 @@ exports[`generator - angular gateway-oauth2-withAdminUi(true)-skipJhipsterDepend
     "stateCleared": "modified",
   },
   "clientRoot/src/main/webapp/app/entities/simple/update/simple-update.component.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/user/service/user.service.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/user/service/user.service.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/user/user.model.ts": {
+    "stateCleared": "modified",
+  },
+  "clientRoot/src/main/webapp/app/entities/user/user.test-samples.ts": {
     "stateCleared": "modified",
   },
   "clientRoot/src/main/webapp/app/home/home.component.html": {

--- a/generators/app/support/config.ts
+++ b/generators/app/support/config.ts
@@ -11,7 +11,7 @@ import { packageJson } from '../../../lib/index.js';
 const { GATLING, CUCUMBER, CYPRESS } = testFrameworkTypes;
 const { GATEWAY, MONOLITH } = applicationTypes;
 const { JWT, OAUTH2, SESSION } = authenticationTypes;
-const { CASSANDRA, NO: NO_DATABASE } = databaseTypes;
+const { NO: NO_DATABASE } = databaseTypes;
 
 /**
  * Load common options to be stored.
@@ -182,8 +182,4 @@ export const loadDerivedAppConfig = ({ application }: { application: any }) => {
   application.generateUserManagement =
     !application.skipUserManagement && application.databaseType !== NO_DATABASE && authenticationApiWithUserManagement;
   application.generateInMemoryUserCredentials = !application.generateUserManagement && authenticationApiWithUserManagement;
-
-  application.generateBuiltInUserEntity = application.generateUserManagement || application.syncUserWithIdp;
-
-  application.generateBuiltInAuthorityEntity = application.generateBuiltInUserEntity && application.databaseType !== CASSANDRA;
 };

--- a/generators/base-application/types.d.ts
+++ b/generators/base-application/types.d.ts
@@ -136,6 +136,7 @@ export type CommonClientServerApplication = BaseApplication &
     prettierExtensions?: string;
 
     skipUserManagement?: boolean;
+    syncUserWithIdp?: boolean;
     generateUserManagement?: boolean;
   };
 

--- a/generators/bootstrap-application-server/generator.ts
+++ b/generators/bootstrap-application-server/generator.ts
@@ -43,7 +43,7 @@ import { getPomVersionProperties } from '../maven/support/index.js';
 import { prepareField as prepareFieldForLiquibaseTemplates } from '../liquibase/support/index.js';
 import { getDockerfileContainers } from '../docker/utils.js';
 import { normalizePathEnd } from '../base/support/path.js';
-import { getFrontendAppName, mutateData } from '../base/support/index.js';
+import { getFrontendAppName } from '../base/support/index.js';
 import { getMainClassName } from '../java/support/index.js';
 import { loadConfig, loadDerivedConfig } from '../../lib/internal/index.js';
 import serverCommand from '../server/command.js';
@@ -67,12 +67,9 @@ export default class BoostrapApplicationServer extends BaseApplicationGenerator 
 
   get loading() {
     return this.asLoadingTaskGroup({
-      async loadApplication({ application }) {
+      async loadApplication({ application, applicationDefaults }) {
         loadConfig(serverCommand.configs, { config: this.jhipsterConfigWithDefaults, application });
         loadServerConfig({ config: this.jhipsterConfigWithDefaults, application });
-
-        application.javaVersion = this.useVersionPlaceholders ? 'JAVA_VERSION' : JAVA_VERSION;
-        application.backendType = this.jhipsterConfig.backendType ?? 'Java';
 
         const pomFile = this.readTemplate(this.jhipsterTemplatePath('../../server/resources/pom.xml'))?.toString();
         const gradleLibsVersions = this.readTemplate(
@@ -95,7 +92,8 @@ export default class BoostrapApplicationServer extends BaseApplicationGenerator 
           'docker',
         );
 
-        mutateData(application, {
+        applicationDefaults({
+          javaVersion: this.useVersionPlaceholders ? 'JAVA_VERSION' : JAVA_VERSION,
           packageInfoJavadocs: [],
           javaProperties: {},
           javaManagedProperties: {},
@@ -138,9 +136,6 @@ export default class BoostrapApplicationServer extends BaseApplicationGenerator 
         application.testResourceDir = SERVER_TEST_RES_DIR;
         application.srcMainDir = MAIN_DIR;
         application.srcTestDir = TEST_DIR;
-
-        application.backendTypeSpringBoot = application.backendType === 'Java';
-        application.backendTypeJavaAny = application.backendTypeJavaAny ?? application.backendTypeSpringBoot;
       },
     });
   }

--- a/generators/server/generator.js
+++ b/generators/server/generator.js
@@ -163,18 +163,8 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
       },
       syncUserWithIdp() {
         if (this.jhipsterConfig.syncUserWithIdp === undefined && this.jhipsterConfig.authenticationType === OAUTH2) {
-          if (this.jhipsterConfig.databaseType === NO_DATABASE) {
-            this.jhipsterConfig.syncUserWithIdp = false;
-          } else if (this.isJhipsterVersionLessThan('8.1.1')) {
+          if (this.isJhipsterVersionLessThan('8.1.1')) {
             this.jhipsterConfig.syncUserWithIdp = true;
-          } else if (this.jhipsterConfig.applicationType === GATEWAY) {
-            // For compatibility with v8 microservices allow syncUserWithIdp by default.
-            // Switch to false at v9.
-            this.jhipsterConfig.syncUserWithIdp = true;
-          } else {
-            this.jhipsterConfig.syncUserWithIdp = this.getExistingEntities().some(entity =>
-              (entity.definition.relationships ?? []).some(relationship => relationship.otherEntityName.toLowerCase() === 'user'),
-            );
           }
         } else if (this.jhipsterConfig.syncUserWithIdp && this.jhipsterConfig.authenticationType !== OAUTH2) {
           throw new Error(`syncUserWithIdp is only supported with authenticationType ${OAUTH2}`);

--- a/generators/spring-boot/command.ts
+++ b/generators/spring-boot/command.ts
@@ -56,7 +56,6 @@ const command: JHipsterCommandDefinition = {
         message: 'Do you want to allow relationships with User entity?',
         when: ({ authenticationType }) => (authenticationType ?? gen.jhipsterConfigWithDefaults.authenticationType) === 'oauth2',
       }),
-      default: false,
     },
     defaultPackaging: {
       description: 'Default packaging for the application',

--- a/generators/vue/__snapshots__/generator.spec.ts.snap
+++ b/generators/vue/__snapshots__/generator.spec.ts.snap
@@ -754,6 +754,9 @@ exports[`generator - vue gateway-oauth2-withAdminUi(true)-skipJhipsterDependenci
   "clientRoot/src/main/webapp/app/entities/simple/simple.vue": {
     "stateCleared": "modified",
   },
+  "clientRoot/src/main/webapp/app/entities/user/user.service.ts": {
+    "stateCleared": "modified",
+  },
   "clientRoot/src/main/webapp/app/locale/translation.service.ts": {
     "stateCleared": "modified",
   },


### PR DESCRIPTION
`syncUserWithIdp` config in server generator is forcing ionic and react-native blueprints to set `syncUserWithIdp` option.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
