### PR TITLE
increase keycloak docker retries

### DIFF
--- a/generators/docker/templates/docker/keycloak.yml.ejs
+++ b/generators/docker/templates/docker/keycloak.yml.ejs
@@ -42,5 +42,5 @@ services:
       test: 'bash /opt/keycloak/health-check.sh'
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 40
       start_period: 10s


### PR DESCRIPTION
required to run keycloak in GitHub MacOS runners.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
