### PR TITLE
Type safety - Incremental step 3

### DIFF
--- a/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
@@ -25,6 +25,7 @@ import fieldTypes from '../../jhipster/field-types.js';
 import JDLObject from '../../models/jdl-object.js';
 import { JSONField } from '../types.js';
 import { JDLEntity } from '../../models/index.js';
+import JDLField from '../../models/jdl-field.js';
 
 const {
   Validations: { UNIQUE, REQUIRED },
@@ -122,7 +123,7 @@ function getBlobFieldData(fieldType: string) {
   return blobFieldData;
 }
 
-function getFieldValidations(jdlField) {
+function getFieldValidations(jdlField: JDLField) {
   const fieldValidations: any = {
     fieldValidateRules: [],
   };

--- a/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
@@ -65,12 +65,12 @@ function getConvertedFieldsForEntity(jdlEntity: JDLEntity, jdlObject: JDLObject)
       fieldData.documentation = comment;
     }
     if (jdlObject.hasEnum(jdlField.type)) {
-      fieldData.fieldValues = jdlObject.getEnum(fieldData.fieldType).getValuesAsString();
-      const fieldTypeComment = jdlObject.getEnum(fieldData.fieldType).comment;
+      fieldData.fieldValues = jdlObject.getEnum(fieldData.fieldType)?.getValuesAsString();
+      const fieldTypeComment = jdlObject.getEnum(fieldData.fieldType)?.comment;
       if (fieldTypeComment) {
         fieldData.fieldTypeDocumentation = fieldTypeComment;
       }
-      const fieldValuesJavadocs = jdlObject.getEnum(fieldData.fieldType).getValueJavadocs();
+      const fieldValuesJavadocs = jdlObject.getEnum(fieldData.fieldType)?.getValueJavadocs();
       if (fieldValuesJavadocs && Object.keys(fieldValuesJavadocs).length > 0) {
         fieldData.fieldValuesJavadocs = fieldValuesJavadocs;
       }
@@ -101,7 +101,7 @@ function getConvertedFieldsForEntity(jdlEntity: JDLEntity, jdlObject: JDLObject)
   return convertedEntityFields;
 }
 
-function getBlobFieldData(fieldType) {
+function getBlobFieldData(fieldType: string) {
   const blobFieldData: any = {
     fieldType: BYTES,
   };

--- a/jdl/converters/jdl-to-json/jdl-to-json-option-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-option-converter.ts
@@ -116,7 +116,7 @@ function getJSONOptionKeyAndValue(jdlOption) {
   }
 }
 
-function preventEntitiesFromBeingSearched(entityNames) {
+function preventEntitiesFromBeingSearched(entityNames: string[]) {
   entityNames.forEach(entityName => {
     setOptionToEntityName({ optionName: 'searchEngine', optionValue: NO_SEARCH_ENGINE }, entityName);
   });

--- a/jdl/converters/jdl-to-json/jdl-to-json-option-converter.ts
+++ b/jdl/converters/jdl-to-json/jdl-to-json-option-converter.ts
@@ -21,6 +21,8 @@ import logger from '../../utils/objects/logger.js';
 import { unaryOptions, binaryOptions, entityOptions, searchEngineTypes } from '../../jhipster/index.js';
 import JDLObject from '../../models/jdl-object.js';
 import JDLApplication from '../../models/jdl-application.js';
+import AbstractJDLOption from '../../models/abstract-jdl-option.js';
+import JDLBinaryOption from '../../models/jdl-binary-option.js';
 
 const { FILTER, NO_FLUENT_METHOD, READ_ONLY, EMBEDDED, SKIP_CLIENT, SKIP_SERVER } = unaryOptions;
 
@@ -94,7 +96,7 @@ function setOptionsToEachEntityName(jdlOption) {
   }
 }
 
-function getJSONOptionKeyAndValue(jdlOption) {
+function getJSONOptionKeyAndValue(jdlOption: AbstractJDLOption): { key: string; value: string | boolean } {
   switch (jdlOption.name) {
     case SKIP_CLIENT:
     case SKIP_SERVER:
@@ -102,17 +104,17 @@ function getJSONOptionKeyAndValue(jdlOption) {
     case EMBEDDED:
       return { key: jdlOption.name, value: true };
     case MICROSERVICE:
-      return { key: 'microserviceName', value: jdlOption.value };
+      return { key: 'microserviceName', value: (jdlOption as JDLBinaryOption).value };
     case NO_FLUENT_METHOD:
       return { key: 'fluentMethods', value: false };
     case ANGULAR_SUFFIX:
-      return { key: 'angularJSSuffix', value: jdlOption.value };
+      return { key: 'angularJSSuffix', value: (jdlOption as JDLBinaryOption).value };
     case SEARCH:
-      return { key: 'searchEngine', value: jdlOption.value };
+      return { key: 'searchEngine', value: (jdlOption as JDLBinaryOption).value };
     case FILTER:
       return { key: 'jpaMetamodelFiltering', value: true };
     default:
-      return { key: jdlOption.name, value: jdlOption.getType() === 'UNARY' ? true : jdlOption.value };
+      return { key: jdlOption.name, value: jdlOption.getType() === 'UNARY' ? true : (jdlOption as JDLBinaryOption).value };
   }
 }
 

--- a/jdl/converters/json-to-jdl-entity-converter.spec.ts
+++ b/jdl/converters/json-to-jdl-entity-converter.spec.ts
@@ -178,8 +178,8 @@ describe('jdl - JSONToJDLEntityConverter', () => {
           ]);
           const jdlObject = convertEntitiesToJDL(entities);
           const relationship = jdlObject.relationships.getManyToOne('ManyToOne_Employee{department(foo)}_Department{employee}');
-          expect(relationship.commentInFrom).to.equal('Another side of the same relationship');
-          expect(relationship.commentInTo).to.equal('A relationship');
+          expect(relationship!.commentInFrom).to.equal('Another side of the same relationship');
+          expect(relationship!.commentInTo).to.equal('A relationship');
         });
         it('should parse required relationships in owner', () => {
           const relationship = jdlObject.relationships.getManyToOne('ManyToOne_Employee{department(foo)}_Department{employee}');

--- a/jdl/converters/json-to-jdl-entity-converter.ts
+++ b/jdl/converters/json-to-jdl-entity-converter.ts
@@ -52,7 +52,7 @@ let jdlObject: JDLObject;
  * @param params.entities - a Map having for keys the entity names and values the JSON entity files.
  * @return the parsed entities in the JDL form.
  */
-export function convertEntitiesToJDL(entities: Map<string, JSONEntity>): JDLObject {
+export function convertEntitiesToJDL(entities?: Map<string, JSONEntity>): JDLObject {
   if (!entities) {
     throw new Error('Entities have to be passed to be converted.');
   }

--- a/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.spec.ts
@@ -532,7 +532,7 @@ JDLApplication {
       "languages": ListJDLApplicationConfigurationOption {
         "name": "languages",
         "quoted": false,
-        "value": [],
+        "value": Set {},
       },
       "packageFolder": StringJDLApplicationConfigurationOption {
         "name": "packageFolder",

--- a/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.spec.ts
+++ b/jdl/converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter.spec.ts
@@ -175,36 +175,36 @@ describe('jdl - ParsedJDLToJDLObjectConverter', () => {
           expect(jdlObject.getOptions()).to.deep.eq([
             new JDLUnaryOption({
               name: unaryOptions.SKIP_SERVER,
-              entityNames: ['Country'],
+              entityNames: new Set(['Country']),
             }),
             new JDLBinaryOption({
               name: binaryOptions.Options.DTO,
-              entityNames: ['Employee'],
+              entityNames: new Set(['Employee']),
               value: BinaryOptionValues.dto.MAPSTRUCT,
             }),
             new JDLBinaryOption({
               name: binaryOptions.Options.SERVICE,
-              entityNames: ['Employee'],
+              entityNames: new Set(['Employee']),
               value: BinaryOptionValues.service.SERVICE_CLASS,
             }),
             new JDLBinaryOption({
               name: binaryOptions.Options.PAGINATION,
-              entityNames: ['JobHistory', 'Employee'],
+              entityNames: new Set(['JobHistory', 'Employee']),
               value: BinaryOptionValues.pagination['INFINITE-SCROLL'],
             }),
             new JDLBinaryOption({
               name: binaryOptions.Options.PAGINATION,
-              entityNames: ['Job'],
+              entityNames: new Set(['Job']),
               value: BinaryOptionValues.pagination.PAGINATION,
             }),
             new JDLBinaryOption({
               name: binaryOptions.Options.MICROSERVICE,
-              entityNames: ['*'],
+              entityNames: new Set(['*']),
               value: 'mymicroservice',
             }),
             new JDLBinaryOption({
               name: binaryOptions.Options.SEARCH,
-              entityNames: ['Employee'],
+              entityNames: new Set(['Employee']),
               value: BinaryOptionValues.search.ELASTICSEARCH,
             }),
           ]);
@@ -357,7 +357,7 @@ describe('jdl - ParsedJDLToJDLObjectConverter', () => {
           expect(jdlObject.getOptions()).to.deep.eq([
             new JDLUnaryOption({
               name: unaryOptions.NO_FLUENT_METHOD,
-              entityNames: ['A'],
+              entityNames: new Set(['A']),
             }),
           ]);
         });
@@ -532,7 +532,7 @@ JDLApplication {
       "languages": ListJDLApplicationConfigurationOption {
         "name": "languages",
         "quoted": false,
-        "value": Set {},
+        "value": [],
       },
       "packageFolder": StringJDLApplicationConfigurationOption {
         "name": "packageFolder",
@@ -746,8 +746,8 @@ JDLDeployment {
             entityB = jdlObject.entities.B;
             entityC = jdlObject.entities.C;
             fieldAnnotation = jdlObject.entities.A.fields.name.options.id;
-            relationshipAnnotationOnSource = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.source;
-            relationshipAnnotationOnDestination = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.destination;
+            relationshipAnnotationOnSource = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}')!.options.source;
+            relationshipAnnotationOnDestination = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}')!.options.destination;
           });
 
           it('should set the annotations as options', () => {
@@ -807,8 +807,8 @@ JDLDeployment {
             entityB = jdlObject.entities.B;
             entityC = jdlObject.entities.C;
             fieldAnnotation = jdlObject.entities.A.fields.name.options.id;
-            relationshipAnnotationOnSource = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.source;
-            relationshipAnnotationOnDestination = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}').options.destination;
+            relationshipAnnotationOnSource = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}')!.options.source;
+            relationshipAnnotationOnDestination = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}')!.options.destination;
           });
 
           it('should set the annotations as options with lower-case letters first', () => {

--- a/jdl/converters/types.ts
+++ b/jdl/converters/types.ts
@@ -6,6 +6,10 @@ export type JSONField = {
   options?: Record<string, boolean | string | number>;
 } & Record<string, any>;
 
+export type JSONFieldBlob = JSONField & {
+  fieldTypeBlobContent: string;
+};
+
 export type JSONRelationship = {
   relationshipSide?: RelationshipSide;
   relationshipName: string;

--- a/jdl/converters/types.ts
+++ b/jdl/converters/types.ts
@@ -3,8 +3,15 @@ import { RelationshipType, RelationshipSide } from '../basic-types/relationships
 export type JSONField = {
   fieldName: string;
   fieldType: string;
+  documentation?: string;
   options?: Record<string, boolean | string | number>;
 } & Record<string, any>;
+
+export type JSONFieldEnum = JSONField & {
+  fieldValues: string;
+  fieldTypeDocumentation?: string;
+  fieldValuesJavadocs?: Record<string, string>;
+};
 
 export type JSONFieldBlob = JSONField & {
   fieldTypeBlobContent: string;

--- a/jdl/jhipster/field-types.ts
+++ b/jdl/jhipster/field-types.ts
@@ -90,7 +90,7 @@ export default {
   BlobTypes,
 };
 
-export function isCommonDBType(type) {
+export function isCommonDBType(type): boolean {
   if (!type) {
     throw new Error('The passed type must not be nil.');
   }
@@ -98,7 +98,7 @@ export function isCommonDBType(type) {
   return snakeCase(type).toUpperCase() in CommonDBTypes || type instanceof JDLEnum;
 }
 
-export function isBlobType(type?: any) {
+export function isBlobType(type?: any): boolean {
   if (!type) {
     return false;
   }
@@ -107,7 +107,7 @@ export function isBlobType(type?: any) {
   );
 }
 
-export function hasValidation(type, validation, isAnEnum?: any) {
+export function hasValidation(type?: any, validation?, isAnEnum?: boolean): boolean {
   if (!type || !validation) {
     throw new Error('The passed type and value must not be nil.');
   }
@@ -117,7 +117,7 @@ export function hasValidation(type, validation, isAnEnum?: any) {
   return isCommonDBType(type) && CommonDBValidations[type].has(validation);
 }
 
-export function getIsType(databaseType, callback?: any) {
+export function getIsType(databaseType?: string, callback?: any): (type: any) => boolean {
   if (!databaseType) {
     throw new Error('The passed type must not be nil.');
   }

--- a/jdl/models/abstract-jdl-option.spec.ts
+++ b/jdl/models/abstract-jdl-option.spec.ts
@@ -42,7 +42,7 @@ describe('jdl - AbstractJDLOption', () => {
         const option = new JDLBinaryOption({
           name: binaryOptions.Options.SERVICE,
           value: binaryOptions.Values.service.SERVICE_CLASS,
-          excludedNames: ['C'],
+          excludedNames: new Set(['C']),
         });
         result = option.resolveEntityNames(['A', 'B', 'C']);
       });

--- a/jdl/models/abstract-jdl-option.ts
+++ b/jdl/models/abstract-jdl-option.ts
@@ -51,7 +51,7 @@ export default class AbstractJDLOption {
     return this.entityNames.add(entityName);
   }
 
-  addEntitiesFromAnotherOption(option?: AbstractJDLOption) {
+  addEntitiesFromAnotherOption(option?: AbstractJDLOption): boolean {
     if (!option) {
       return false;
     }
@@ -60,7 +60,7 @@ export default class AbstractJDLOption {
     return true;
   }
 
-  excludeEntityName(entityName: string) {
+  excludeEntityName(entityName: string): void {
     if (!entityName) {
       throw new Error('An entity name has to be passed so as to be excluded from the option.');
     }
@@ -74,7 +74,7 @@ export default class AbstractJDLOption {
     throw new Error('Unsupported operation');
   }
 
-  setEntityNames(newEntityNames: Iterable<string>) {
+  setEntityNames(newEntityNames: Iterable<string>): void {
     this.entityNames = new Set(newEntityNames);
   }
 
@@ -83,7 +83,7 @@ export default class AbstractJDLOption {
    * @param entityNames all the entity names declared in a JDL Object.
    * @returns the resolved list.
    */
-  resolveEntityNames(entityNames: string[]) {
+  resolveEntityNames(entityNames: string[]): Set<string> {
     if (!entityNames) {
       throw new Error("Entity names have to be passed to resolve the option's entities.");
     }

--- a/jdl/models/boolean-jdl-application-configuration-option.ts
+++ b/jdl/models/boolean-jdl-application-configuration-option.ts
@@ -19,4 +19,4 @@
 
 import JDLApplicationConfigurationOption from './jdl-application-configuration-option.js';
 
-export default class BooleanJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption {}
+export default class BooleanJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption<boolean> {}

--- a/jdl/models/integer-jdl-application-configuration-option.ts
+++ b/jdl/models/integer-jdl-application-configuration-option.ts
@@ -19,4 +19,4 @@
 
 import JDLApplicationConfigurationOption from './jdl-application-configuration-option.js';
 
-export default class IntegerJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption {}
+export default class IntegerJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption<number> {}

--- a/jdl/models/jdl-application-configuration-factory.spec.ts
+++ b/jdl/models/jdl-application-configuration-factory.spec.ts
@@ -129,9 +129,9 @@ JDLApplicationConfiguration {
     "testFrameworks": ListJDLApplicationConfigurationOption {
       "name": "testFrameworks",
       "quoted": false,
-      "value": [
+      "value": Set {
         "gatling",
-      ],
+      },
     },
   },
 }

--- a/jdl/models/jdl-application-configuration-factory.spec.ts
+++ b/jdl/models/jdl-application-configuration-factory.spec.ts
@@ -129,9 +129,9 @@ JDLApplicationConfiguration {
     "testFrameworks": ListJDLApplicationConfigurationOption {
       "name": "testFrameworks",
       "quoted": false,
-      "value": Set {
+      "value": [
         "gatling",
-      },
+      ],
     },
   },
 }

--- a/jdl/models/jdl-application-configuration-factory.ts
+++ b/jdl/models/jdl-application-configuration-factory.ts
@@ -24,10 +24,11 @@ import IntegerJDLApplicationConfigurationOption from './integer-jdl-application-
 import BooleanJDLApplicationConfigurationOption from './boolean-jdl-application-configuration-option.js';
 import ListJDLApplicationConfigurationOption from './list-jdl-application-configuration-option.js';
 import JDLApplicationDefinition, { JDLApplicationOptionTypeValue } from './jdl-application-definition.js';
+import JDLApplicationConfigurationOption from './jdl-application-configuration-option.js';
 
 const applicationDefinition = new JDLApplicationDefinition();
 
-export default function createApplicationConfigurationFromObject(configurationObject = {}) {
+export default function createApplicationConfigurationFromObject(configurationObject = {}): JDLApplicationConfiguration {
   const configuration = new JDLApplicationConfiguration();
   Object.keys(configurationObject).forEach(optionName => {
     const optionValue = configurationObject[optionName];
@@ -52,7 +53,7 @@ export function createApplicationNamespaceConfigurationFromObject(
   });
 }
 
-function createUnknownJDLConfigurationOption(name: string, value: any) {
+function createUnknownJDLConfigurationOption(name: string, value: any): JDLApplicationConfigurationOption<any> {
   let type;
   if (typeof value === 'boolean') {
     type = 'boolean';
@@ -69,12 +70,16 @@ function createUnknownJDLConfigurationOption(name: string, value: any) {
   return createJDLConfigurationOption(type, name, value);
 }
 
-function createApplicationJDLConfigurationOption(name: string, value: any) {
+function createApplicationJDLConfigurationOption(name: string, value: any): JDLApplicationConfigurationOption<any> {
   const type = applicationDefinition.getTypeForOption(name);
   return createJDLConfigurationOption(type, name, value);
 }
 
-function createJDLConfigurationOption(type: JDLApplicationOptionTypeValue, name: string, value: any) {
+function createJDLConfigurationOption(
+  type: JDLApplicationOptionTypeValue,
+  name: string,
+  value: any,
+): JDLApplicationConfigurationOption<any> {
   switch (type) {
     case 'string':
       return new StringJDLApplicationConfigurationOption(name, value, applicationDefinition.shouldTheValueBeQuoted(name));

--- a/jdl/models/jdl-application-configuration-option.ts
+++ b/jdl/models/jdl-application-configuration-option.ts
@@ -17,25 +17,25 @@
  * limitations under the License.
  */
 
-export default class JDLApplicationConfigurationOption {
+export default class JDLApplicationConfigurationOption<T> {
   name: string;
-  value: any;
+  value: T;
 
   /**
    * Creates a new application option.
    * @param {String} name - the option's name.
    * @param {any} value - the option's value, can be virtually anything: a String, an Int, a boolean...
    */
-  constructor(name: string, value: any) {
+  constructor(name: string, value: T) {
     this.name = name;
     this.value = value;
   }
 
-  getValue() {
+  getValue(): T {
     return this.value;
   }
 
-  toString() {
+  toString(): string {
     return `${this.name} ${this.value}`;
   }
 }

--- a/jdl/models/jdl-application-configuration.ts
+++ b/jdl/models/jdl-application-configuration.ts
@@ -23,7 +23,7 @@ import JDLApplicationConfigurationOption from './jdl-application-configuration-o
 const { OptionNames } = ApplicationOptions;
 
 export default class JDLApplicationConfiguration {
-  options: Record<string, JDLApplicationConfigurationOption>;
+  options: Record<string, JDLApplicationConfigurationOption<any>>;
   namespace?: string;
 
   constructor(namespace?: string) {
@@ -31,14 +31,14 @@ export default class JDLApplicationConfiguration {
     this.namespace = namespace;
   }
 
-  hasOption(optionName: string) {
+  hasOption(optionName: string): boolean {
     if (!optionName) {
       return false;
     }
     return optionName in this.options;
   }
 
-  getOption(optionName: string) {
+  getOption(optionName: string): JDLApplicationConfigurationOption<any> | undefined {
     if (!optionName) {
       throw new Error('An option name has to be passed to get the option.');
     }
@@ -48,14 +48,14 @@ export default class JDLApplicationConfiguration {
     return this.options[optionName];
   }
 
-  setOption(option: JDLApplicationConfigurationOption) {
+  setOption(option: JDLApplicationConfigurationOption<any>): void {
     if (!option) {
       throw new Error('An option has to be passed to set an option.');
     }
     this.options[option.name] = option;
   }
 
-  forEachOption(passedFunction: (option: JDLApplicationConfigurationOption) => void) {
+  forEachOption(passedFunction: (option: JDLApplicationConfigurationOption<any>) => void): void {
     if (!passedFunction) {
       return;
     }
@@ -64,7 +64,7 @@ export default class JDLApplicationConfiguration {
     });
   }
 
-  toString(indent = 0) {
+  toString(indent = 0): string {
     const spaceBeforeConfigKeyword = ' '.repeat(indent);
     const namespace = this.namespace ? `:${this.namespace}` : '';
     if (Object.keys(this.options).length === 0) {
@@ -78,7 +78,7 @@ ${spaceBeforeConfigKeyword}}`;
   }
 }
 
-function getFormattedConfigOptionsString(options: Record<string, JDLApplicationConfigurationOption>, indent: string) {
+function getFormattedConfigOptionsString(options: Record<string, JDLApplicationConfigurationOption<any>>, indent: string): string {
   const filteredOptions = filterOutUnwantedOptions(options);
   return Object.keys(filteredOptions)
     .sort()
@@ -89,11 +89,15 @@ function getFormattedConfigOptionsString(options: Record<string, JDLApplicationC
     .join('\n');
 }
 
-function filterOutUnwantedOptions(options: Record<string, JDLApplicationConfigurationOption>) {
+function filterOutUnwantedOptions(
+  options: Record<string, JDLApplicationConfigurationOption<any>>,
+): Record<string, JDLApplicationConfigurationOption<any>> {
   return filterOutOptionsThatShouldNotBeExported(filterOutOptionsWithoutValues(options));
 }
 
-function filterOutOptionsWithoutValues(options: Record<string, JDLApplicationConfigurationOption>) {
+function filterOutOptionsWithoutValues(
+  options: Record<string, JDLApplicationConfigurationOption<any>>,
+): Record<string, JDLApplicationConfigurationOption<any>> {
   const filteredOptions = { ...options };
   if (!(OptionNames.ENTITY_SUFFIX in options) || !options[OptionNames.ENTITY_SUFFIX].getValue()) {
     delete filteredOptions[OptionNames.ENTITY_SUFFIX];
@@ -107,7 +111,9 @@ function filterOutOptionsWithoutValues(options: Record<string, JDLApplicationCon
   return filteredOptions;
 }
 
-function filterOutOptionsThatShouldNotBeExported(options: Record<string, JDLApplicationConfigurationOption>) {
+function filterOutOptionsThatShouldNotBeExported(
+  options: Record<string, JDLApplicationConfigurationOption<any>>,
+): Record<string, JDLApplicationConfigurationOption<any>> {
   const filteredOptions = { ...options };
   delete filteredOptions[OptionNames.PACKAGE_FOLDER];
   return filteredOptions;

--- a/jdl/models/jdl-application.spec.ts
+++ b/jdl/models/jdl-application.spec.ts
@@ -18,7 +18,7 @@
  */
 /* eslint-disable no-unused-expressions */
 
-import { before, it, describe, expect, expect as jestExpect } from 'esmocha';
+import { before, it, describe, expect as jestExpect } from 'esmocha';
 import { expect } from 'chai';
 import { applicationOptions, binaryOptions } from '../jhipster/index.js';
 import StringJDLApplicationConfigurationOption from '../models/string-jdl-application-configuration-option.js';
@@ -335,8 +335,8 @@ describe('jdl - JDLApplication', () => {
         const option = new JDLBinaryOption({
           name: binaryOptions.Options.PAGINATION,
           value: binaryOptions.Values.pagination['INFINITE-SCROLL'],
-          entityNames: ['*'],
-          excludedNames: ['D'],
+          entityNames: new Set(['*']),
+          excludedNames: new Set(['D']),
         });
         application.addOption(option);
         result = application.toString();
@@ -367,15 +367,15 @@ describe('jdl - JDLApplication', () => {
         const option1 = new JDLBinaryOption({
           name: binaryOptions.Options.PAGINATION,
           value: binaryOptions.Values.pagination['INFINITE-SCROLL'],
-          entityNames: ['*'],
-          excludedNames: ['D'],
+          entityNames: new Set(['*']),
+          excludedNames: new Set(['D']),
         });
         application.addOption(option1);
         const option2 = new JDLBinaryOption({
           name: binaryOptions.Options.DTO,
           value: binaryOptions.Values.dto.MAPSTRUCT,
-          entityNames: ['*'],
-          excludedNames: ['D'],
+          entityNames: new Set(['*']),
+          excludedNames: new Set(['D']),
         });
         application.addOption(option2);
       });
@@ -596,13 +596,13 @@ describe('jdl - JDLApplication', () => {
         const option1 = new JDLBinaryOption({
           name: binaryOptions.Options.PAGINATION,
           value: binaryOptions.Values.pagination['INFINITE-SCROLL'],
-          entityNames: ['*'],
-          excludedNames: ['D'],
+          entityNames: new Set(['*']),
+          excludedNames: new Set(['D']),
         });
         const option2 = new JDLBinaryOption({
           name: binaryOptions.Options.SERVICE,
           value: binaryOptions.Values.service.SERVICE_CLASS,
-          entityNames: ['A', 'B', 'C'],
+          entityNames: new Set(['A', 'B', 'C']),
         });
         application.addOption(option1);
         application.addOption(option2);

--- a/jdl/models/jdl-application.ts
+++ b/jdl/models/jdl-application.ts
@@ -39,14 +39,14 @@ export default class JDLApplication {
     this.options = new JDLOptions();
   }
 
-  setConfigurationOption(option: JDLApplicationConfigurationOption) {
+  setConfigurationOption(option: JDLApplicationConfigurationOption<any>): void {
     if (!option) {
       throw new Error('An option has to be passed to set an option.');
     }
     this.config.setOption(option);
   }
 
-  hasConfigurationOption(optionName: string) {
+  hasConfigurationOption(optionName: string): boolean {
     return this.config.hasOption(optionName);
   }
 
@@ -61,7 +61,7 @@ export default class JDLApplication {
     return option!.getValue();
   }
 
-  forEachConfigurationOption(passedFunction: (option: JDLApplicationConfigurationOption) => void) {
+  forEachConfigurationOption(passedFunction: (option: JDLApplicationConfigurationOption<any>) => void) {
     this.config.forEachOption(passedFunction);
   }
 
@@ -104,7 +104,7 @@ export default class JDLApplication {
     this.options.addOption(jdlOption);
   }
 
-  forEachOption(passedFunction) {
+  forEachOption(passedFunction: (option: AbstractJDLOption) => void): void {
     if (!passedFunction) {
       return;
     }

--- a/jdl/models/jdl-binary-option.ts
+++ b/jdl/models/jdl-binary-option.ts
@@ -25,7 +25,7 @@ import { join } from '../utils/set-utils.js';
  * For options like the DTO, the service, etc.
  */
 export default class JDLBinaryOption extends AbstractJDLOption {
-  value: any;
+  value: string;
 
   constructor(args: Partial<JDLBinaryOption>) {
     super(args);

--- a/jdl/models/jdl-deployment.spec.ts
+++ b/jdl/models/jdl-deployment.spec.ts
@@ -77,9 +77,9 @@ describe('jdl - JDLDeployment', () => {
       it('should stringify its content without default values', () => {
         expect(deployment.toString()).toMatchInlineSnapshot(`
 "deployment {
+    deploymentType docker-compose
     appsFolders [foo, bar]
     clusteredDbApps []
-    deploymentType docker-compose
     dockerRepositoryName test
   }"
 `);
@@ -103,10 +103,10 @@ describe('jdl - JDLDeployment', () => {
       it('should stringify it', () => {
         expect(deployment.toString()).toMatchInlineSnapshot(`
 "deployment {
+    deploymentType docker-compose
     appsFolders [foo, bar]
     directoryPath ../parent
     clusteredDbApps []
-    deploymentType docker-compose
     dockerRepositoryName test
   }"
 `);

--- a/jdl/models/jdl-deployment.ts
+++ b/jdl/models/jdl-deployment.ts
@@ -26,7 +26,9 @@ const arrayTypes = ['appsFolders', 'clusteredDbApps'];
 const NO_SERVICE_DISCOVERY = serviceDiscoveryTypes.NO;
 
 export default class JDLDeployment {
-  constructor(args) {
+  deploymentType: any;
+
+  constructor(args: Partial<JDLDeployment>) {
     if (!args || !args.deploymentType) {
       throw new Error('The deploymentType is mandatory to create a deployment.');
     }
@@ -57,7 +59,7 @@ function stringifyConfig(applicationConfig) {
   return `${config}\n  }`;
 }
 
-function stringifyOptionValue(name: string, value): string {
+function stringifyOptionValue(name: string, value: any): string {
   if (arrayTypes.includes(name)) {
     if (value.size === 0) {
       return ' []';

--- a/jdl/models/jdl-enum-value.ts
+++ b/jdl/models/jdl-enum-value.ts
@@ -1,9 +1,9 @@
 export default class JDLEnumValue {
-  name: any;
-  value: any;
-  comment: any;
+  name: string;
+  value: string;
+  comment: string;
 
-  constructor(name, value, comment) {
+  constructor(name: string, value: string, comment: string) {
     if (!name) {
       throw new Error('The enum value name has to be passed to create an enum.');
     }

--- a/jdl/models/jdl-enum.ts
+++ b/jdl/models/jdl-enum.ts
@@ -21,29 +21,29 @@ import { merge } from '../utils/object-utils.js';
 import JDLEnumValue from './jdl-enum-value.js';
 
 export default class JDLEnum {
-  comment: any;
-  name: any;
-  values: Map<any, any>;
+  comment?: string;
+  name: string;
+  values: Map<string, JDLEnumValue>;
 
-  constructor(args) {
-    const merged = merge(defaults(), args);
+  constructor(args: Partial<Omit<JDLEnum, 'values'> & { values: any[] }>) {
+    const merged: Partial<Omit<JDLEnum, 'values'> & { values: any[] }> = merge(defaults(), args);
     if (!merged.name) {
       throw new Error("The enum's name must be passed to create an enum.");
     }
     this.comment = merged.comment;
     this.name = merged.name;
     this.values = new Map(
-      merged.values.map(entry => {
+      merged.values!.map(entry => {
         return [entry.key, new JDLEnumValue(entry.key, entry.value, entry.comment)];
       }),
     );
   }
 
-  getValuesAsString() {
+  getValuesAsString(): string {
     return stringifyValues(this.values).join(',');
   }
 
-  getValueJavadocs() {
+  getValueJavadocs(): Record<string, string> {
     const documentations = {};
     this.values.forEach(jdlEnumValue => {
       if (jdlEnumValue.comment) {
@@ -53,7 +53,7 @@ export default class JDLEnum {
     return documentations;
   }
 
-  toString() {
+  toString(): string {
     let comment = '';
     if (this.comment) {
       comment += `/**\n * ${this.comment}\n */\n`;
@@ -63,13 +63,13 @@ export default class JDLEnum {
   }
 }
 
-function defaults() {
+function defaults(): { values: any[] } {
   return {
     values: [],
   };
 }
 
-function stringifyValues(jdlEnumValues) {
+function stringifyValues(jdlEnumValues: Map<string, JDLEnumValue>): string[] {
   const values: string[] = [];
   jdlEnumValues.forEach(jdlEnumValue => {
     values.push(jdlEnumValue.toString());

--- a/jdl/models/jdl-enums.ts
+++ b/jdl/models/jdl-enums.ts
@@ -16,34 +16,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import JDLEnum from './jdl-enum.js';
 
 export default class JDLEnums {
-  enums: Map<any, any>;
+  enums: Map<string, JDLEnum>;
 
   constructor() {
     this.enums = new Map();
   }
 
-  add(jdlEnum) {
+  add(jdlEnum: JDLEnum) {
     if (!jdlEnum) {
       throw new Error("Can't add a nil JDL enum to the JDL enums.");
     }
     this.enums.set(jdlEnum.name, jdlEnum);
   }
 
-  get(enumName) {
+  get(enumName: string) {
     return this.enums.get(enumName);
   }
 
-  has(enumName) {
+  has(enumName: string): boolean {
     return this.enums.has(enumName);
   }
 
-  size() {
+  size(): number {
     return this.enums.size;
   }
 
-  forEach(passedFunction) {
+  forEach(passedFunction: (jdlEnum: JDLEnum) => void): void {
     if (!passedFunction) {
       return;
     }
@@ -52,7 +53,7 @@ export default class JDLEnums {
     });
   }
 
-  toString() {
+  toString(): string {
     let string = '';
     this.enums.forEach(jdlEnum => {
       string += `${jdlEnum.toString()}\n`;

--- a/jdl/models/jdl-field.ts
+++ b/jdl/models/jdl-field.ts
@@ -95,7 +95,11 @@ export default class JDLField {
   }
 }
 
+<<<<<<< HEAD
 function defaults(): Pick<JDLField, 'validations' | 'options'> {
+=======
+function defaults(): Partial<JDLField> {
+>>>>>>> ddb978d402 (add few typesafe params)
   return {
     validations: {},
     options: {},

--- a/jdl/models/jdl-field.ts
+++ b/jdl/models/jdl-field.ts
@@ -95,11 +95,7 @@ export default class JDLField {
   }
 }
 
-<<<<<<< HEAD
 function defaults(): Pick<JDLField, 'validations' | 'options'> {
-=======
-function defaults(): Partial<JDLField> {
->>>>>>> ddb978d402 (add few typesafe params)
   return {
     validations: {},
     options: {},

--- a/jdl/models/jdl-object.ts
+++ b/jdl/models/jdl-object.ts
@@ -24,6 +24,7 @@ import { binaryOptions } from '../jhipster/index.js';
 import JDLEntity from './jdl-entity.js';
 import JDLRelationship from './jdl-relationship.js';
 import AbstractJDLOption from './abstract-jdl-option.js';
+import JDLEnum from './jdl-enum.js';
 
 /**
  * The JDL object class, containing applications, entities etc.
@@ -174,7 +175,7 @@ export default class JDLObject {
     return this.enums.size();
   }
 
-  forEachEnum(passedFunction: (jdlEnum: JDLEnums) => void): void {
+  forEachEnum(passedFunction: (jdlEnum: JDLEnum) => void): void {
     if (!passedFunction) {
       return;
     }

--- a/jdl/models/jdl-object.ts
+++ b/jdl/models/jdl-object.ts
@@ -25,13 +25,15 @@ import JDLEntity from './jdl-entity.js';
 import JDLRelationship from './jdl-relationship.js';
 import AbstractJDLOption from './abstract-jdl-option.js';
 import JDLEnum from './jdl-enum.js';
+import JDLDeployment from './jdl-deployment.js';
+import JDLApplication from './jdl-application.js';
 
 /**
  * The JDL object class, containing applications, entities etc.
  */
 export default class JDLObject {
-  applications: Record<string, any>;
-  deployments: Record<string, any>;
+  applications: Record<string, JDLApplication>;
+  deployments: Record<string, JDLDeployment>;
   entities: Record<string, JDLEntity>;
   enums: JDLEnums;
   relationships: JDLRelationships;
@@ -91,7 +93,7 @@ export default class JDLObject {
    * Adds or replaces a deployment.
    * @param deployment the deployment.
    */
-  addDeployment(deployment): void {
+  addDeployment(deployment: JDLDeployment): void {
     if (!deployment) {
       throw new Error("Can't add nil deployment.");
     }
@@ -102,7 +104,7 @@ export default class JDLObject {
     return Object.keys(this.deployments).length;
   }
 
-  forEachDeployment(passedFunction): void {
+  forEachDeployment(passedFunction: (deployment: JDLDeployment, index: number, array: string[]) => void): void {
     if (!passedFunction) {
       return;
     }
@@ -116,7 +118,7 @@ export default class JDLObject {
    * Adds or replaces an entity.
    * @param entity the entity to add.
    */
-  addEntity(entity: JDLEntity) {
+  addEntity(entity: JDLEntity): void {
     if (!entity) {
       throw new Error("Can't add nil entity.");
     }
@@ -142,7 +144,7 @@ export default class JDLObject {
     return Object.keys(this.entities);
   }
 
-  forEachEntity(passedFunction: (entity: JDLEntity, index: number, entityNames: string[]) => void) {
+  forEachEntity(passedFunction: (entity: JDLEntity, index: number, entityNames: string[]) => void): void {
     if (!passedFunction) {
       return;
     }
@@ -156,7 +158,7 @@ export default class JDLObject {
    * Adds or replaces an enum.
    * @param enumToAdd the enum to add.
    */
-  addEnum(enumToAdd: any): void {
+  addEnum(enumToAdd: JDLEnum): void {
     if (!enumToAdd) {
       throw new Error("Can't add nil enum.");
     }
@@ -167,7 +169,7 @@ export default class JDLObject {
     return this.enums.has(enumName);
   }
 
-  getEnum(enumName: string): any {
+  getEnum(enumName: string): JDLEnum | undefined {
     return this.enums.get(enumName);
   }
 
@@ -184,7 +186,7 @@ export default class JDLObject {
     });
   }
 
-  addRelationship(relationship): void {
+  addRelationship(relationship: JDLRelationship): void {
     if (!relationship) {
       throw new Error("Can't add nil relationship.");
     }
@@ -205,7 +207,7 @@ export default class JDLObject {
     return count;
   }
 
-  forEachRelationship(passedFunction?: (relationship: JDLRelationship) => void): void {
+  forEachRelationship(passedFunction: (relationship: JDLRelationship) => void): void {
     if (!passedFunction) {
       return;
     }
@@ -236,14 +238,14 @@ export default class JDLObject {
     this.options.forEach(passedFunction);
   }
 
-  hasOption(optionName): boolean {
+  hasOption(optionName: string): boolean {
     if (!optionName) {
       return false;
     }
     return this.options.has(optionName);
   }
 
-  isEntityInMicroservice(entityName): boolean {
+  isEntityInMicroservice(entityName: string): boolean {
     const options = this.getOptionsForName(binaryOptions.Options.MICROSERVICE);
     return options.some(option => option.entityNames.has('*') || option.entityNames.has(entityName));
   }
@@ -268,13 +270,13 @@ export default class JDLObject {
   }
 }
 
-function applicationsToString(applications: Record<string, any>): string {
+function applicationsToString(applications: Record<string, JDLApplication>): string {
   return Object.values(applications)
     .map(application => application.toString())
     .join('\n');
 }
 
-function deploymentsToString(deployments: Record<any, any>): string {
+function deploymentsToString(deployments: Record<any, JDLDeployment>): string {
   return Object.values(deployments)
     .map(deployment => deployment.toString())
     .join('\n');

--- a/jdl/models/jdl-options.spec.ts
+++ b/jdl/models/jdl-options.spec.ts
@@ -49,10 +49,10 @@ describe('jdl - JDLOptions', () => {
         options = new JDLOptions();
         option1 = new JDLUnaryOption({
           name: unaryOptions.SKIP_CLIENT,
-          entityNames: ['A', 'B', 'C'],
-          excludedNames: ['M'],
+          entityNames: new Set(['A', 'B', 'C']),
+          excludedNames: new Set(['M']),
         });
-        option2 = new JDLUnaryOption({ name: unaryOptions.SKIP_SERVER, entityNames: ['D'] });
+        option2 = new JDLUnaryOption({ name: unaryOptions.SKIP_SERVER, entityNames: new Set(['D']) });
         options.addOption(option1);
         options.addOption(option2);
       });
@@ -66,7 +66,9 @@ describe('jdl - JDLOptions', () => {
 
       describe('that has been added before', () => {
         before(() => {
-          options.addOption(new JDLUnaryOption({ name: unaryOptions.SKIP_CLIENT, entityNames: ['A', 'J'], excludedNames: ['N', 'O'] }));
+          options.addOption(
+            new JDLUnaryOption({ name: unaryOptions.SKIP_CLIENT, entityNames: new Set(['A', 'J']), excludedNames: new Set(['N', 'O']) }),
+          );
         });
 
         it('should not duplicate it', () => {
@@ -76,8 +78,8 @@ describe('jdl - JDLOptions', () => {
           expect(options.getOptions()[0]).to.deep.eq(
             new JDLUnaryOption({
               name: unaryOptions.SKIP_CLIENT,
-              entityNames: ['A', 'B', 'C', 'J'],
-              excludedNames: ['M', 'N', 'O'],
+              entityNames: new Set(['A', 'B', 'C', 'J']),
+              excludedNames: new Set(['M', 'N', 'O']),
             }),
           );
         });
@@ -87,7 +89,7 @@ describe('jdl - JDLOptions', () => {
   describe('has', () => {
     describe('with an invalid input', () => {
       it('should return false', () => {
-        expect(new JDLOptions().has(null)).to.be.false;
+        expect(new JDLOptions().has()).to.be.false;
       });
     });
     describe('with a valid input', () => {
@@ -101,7 +103,7 @@ describe('jdl - JDLOptions', () => {
         options.addOption(
           new JDLUnaryOption({
             name: unaryOptions.SKIP_CLIENT,
-            entityNames: ['A'],
+            entityNames: new Set(['A']),
           }),
         );
         expect(options.has(unaryOptions.SKIP_CLIENT)).to.be.true;
@@ -121,8 +123,8 @@ describe('jdl - JDLOptions', () => {
       options.addOption(
         new JDLUnaryOption({
           name: unaryOptions.SKIP_CLIENT,
-          entityNames: ['A', 'B', 'C'],
-          excludedNames: ['M'],
+          entityNames: new Set(['A', 'B', 'C']),
+          excludedNames: new Set(['M']),
         }),
       );
       expect(options.size()).to.equal(1);
@@ -226,16 +228,16 @@ describe('jdl - JDLOptions', () => {
       options.addOption(
         new JDLUnaryOption({
           name: unaryOptions.SKIP_CLIENT,
-          entityNames: ['A', 'B', 'C'],
-          excludedNames: ['M'],
+          entityNames: new Set(['A', 'B', 'C']),
+          excludedNames: new Set(['M']),
         }),
       );
-      options.addOption(new JDLUnaryOption({ name: unaryOptions.SKIP_SERVER, entityNames: ['D'] }));
+      options.addOption(new JDLUnaryOption({ name: unaryOptions.SKIP_SERVER, entityNames: new Set(['D']) }));
       options.addOption(
         new JDLUnaryOption({
           name: unaryOptions.SKIP_CLIENT,
-          entityNames: ['A', 'J'],
-          excludedNames: ['N', 'O'],
+          entityNames: new Set(['A', 'J']),
+          excludedNames: new Set(['N', 'O']),
         }),
       );
     });

--- a/jdl/models/jdl-options.ts
+++ b/jdl/models/jdl-options.ts
@@ -21,7 +21,7 @@ import JDLUnaryOption from './jdl-unary-option.js';
 import AbstractJDLOption from './abstract-jdl-option.js';
 
 export default class JDLOptions {
-  options: Record<string, any>;
+  options: Record<string, AbstractJDLOption>;
   optionSize: number;
 
   constructor() {

--- a/jdl/models/jdl-options.ts
+++ b/jdl/models/jdl-options.ts
@@ -21,7 +21,7 @@ import JDLUnaryOption from './jdl-unary-option.js';
 import AbstractJDLOption from './abstract-jdl-option.js';
 
 export default class JDLOptions {
-  options: Record<any, any>;
+  options: Record<string, any>;
   optionSize: number;
 
   constructor() {
@@ -29,7 +29,7 @@ export default class JDLOptions {
     this.optionSize = 0;
   }
 
-  addOption(option: AbstractJDLOption) {
+  addOption(option: AbstractJDLOption): void {
     if (!option || !option.getType) {
       throw new Error("Can't add nil option.");
     }
@@ -60,14 +60,14 @@ export default class JDLOptions {
     return this.getOptions().filter(option => option.name === optionName);
   }
 
-  has(optionName: string) {
+  has(optionName?: string): boolean {
     if (!optionName) {
       return false;
     }
     return !!this.options[optionName] || this.getOptions().filter(option => option.name === optionName).length !== 0;
   }
 
-  size() {
+  size(): number {
     return this.optionSize;
   }
 
@@ -80,7 +80,7 @@ export default class JDLOptions {
     });
   }
 
-  toString(indent = 0) {
+  toString(indent = 0): string {
     if (this.optionSize === 0) {
       return '';
     }
@@ -90,7 +90,7 @@ export default class JDLOptions {
   }
 }
 
-function addUnaryOption(options: Record<string, JDLUnaryOption | JDLBinaryOption>, optionToAdd: JDLUnaryOption) {
+function addUnaryOption(options: Record<string, JDLUnaryOption | JDLBinaryOption>, optionToAdd: JDLUnaryOption): void {
   const key = optionToAdd.name;
   if (!options[key]) {
     options[key] = optionToAdd;
@@ -99,7 +99,7 @@ function addUnaryOption(options: Record<string, JDLUnaryOption | JDLBinaryOption
   options[key].addEntitiesFromAnotherOption(optionToAdd);
 }
 
-function addBinaryOption(options: Record<string, any>, optionToAdd: JDLBinaryOption) {
+function addBinaryOption(options: Record<string, any>, optionToAdd: JDLBinaryOption): void {
   const { name, value } = optionToAdd;
 
   if (!options[name]) {

--- a/jdl/models/jdl-relationships.ts
+++ b/jdl/models/jdl-relationships.ts
@@ -34,30 +34,30 @@ export default class JDLRelationships {
     };
   }
 
-  add(relationship: JDLRelationship) {
+  add(relationship: JDLRelationship): void {
     if (!relationship) {
       throw new Error('A relationship must be passed so as to be added.');
     }
     this.relationships[relationship.type].set(relationship.getId(), relationship);
   }
 
-  getOneToOne(relationshipId) {
+  getOneToOne(relationshipId: string): JDLRelationship | undefined {
     return this.get(relationshipTypes.ONE_TO_ONE, relationshipId);
   }
 
-  getOneToMany(relationshipId) {
+  getOneToMany(relationshipId: string): JDLRelationship | undefined {
     return this.get(relationshipTypes.ONE_TO_MANY, relationshipId);
   }
 
-  getManyToOne(relationshipId) {
+  getManyToOne(relationshipId: string): JDLRelationship | undefined {
     return this.get(relationshipTypes.MANY_TO_ONE, relationshipId);
   }
 
-  getManyToMany(relationshipId) {
+  getManyToMany(relationshipId: string): JDLRelationship | undefined {
     return this.get(relationshipTypes.MANY_TO_MANY, relationshipId);
   }
 
-  get(type, relationshipId): JDLRelationship {
+  get(type: JDLRelationshipType, relationshipId: string): JDLRelationship | undefined {
     if (!relationshipTypeExists(type)) {
       throw new Error(`A valid relationship type must be passed so as to retrieve the relationship, got '${type}'.`);
     }
@@ -67,23 +67,23 @@ export default class JDLRelationships {
     return this.relationships[type].get(relationshipId);
   }
 
-  oneToOneQuantity() {
+  oneToOneQuantity(): number {
     return this.relationships.OneToOne.size;
   }
 
-  oneToManyQuantity() {
+  oneToManyQuantity(): number {
     return this.relationships.OneToMany.size;
   }
 
-  manyToOneQuantity() {
+  manyToOneQuantity(): number {
     return this.relationships.ManyToOne.size;
   }
 
-  manyToManyQuantity() {
+  manyToManyQuantity(): number {
     return this.relationships.ManyToMany.size;
   }
 
-  size() {
+  size(): number {
     return this.oneToOneQuantity() + this.oneToManyQuantity() + this.manyToOneQuantity() + this.manyToManyQuantity();
   }
 
@@ -106,7 +106,7 @@ export default class JDLRelationships {
     return relationships;
   }
 
-  toString() {
+  toString(): string {
     if (this.size() === 0) {
       return '';
     }

--- a/jdl/models/jdl-unary-option.ts
+++ b/jdl/models/jdl-unary-option.ts
@@ -24,11 +24,11 @@ import { join } from '../utils/set-utils.js';
  * For flags such as skipServer, skipClient, etc.
  */
 export default class JDLUnaryOption extends AbstractJDLOption {
-  getType() {
+  getType(): string {
     return 'UNARY';
   }
 
-  toString() {
+  toString(): string {
     const entityNames = join(this.entityNames, ', ');
     entityNames.slice(1, entityNames.length - 1);
     const firstPart = `${this.name} ${entityNames}`;

--- a/jdl/models/jdl-validation.ts
+++ b/jdl/models/jdl-validation.ts
@@ -25,12 +25,12 @@ const {
 } = validations;
 
 export default class JDLValidation {
-  name: any;
-  value: any;
+  name: string;
+  value?: string | number | RegExp;
 
-  constructor(args) {
+  constructor(args: Partial<JDLValidation>) {
     const merged = merge(defaults(), args);
-    this.name = merged.name;
+    this.name = merged.name!;
     this.value = merged.value;
   }
 
@@ -43,21 +43,21 @@ export default class JDLValidation {
   }
 }
 
-function defaults() {
+function defaults(): JDLValidation {
   return {
     name: REQUIRED,
     value: '',
   };
 }
 
-function formatValidationValue(name, value) {
+function formatValidationValue(name: string, value: string | number | RegExp) {
   if (name === PATTERN) {
     return getPatternValidationValue(value);
   }
   return value;
 }
 
-function getPatternValidationValue(value) {
+function getPatternValidationValue(value: string | number | RegExp) {
   if (value instanceof RegExp) {
     return value.toString();
   }

--- a/jdl/models/list-jdl-application-configuration-option.ts
+++ b/jdl/models/list-jdl-application-configuration-option.ts
@@ -18,21 +18,21 @@
  */
 
 import JDLApplicationConfigurationOption from './jdl-application-configuration-option.js';
-import { join } from '../utils/set-utils.js';
+import { join } from '../utils/array-utils.js';
 
-export default class ListJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption {
+export default class ListJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption<string[]> {
   quoted: boolean;
 
   constructor(name: string, value: string[], quoted: boolean = false) {
-    super(name, new Set(value));
+    super(name, value);
     this.quoted = quoted;
   }
 
-  getValue(): any[] {
-    return Array.from(this.value);
+  getValue(): string[] {
+    return this.value;
   }
 
-  toString() {
+  toString(): string {
     return `${this.name} [${join(this.value, ', ', this.quoted)}]`;
   }
 }

--- a/jdl/models/list-jdl-application-configuration-option.ts
+++ b/jdl/models/list-jdl-application-configuration-option.ts
@@ -18,18 +18,19 @@
  */
 
 import JDLApplicationConfigurationOption from './jdl-application-configuration-option.js';
-import { join } from '../utils/array-utils.js';
+import { join } from '../utils/set-utils.js';
 
-export default class ListJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption<string[]> {
+export default class ListJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption<any> {
+  // TODO for v9, use set everywhere
   quoted: boolean;
 
   constructor(name: string, value: string[], quoted: boolean = false) {
-    super(name, value);
+    super(name, new Set(value));
     this.quoted = quoted;
   }
 
   getValue(): string[] {
-    return this.value;
+    return Array.from(this.value);
   }
 
   toString(): string {

--- a/jdl/models/string-jdl-application-configuration-option.ts
+++ b/jdl/models/string-jdl-application-configuration-option.ts
@@ -19,15 +19,15 @@
 
 import JDLApplicationConfigurationOption from './jdl-application-configuration-option.js';
 
-export default class StringJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption {
+export default class StringJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption<string> {
   quoted: boolean;
 
-  constructor(name: string, value, quoted = false) {
+  constructor(name: string, value: string, quoted = false) {
     super(name, value);
     this.quoted = quoted;
   }
 
-  toString() {
+  toString(): string {
     const value = this.quoted && !this.value.includes('"') ? `"${this.value}"` : this.value;
     return `${this.name} ${value}`;
   }

--- a/jdl/utils/array-utils.ts
+++ b/jdl/utils/array-utils.ts
@@ -23,7 +23,7 @@ export default function deduplicate<T>(array: T[]): T[] {
 
 export function join(set: unknown[], separator = ',', quoted = false) {
   if (!set) {
-    throw new Error('A Set must be passed so as to join elements.');
+    throw new Error('An Array must be passed so as to join elements.');
   }
   return set.map(val => (quoted ? `"${val}"` : val)).join(separator);
 }

--- a/jdl/utils/array-utils.ts
+++ b/jdl/utils/array-utils.ts
@@ -20,3 +20,10 @@
 export default function deduplicate<T>(array: T[]): T[] {
   return Array.from(new Set(array));
 }
+
+export function join(set: unknown[], separator = ',', quoted = false) {
+  if (!set) {
+    throw new Error('A Set must be passed so as to join elements.');
+  }
+  return set.map(val => (quoted ? `"${val}"` : val)).join(separator);
+}

--- a/jdl/utils/set-utils.ts
+++ b/jdl/utils/set-utils.ts
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { join as arrayJoin } from './array-utils.js';
 
 export function addAll<T>(set: Set<T>, elements: T[]) {
   if (!set) {
@@ -32,7 +33,5 @@ export function join(set: Set<unknown>, separator = ',', quoted = false) {
   if (!set) {
     throw new Error('A Set must be passed so as to join elements.');
   }
-  return Array.from(set)
-    .map(val => (quoted ? `"${val}"` : val))
-    .join(separator);
+  return arrayJoin(Array.from(set), separator, quoted);
 }

--- a/jdl/validators/jdl-with-application-validator.spec.ts
+++ b/jdl/validators/jdl-with-application-validator.spec.ts
@@ -328,14 +328,14 @@ describe('jdl - JDLWithApplicationValidator', () => {
           new JDLBinaryOption({
             name: binaryOptions.Options.DTO,
             value: binaryOptions.Values.dto.MAPSTRUCT,
-            entityNames: ['A', 'B', 'C'],
+            entityNames: new Set(['A', 'B', 'C']),
           }),
         );
         jdlObject.addOption(
           new JDLBinaryOption({
             name: binaryOptions.Options.SERVICE,
             value: binaryOptions.Values.service.SERVICE_CLASS,
-            entityNames: ['B'],
+            entityNames: new Set(['B']),
           }),
         );
         validator = createValidator(jdlObject);
@@ -379,14 +379,14 @@ describe('jdl - JDLWithApplicationValidator', () => {
           new JDLBinaryOption({
             name: binaryOptions.Options.DTO,
             value: binaryOptions.Values.dto.MAPSTRUCT,
-            entityNames: ['A', 'B'],
+            entityNames: new Set(['A', 'B']),
           }),
         );
         jdlObject.addOption(
           new JDLBinaryOption({
             name: binaryOptions.Options.SERVICE,
             value: binaryOptions.Values.service.SERVICE_CLASS,
-            excludedNames: ['C'],
+            excludedNames: new Set(['C']),
           }),
         );
         validator = createValidator(jdlObject);
@@ -421,8 +421,8 @@ describe('jdl - JDLWithApplicationValidator', () => {
         jdlObject.addEntity(sourceEntity);
         jdlObject.addEntity(destinationEntity);
         jdlObject.addRelationship(relationship);
-        application.addEntityName(sourceEntity);
-        application.addEntityName(destinationEntity);
+        application.addEntityName(sourceEntity.name);
+        application.addEntityName(destinationEntity.name);
         jdlObject.addApplication(application);
         validator = createValidator(jdlObject);
       });
@@ -455,8 +455,8 @@ describe('jdl - JDLWithApplicationValidator', () => {
         jdlObject.addEntity(sourceEntity);
         jdlObject.addEntity(destinationEntity);
         jdlObject.addRelationship(relationship);
-        application.addEntityName(sourceEntity);
-        application.addEntityName(destinationEntity);
+        application.addEntityName(sourceEntity.name);
+        application.addEntityName(destinationEntity.name);
         jdlObject.addApplication(application);
         validator = createValidator(jdlObject);
       });

--- a/jdl/validators/jdl-with-application-validator.ts
+++ b/jdl/validators/jdl-with-application-validator.ts
@@ -30,7 +30,8 @@ import JDLObject from '../models/jdl-object.js';
 import JDLRelationship from '../models/jdl-relationship.js';
 import JDLApplication from '../models/jdl-application.js';
 import { ValidatorOptions } from './validator.js';
-import type JDLApplicationConfigurationOption from '../models/jdl-application-configuration-option.js';
+import JDLField from '../models/jdl-field.js';
+import JDLApplicationConfigurationOption from '../models/jdl-application-configuration-option.js';
 
 const { OptionNames } = applicationOptions;
 
@@ -48,7 +49,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
   }
 
   return {
-    checkForErrors: () => {
+    checkForErrors: (): void => {
       jdlObject.forEachApplication(jdlApplication => {
         const blueprints = jdlApplication.getConfigurationOptionValue(BLUEPRINTS);
         const checkReservedKeywords = (blueprints?.length ?? 0) === 0;
@@ -67,16 +68,16 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     },
   };
 
-  function checkForNamespaceConfigErrors(jdlApplication: JDLApplication) {
+  function checkForNamespaceConfigErrors(jdlApplication: JDLApplication): void {
     jdlApplication.forEachNamespaceConfiguration(config => {
-      const blueprints: JDLApplicationConfigurationOption | undefined = jdlApplication.config.getOption('blueprints');
+      const blueprints: JDLApplicationConfigurationOption<string[]> | undefined = jdlApplication.config.getOption('blueprints');
       if (!blueprints || !blueprints.getValue().some(blueprint => blueprint === config.namespace)) {
         throw new Error(`Blueprint namespace config ${config.namespace} requires the blueprint ${config.namespace}`);
       }
     });
   }
 
-  function checkForEntityErrors(jdlApplication, options: ValidatorOptions) {
+  function checkForEntityErrors(jdlApplication: JDLApplication, options: ValidatorOptions): void {
     if (jdlObject.getEntityQuantity() === 0) {
       return;
     }
@@ -90,7 +91,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     });
   }
 
-  function checkForFieldErrors(_entityName, jdlFields, _jdlApplication) {
+  function checkForFieldErrors(_entityName: string, jdlFields: Record<string, JDLField>, _jdlApplication: JDLApplication): void {
     const validator = new FieldValidator();
     Object.keys(jdlFields).forEach(fieldName => {
       const jdlField = jdlFields[fieldName];
@@ -100,7 +101,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     });
   }
 
-  function checkForValidationErrors(jdlField, isAnEnum) {
+  function checkForValidationErrors(jdlField: JDLField, isAnEnum: boolean): void {
     const validator = new ValidationValidator();
     Object.keys(jdlField.validations).forEach(validationName => {
       const jdlValidation = jdlField.validations[validationName];
@@ -111,7 +112,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     });
   }
 
-  function checkForRelationshipErrors() {
+  function checkForRelationshipErrors(): void {
     if (jdlObject.getRelationshipQuantity() === 0) {
       return;
     }
@@ -125,7 +126,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     });
   }
 
-  function checkForEnumErrors(options: ValidatorOptions) {
+  function checkForEnumErrors(options: ValidatorOptions): void {
     if (jdlObject.getEnumQuantity() === 0) {
       return;
     }
@@ -135,7 +136,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     });
   }
 
-  function checkDeploymentsErrors() {
+  function checkDeploymentsErrors(): void {
     if (jdlObject.getDeploymentQuantity() === 0) {
       return;
     }
@@ -145,7 +146,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     });
   }
 
-  function checkForOptionErrors() {
+  function checkForOptionErrors(): void {
     if (jdlObject.getOptionQuantity() === 0) {
       return;
     }
@@ -160,7 +161,7 @@ export default function createValidator(jdlObject: JDLObject, logger: any = cons
     });
   }
 
-  function checkForRelationshipsBetweenApplications() {
+  function checkForRelationshipsBetweenApplications(): void {
     const applicationsPerEntityNames = getApplicationsPerEntityNames(jdlObject);
     jdlObject.forEachRelationship(jdlRelationship => {
       checkIfRelationshipIsBetweenApplications({
@@ -212,7 +213,7 @@ function checkIfRelationshipIsBetweenApplications({ jdlRelationship, application
     );
   }
 }
-function getApplicationsPerEntityNames(jdlObject) {
+function getApplicationsPerEntityNames(jdlObject: JDLObject) {
   const applicationsPerEntityName = {};
   jdlObject.forEachApplication(jdlApplication => {
     jdlApplication.forEachEntityName(entityName => {

--- a/jdl/validators/jdl-without-application-validator.ts
+++ b/jdl/validators/jdl-without-application-validator.ts
@@ -105,10 +105,10 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
         }
       }
       const typeCheckingFunction = getTypeCheckingFunction(entityName, applicationSettings);
-      if (!jdlObject.hasEnum(jdlField.type) && !typeCheckingFunction(jdlField.type)) {
+      const isAnEnum = jdlObject.hasEnum(jdlField.type);
+      if (!isAnEnum && !typeCheckingFunction(jdlField.type)) {
         throw new Error(`The type '${jdlField.type}' is an unknown field type for field '${fieldName}' of entity '${entityName}'.`);
       }
-      const isAnEnum = jdlObject.hasEnum(jdlField.type);
       checkForValidationErrors(jdlField, isAnEnum);
     });
   }
@@ -186,7 +186,7 @@ function checkForAbsentEntities({
   doesEntityExist,
 }: {
   jdlRelationship: JDLRelationship;
-  doesEntityExist: (string) => boolean;
+  doesEntityExist: (entityName: string) => boolean;
 }) {
   const absentEntities: any[] = [];
   if (!doesEntityExist(jdlRelationship.from)) {
@@ -204,6 +204,7 @@ function checkForAbsentEntities({
     );
   }
 }
+
 function checkForPaginationInAppWithCassandra(jdlOption: AbstractJDLOption, applicationSettings): void {
   if (applicationSettings.databaseType === databaseTypes.CASSANDRA && jdlOption.name === binaryOptions.Options.PAGINATION) {
     throw new Error("Pagination isn't allowed when the application uses Cassandra.");

--- a/jdl/validators/jdl-without-application-validator.ts
+++ b/jdl/validators/jdl-without-application-validator.ts
@@ -31,6 +31,8 @@ import JDLObject from '../models/jdl-object.js';
 import JDLRelationship from '../models/jdl-relationship.js';
 import { ValidatorOptions } from './validator.js';
 import { isReservedFieldName, isReservedPaginationWords, isReservedTableName } from '../jhipster/reserved-keywords.js';
+import JDLField from '../models/jdl-field.js';
+import AbstractJDLOption from '../models/abstract-jdl-option.js';
 
 const { BUILT_IN_ENTITY } = relationshipOptions;
 const { SQL } = databaseTypes;
@@ -67,7 +69,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
     },
   };
 
-  function checkForEntityErrors(options: ValidatorOptions) {
+  function checkForEntityErrors(options: ValidatorOptions): void {
     if (jdlObject.getEntityQuantity() === 0) {
       return;
     }
@@ -85,7 +87,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
     });
   }
 
-  function checkForFieldErrors(entityName, jdlFields, options: ValidatorOptions) {
+  function checkForFieldErrors(entityName: string, jdlFields: Record<string, JDLField>, options: ValidatorOptions) {
     const validator = new FieldValidator();
     const filtering = applicationSettings.databaseType === SQL;
 
@@ -111,7 +113,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
     });
   }
 
-  function checkForValidationErrors(jdlField, isAnEnum) {
+  function checkForValidationErrors(jdlField: JDLField, isAnEnum: boolean): void {
     const validator = new ValidationValidator();
     jdlField.forEachValidation(jdlValidation => {
       validator.validate(jdlValidation);
@@ -121,7 +123,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
     });
   }
 
-  function checkForRelationshipErrors() {
+  function checkForRelationshipErrors(): void {
     if (jdlObject.getRelationshipQuantity() === 0) {
       return;
     }
@@ -135,7 +137,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
     });
   }
 
-  function checkForEnumErrors(options: ValidatorOptions) {
+  function checkForEnumErrors(options: ValidatorOptions): void {
     if (jdlObject.getEnumQuantity() === 0) {
       return;
     }
@@ -145,7 +147,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
     });
   }
 
-  function checkDeploymentsErrors() {
+  function checkDeploymentsErrors(): void {
     if (jdlObject.getDeploymentQuantity() === 0) {
       return;
     }
@@ -155,7 +157,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
     });
   }
 
-  function checkForOptionErrors() {
+  function checkForOptionErrors(): void {
     if (jdlObject.getOptionQuantity() === 0) {
       return;
     }
@@ -172,7 +174,7 @@ export default function createValidator(jdlObject: JDLObject, applicationSetting
   }
 }
 
-function getTypeCheckingFunction(entityName, applicationSettings) {
+function getTypeCheckingFunction(entityName: string, applicationSettings) {
   if (applicationSettings.applicationType === applicationTypes.GATEWAY) {
     return () => true;
   }
@@ -202,7 +204,7 @@ function checkForAbsentEntities({
     );
   }
 }
-function checkForPaginationInAppWithCassandra(jdlOption, applicationSettings) {
+function checkForPaginationInAppWithCassandra(jdlOption: AbstractJDLOption, applicationSettings): void {
   if (applicationSettings.databaseType === databaseTypes.CASSANDRA && jdlOption.name === binaryOptions.Options.PAGINATION) {
     throw new Error("Pagination isn't allowed when the application uses Cassandra.");
   }


### PR DESCRIPTION
~~Unfortunately, this PR has a breaking change: JDL exporter do not print a Set anymore but an array instead for JDLOption.~~
I think that we should generalize the use of array for persistence and the use of Sets when manipulating data (when there's a need for unicity).

~~I didn't succeed (after hours) to keep retrocompatibility after hours, so guess that I fixed a bug somewhere by forcing type safety~~

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
