### PR TITLE
Cypress: Fix warn 'response is possibly undefined'

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/login-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/login-page.cy.ts.ejs
@@ -52,7 +52,7 @@ describe('login modal', () => {
     cy.get(passwordLoginSelector).type('a-password');
     cy.get(submitLoginSelector).click();
 <%_ if (!clientFrameworkReact) { _%>
-    cy.wait('@authenticate').then(({ response }) => expect(response.statusCode).to.equal(<% if (authenticationTypeSession) { %>401<% } else { %>400<% } %>));
+    cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(<% if (authenticationTypeSession) { %>401<% } else { %>400<% } %>));
 <%_ } _%>
     // login page should stay open when login fails
     cy.get(titleLoginSelector).should('be.visible');
@@ -62,7 +62,7 @@ describe('login modal', () => {
     cy.get(usernameLoginSelector).type('a-login');
     cy.get(submitLoginSelector).click();
 <%_ if (!clientFrameworkReact) { _%>
-    cy.wait('@authenticate').then(({ response }) => expect(response.statusCode).to.equal(<% if (authenticationTypeSession) { %>401<% } else { %>400<% } %>));
+    cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(<% if (authenticationTypeSession) { %>401<% } else { %>400<% } %>));
     cy.get(errorLoginSelector).should('be.visible');
 <%_ } else { _%>
     // login page should stay open when login fails
@@ -74,7 +74,7 @@ describe('login modal', () => {
     cy.get(usernameLoginSelector).type(username);
     cy.get(passwordLoginSelector).type('bad-password');
     cy.get(submitLoginSelector).click();
-    cy.wait('@authenticate').then(({ response }) => expect(response.statusCode).to.equal(401));
+    cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(401));
     cy.get(errorLoginSelector).should('be.visible');
   });
 
@@ -82,7 +82,7 @@ describe('login modal', () => {
     cy.get(usernameLoginSelector).type(username);
     cy.get(passwordLoginSelector).type(password);
     cy.get(submitLoginSelector).click();
-    cy.wait('@authenticate').then(({ response }) => expect(response.statusCode).to.equal(200));
+    cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(200));
     cy.hash().should('eq', '');
   });
 });

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/password-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/password-page.cy.ts.ejs
@@ -80,7 +80,7 @@ describe('/account/password', () => {
     cy.get(newPasswordSelector).type('jhipster');
     cy.get(confirmPasswordSelector).type('jhipster');
     cy.get(submitPasswordSelector).click();
-    cy.wait('@passwordSave').then(({ response }) => expect(response.statusCode).to.equal(400));
+    cy.wait('@passwordSave').then(({ response }) => expect(response?.statusCode).to.equal(400));
   });
 
   it("should be able to update password", () => {
@@ -88,6 +88,6 @@ describe('/account/password', () => {
     cy.get(newPasswordSelector).type(password);
     cy.get(confirmPasswordSelector).type(password);
     cy.get(submitPasswordSelector).click();
-    cy.wait('@passwordSave').then(({ response }) => expect(response.statusCode).to.equal(200));
+    cy.wait('@passwordSave').then(({ response }) => expect(response?.statusCode).to.equal(200));
   });
 });

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/register-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/register-page.cy.ts.ejs
@@ -128,6 +128,6 @@ describe('<%= registerPage %>', () => {
     cy.get(firstPasswordRegisterSelector).type('jondoe');
     cy.get(secondPasswordRegisterSelector).type('jondoe');
     cy.get(submitRegisterSelector).click();
-    cy.wait('@registerSave').then(({ response }) => expect(response.statusCode).to.equal(201));
+    cy.wait('@registerSave').then(({ response }) => expect(response?.statusCode).to.equal(201));
   });
 });

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/reset-password-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/reset-password-page.cy.ts.ejs
@@ -54,6 +54,6 @@ describe('forgot your password', () => {
   it('should be able to init reset password', () => {
     cy.get(emailResetPasswordSelector).type('user@gmail.com');
     cy.get(submitInitResetPasswordSelector).click({ force: true });
-    cy.wait('@initResetPassword').then(({ response }) => expect(response.statusCode).to.equal(200));
+    cy.wait('@initResetPassword').then(({ response }) => expect(response?.statusCode).to.equal(200));
   });
 });

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/entity/_entity_.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/entity/_entity_.cy.ts.ejs
@@ -146,7 +146,7 @@ describe('<%= entityClass %> e2e test', () => {
     cy.visit('/');
     cy.clickOnEntityMenuItem('<%= entityPage %>');
     cy.wait('@entitiesRequest').then(({ response }) => {
-      if (response.body.length === 0) {
+      if (response?.body.length === 0) {
         cy.get(entityTableSelector).should('not.exist');
       } else {
         cy.get(entityTableSelector).should('exist');
@@ -171,7 +171,7 @@ describe('<%= entityClass %> e2e test', () => {
         cy.get(entityCreateSaveButtonSelector).should('exist');
         cy.get(entityCreateCancelButtonSelector).click();
         cy.wait('@entitiesRequest').then(({ response }) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response?.statusCode).to.equal(200);
         });
         cy.url().should('match', <%= entityInstance %>PageUrlPattern);
       });
@@ -232,7 +232,7 @@ describe('<%= entityClass %> e2e test', () => {
         cy.visit(<%= entityInstance %>PageUrl);
 
         cy.wait('@entitiesRequest').then(({ response }) => {
-          if (response.body.length === 0) {
+          if (response?.body.length === 0) {
             this.skip();
           }
         });
@@ -244,7 +244,7 @@ describe('<%= entityClass %> e2e test', () => {
         cy.getEntityDetailsHeading('<%= entityInstance %>');
         cy.get(entityDetailsBackButtonSelector).click();
         cy.wait('@entitiesRequest').then(({ response }) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response?.statusCode).to.equal(200);
         });
         cy.url().should('match', <%= entityInstance %>PageUrlPattern);
       });
@@ -256,7 +256,7 @@ describe('<%= entityClass %> e2e test', () => {
         cy.get(entityCreateSaveButtonSelector).should('exist');
         cy.get(entityCreateCancelButtonSelector).click();
         cy.wait('@entitiesRequest').then(({ response }) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response?.statusCode).to.equal(200);
         });
         cy.url().should('match', <%= entityInstance %>PageUrlPattern);
       });
@@ -266,7 +266,7 @@ describe('<%= entityClass %> e2e test', () => {
         cy.getEntityCreateUpdateHeading('<%= entityClass %>');
         cy.get(entityCreateSaveButtonSelector).click();
         cy.wait('@entitiesRequest').then(({ response }) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response?.statusCode).to.equal(200);
         });
         cy.url().should('match', <%= entityInstance %>PageUrlPattern);
       });
@@ -284,10 +284,10 @@ describe('<%= entityClass %> e2e test', () => {
         cy.getEntityDeleteDialogHeading('<%= entityInstance %>').should('exist');
         cy.get(entityConfirmDeleteButtonSelector).click();
         cy.wait('@deleteEntityRequest').then(({ response }) => {
-          expect(response.statusCode).to.equal(204);
+          expect(response?.statusCode).to.equal(204);
         });
         cy.wait('@entitiesRequest').then(({ response }) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response?.statusCode).to.equal(200);
         });
         cy.url().should('match', <%= entityInstance %>PageUrlPattern);
   <% if (cypressBootstrapEntities) { %>
@@ -351,11 +351,11 @@ describe('<%= entityClass %> e2e test', () => {
       cy.get(entityCreateSaveButtonSelector).click();
 
       cy.wait('@postEntityRequest').then(({ response }) => {
-        expect(response.statusCode).to.equal(201);
+        expect(response?.statusCode).to.equal(201);
         <%= entityInstance %> = response.body;
       });
       cy.wait('@entitiesRequest').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
+        expect(response?.statusCode).to.equal(200);
       });
       cy.url().should('match', <%= entityInstance %>PageUrlPattern);
     });


### PR DESCRIPTION
Fix warn
![image](https://github.com/jhipster/generator-jhipster/assets/9989211/ed21eaad-9add-428a-ada6-ab0f44bb35a8)

Already done here https://github.com/jhipster/generator-jhipster/blob/f360fb3c4cb8411ef05f1dbd75032d5334a0d50f/generators/cypress/templates/src/test/javascript/cypress/e2e/account/settings-page.cy.ts.ejs#L77

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
