### PR TITLE
improvements to generate-sample

### DIFF
--- a/.blueprint/generate-sample/command.mts
+++ b/.blueprint/generate-sample/command.mts
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { join } from 'node:path';
+import process from 'node:process';
+import { defaultSamplesFolder } from '../constants.js';
 import { JHipsterCommandDefinition } from '../../generators/base/api.js';
 import { GENERATOR_APP, GENERATOR_WORKSPACES } from '../../generators/generator-list.js';
 
@@ -25,17 +28,51 @@ const command: JHipsterCommandDefinition = {
       type: String,
     },
   },
-  options: {
+  configs: {
+    entitiesSample: {
+      cli: {
+        type: String,
+        description: 'Entities sample to copy',
+      },
+      configure: (gen: any) => {
+        if (['mongodb', 'couchbase'].includes(gen.entitiesSample)) {
+          gen.entitiesSample = 'document';
+        }
+      },
+      choices: ['sql', 'sqllight', 'micro', 'sqlfull', 'mongodb', 'document', 'cassandra', 'couchbase'],
+      scope: 'generator',
+    },
     global: {
-      type: Boolean,
-      description: 'Generate in global samples folder',
+      cli: {
+        type: Boolean,
+        description: 'Generate in global samples folder',
+      },
+      configure: (gen: any) => {
+        if (gen.global && !gen.projectFolder) {
+          gen.projectFolder = join(gen._globalConfig.get('samplesFolder') ?? defaultSamplesFolder, gen.sampleName);
+        }
+      },
       scope: 'generator',
     },
     projectFolder: {
-      type: String,
-      description: 'Folder to generate the sample',
+      cli: {
+        type: String,
+        description: 'Folder to generate the sample',
+        env: 'JHI_FOLDER_APP',
+      },
+      configure: (gen: any) => {
+        if (!gen.projectFolder) {
+          gen.projectFolder = process.cwd();
+        }
+      },
       scope: 'generator',
-      env: 'JHI_FOLDER_APP',
+    },
+  },
+  options: {
+    sampleYorcFolder: {
+      type: Boolean,
+      description: 'Treat sample arg as .yo-rc.json folder path',
+      scope: 'generator',
     },
   },
   import: [GENERATOR_APP, GENERATOR_WORKSPACES],

--- a/.blueprint/generate-sample/generator.mjs
+++ b/.blueprint/generate-sample/generator.mjs
@@ -2,7 +2,7 @@ import { extname } from 'path';
 import { transform } from '@yeoman/transform';
 import BaseGenerator from '../../generators/base/index.js';
 import { packageJson } from '../../lib/index.js';
-import { generateSample } from './support/generate-sample.js';
+import { generateSample, entitiesByType } from './support/index.js';
 import { promptSamplesFolder } from '../support.mjs';
 import { GENERATOR_APP, GENERATOR_JDL } from '../../generators/generator-list.js';
 
@@ -11,6 +11,8 @@ export default class extends BaseGenerator {
   global;
   projectFolder;
   projectVersion;
+  entitiesSample;
+  sampleYorcFolder;
 
   get [BaseGenerator.INITIALIZING]() {
     return this.asInitializingTaskGroup({
@@ -33,6 +35,14 @@ export default class extends BaseGenerator {
     });
   }
 
+  get [BaseGenerator.CONFIGURING]() {
+    return this.asConfiguringTaskGroup({
+      async configureCommand() {
+        await this.configureCurrentJHipsterCommandConfig();
+      },
+    });
+  }
+
   get [BaseGenerator.END]() {
     return this.asEndTaskGroup({
       async generateJdlSample() {
@@ -40,15 +50,14 @@ export default class extends BaseGenerator {
 
         await this.composeWithJHipster(GENERATOR_JDL, {
           generatorArgs: [this.templatePath('samples', this.sampleName)],
-          generatorOptions: { projectVersion: this.projectVersion },
+          generatorOptions: { projectVersion: this.projectVersion, destinationPath: this.projectFolder },
         });
       },
       async generateSample() {
-        if (extname(this.sampleName) === '.jdl') return;
+        if (extname(this.sampleName) === '.jdl' || this.sampleYorcFolder) return;
 
         const sample = await generateSample(this.sampleName, {
-          destSamplesFolder: this._globalConfig.get('samplesFolder'),
-          destProjectFolder: this.projectFolder ?? this.global ? undefined : process.cwd(),
+          destProjectFolder: this.projectFolder,
           fork: false,
         });
 
@@ -58,7 +67,11 @@ export default class extends BaseGenerator {
           transform(() => {}),
         );
 
-        let generatorOptions = { projectVersion: this.projectVersion, ...sample.sample.generatorOptions };
+        let generatorOptions = {
+          projectVersion: this.projectVersion,
+          destinationPath: this.projectFolder,
+          ...sample.sample.generatorOptions,
+        };
         if (sample.sample.workspaces && sample.sample.workspaces !== 'false') {
           generatorOptions = { ...generatorOptions, workspaces: true, monorepository: true };
         }
@@ -71,11 +84,34 @@ export default class extends BaseGenerator {
           if (sample.jdlFiles) {
             await this.composeWithJHipster(GENERATOR_JDL, {
               generatorArgs: sample.jdlFiles,
-              generatorOptions: { jsonOnly: true },
+              generatorOptions: { jsonOnly: true, destinationPath: this.projectFolder },
             });
           }
           await this.composeWithJHipster(GENERATOR_APP, { generatorOptions });
         }
+      },
+      async generateYoRcSample() {
+        if (!this.sampleYorcFolder) return;
+        this.copyTemplate(`../../../test-integration/${this.sampleName}/.yo-rc.json`, '.yo-rc.json');
+        const entitiesFiles = entitiesByType[this.entitiesSample];
+        if (entitiesFiles) {
+          this.jhipsterConfig.entities = entitiesFiles;
+          /*
+          this.copyTemplate(
+            entitiesFiles.map(entity => `.jhipster/${entity}.json`),
+            this.projectFolder,
+            { noGlob: true, fromBasePath: this.templatePath('../../../test-integration/samples/') },
+          );
+          */
+          entitiesFiles.forEach(entity =>
+            this.copyTemplate(
+              `../../../test-integration/samples/.jhipster/${entity}.json`,
+              `${this.projectFolder}/.jhipster/${entity}.json`,
+              { noGlob: true },
+            ),
+          );
+        }
+        await this.composeWithJHipster(GENERATOR_APP, { generatorOptions: { destinationPath: this.projectFolder } });
       },
       async updateVscodeWorkspace() {
         if (this.global) {

--- a/.blueprint/generate-sample/support/generate-sample.js
+++ b/.blueprint/generate-sample/support/generate-sample.js
@@ -7,22 +7,14 @@ import { execa } from 'execa';
 import getSamples, { DAILY_PREFIX, isDaily } from './get-workflow-samples.js';
 import copyEntitySamples from './copy-entity-samples.js';
 import copyJdlEntitySamples from './copy-jdl-entity-samples.js';
-import {
-  dailyBuildsFolder,
-  defaultSamplesFolder,
-  jdlEntitiesSamplesFolder,
-  jdlSamplesFolder,
-  jhipsterBin,
-  samplesFolder,
-} from '../../constants.js';
+import { dailyBuildsFolder, jdlEntitiesSamplesFolder, jdlSamplesFolder, jhipsterBin, samplesFolder } from '../../constants.js';
 
 const commonCliOptions = ['--skip-jhipster-dependencies', '--skip-checks', '--skip-install', '--no-insight'];
 
 export const generateSample = async (
   sampleName = process.argv.length > 2 ? process.argv[2] : process.env.JHI_APP,
   {
-    destSamplesFolder = defaultSamplesFolder,
-    destProjectFolder = process.env.JHI_FOLDER_APP ? resolve(process.env.JHI_FOLDER_APP) : join(destSamplesFolder, sampleName),
+    destProjectFolder,
     environment: passedEnvironment,
     war: passedWar,
     entity: passedEntity,

--- a/.blueprint/generate-sample/support/index.ts
+++ b/.blueprint/generate-sample/support/index.ts
@@ -1,0 +1,2 @@
+export * from './copy-entity-samples.js';
+export * from './generate-sample.js';


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/24135

Allow to generate a sample using `.yo-rc.json` folder.
Related to https://github.com/hipster-labs/jhipster-daily-builds/pull/156.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
