### PR TITLE
remove close button from the header.

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/admin/user-management/delete/user-management-delete-dialog.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/user-management/delete/user-management-delete-dialog.component.html.ejs
@@ -20,8 +20,6 @@
 <form name="deleteForm" (ngSubmit)="confirmDelete(user.login!)">
   <div class="modal-header">
     <h4 class="modal-title">__jhiTranslateTag__('entity.delete.title')</h4>
-
-    <span class="btn btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></span>
   </div>
 
   <div class="modal-body">

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/delete/_entityFile_-delete-dialog.component.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/delete/_entityFile_-delete-dialog.component.html.ejs
@@ -20,9 +20,6 @@
 <form name="deleteForm" (ngSubmit)="confirmDelete(<%= entityInstance %>.<%= primaryKey.name %>!)">
     <div class="modal-header">
         <h4 class="modal-title" data-cy="<%= entityInstance %>DeleteDialogHeading">__jhiTranslateTag__('entity.delete.title')</h4>
-
-        <span class="btn btn-close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()"></span>
     </div>
 
     <div class="modal-body">


### PR DESCRIPTION
Related to https://github.com/SonarSource/sonar-html/pull/291#issuecomment-2109599752.

The dismiss button in the header is duplicated of the cancel button action.
We can remove the button from the header or ignore the error.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
