### PR TITLE
[Angular] Fix deprecated RxJS method (throwError)

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/activate/activate.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/activate/activate.component.spec.ts.ejs
@@ -76,7 +76,7 @@ describe('ActivateComponent', () => {
   it('should set set error to true upon activation failure', inject(
     [ActivateService],
     fakeAsync((service: ActivateService) => {
-      jest.spyOn(service, 'get').mockReturnValue(throwError('ERROR'));
+      jest.spyOn(service, 'get').mockReturnValue(throwError(() => {}));
 
       comp.ngOnInit();
       tick();

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
@@ -98,7 +98,7 @@ describe('PasswordResetFinishComponent', () => {
   it('should notify of generic error', inject(
     [PasswordResetFinishService],
     fakeAsync((service: PasswordResetFinishService) => {
-      jest.spyOn(service, 'save').mockReturnValue(throwError('ERROR'));
+      jest.spyOn(service, 'save').mockReturnValue(throwError(() => {}));
       comp.passwordForm.patchValue({
         newPassword: 'password',
         confirmPassword: 'password',

--- a/generators/angular/templates/src/main/webapp/app/account/password/password.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password.component.spec.ts.ejs
@@ -106,7 +106,7 @@ describe('PasswordComponent', () => {
 
   it('should notify of error if change password fails', () => {
     // GIVEN
-    jest.spyOn(service, 'save').mockReturnValue(throwError('ERROR'));
+    jest.spyOn(service, 'save').mockReturnValue(throwError(() => {}));
     comp.passwordForm.patchValue({
       newPassword: 'myPassword',
       confirmPassword: 'myPassword',

--- a/generators/angular/templates/src/main/webapp/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/settings/settings.component.spec.ts.ejs
@@ -108,7 +108,7 @@ describe('SettingsComponent', () => {
 
   it('should notify of error upon failed save', () => {
     // GIVEN
-    mockAccountService.save = jest.fn(() => throwError('ERROR'));
+    mockAccountService.save = jest.fn(() => throwError(() => {}));
 
     // WHEN
     comp.ngOnInit();


### PR DESCRIPTION
Fix
![image](https://github.com/jhipster/generator-jhipster/assets/9989211/44919bbd-00f7-4d0d-83f9-6f16e15a540a)


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
