### PR TITLE
Fix OAuth2 login and logout issues in React application

### DIFF
--- a/generators/react/templates/src/main/webapp/app/modules/home/home.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/home/home.tsx.ejs
@@ -23,7 +23,11 @@ import React, { useEffect } from 'react';
 <%_ } else { _%>
 import React from 'react';
 <%_ } _%>
+<%_ if (authenticationTypeOauth2) { _%>
+import { useLocation, useNavigate } from 'react-router-dom';
+<%_ } else { _%>
 import { Link } from 'react-router-dom';
+<%_ } _%>
 import { Translate } from 'react-jhipster';
 import { Row, Col, Alert } from 'reactstrap';
 
@@ -35,6 +39,9 @@ import { useAppSelector } from 'app/config/store';
 export const Home = () => {
   const account = useAppSelector(state => state.authentication.account);
 <%_ if (authenticationTypeOauth2) { _%>
+  const pageLocation = useLocation();
+  const navigate = useNavigate();
+
   useEffect(() => {
     const redirectURL = localStorage.getItem(REDIRECT_URL);
     if (redirectURL) {
@@ -65,7 +72,14 @@ export const Home = () => {
                 <Translate contentKey="global.messages.info.authenticated.prefix">If you want to </Translate>
                 <% if (!enableTranslation) { %><span>&nbsp;</span><% } %>
 <%_ if (authenticationTypeOauth2) { _%>
-                <a href={getLoginUrl()} className="alert-link">
+                <a
+                  className="alert-link"
+                  onClick={() =>
+                    navigate(getLoginUrl(), {
+                      state: { from: pageLocation },
+                    })
+                  }
+                >
                   <Translate contentKey="global.messages.info.authenticated.link">sign in</Translate>
                 </a>
 <%_ } else { _%>

--- a/generators/react/templates/src/main/webapp/app/modules/login/login-redirect.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/login/login-redirect.tsx.ejs
@@ -7,7 +7,11 @@ export const LoginRedirect = () => {
 
   useEffect(() => {
     localStorage.setItem(REDIRECT_URL, pageLocation.state.from.pathname);
+<%_ if (authenticationTypeOauth2) { _%>
+    window.location.href = '/oauth2/authorization/oidc';
+<%_ } else { _%>
     window.location.reload();
+<%_ } _%>
   });
 
   return null;

--- a/generators/react/templates/src/main/webapp/app/modules/login/logout.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/login/logout.tsx.ejs
@@ -22,13 +22,15 @@ import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { logout } from 'app/shared/reducers/authentication';
 
 export const Logout = () => {
-  const logoutUrl = useAppSelector(state => state.authentication.logoutUrl);
+  const authentication = useAppSelector(state => state.authentication);
   const dispatch = useAppDispatch();
 
   useLayoutEffect(() => {
     dispatch(logout());
-    if (logoutUrl) {
-      window.location.href = logoutUrl;
+    if (authentication.logoutUrl) {
+      window.location.href = authentication.logoutUrl;
+    } else if (!authentication.isAuthenticated) {
+      window.location.href = '/';
     }
   });
 

--- a/generators/react/templates/src/main/webapp/app/routes.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/routes.tsx.ejs
@@ -112,7 +112,7 @@ const AppRoutes = () => {
           }
         />
 <%_ if (authenticationTypeOauth2) { _%>
-        <Route path="oauth2/authorization/oidc" element={<LoginRedirect />} />
+        <Route path="sign-in" element={<LoginRedirect />} />
 <%_ } _%>
 <%_ if (applicationTypeGateway && microfrontend) { _%>
   <%_ for (const remote of microfrontends) { _%>

--- a/generators/react/templates/src/main/webapp/app/shared/auth/private-route.spec.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/auth/private-route.spec.tsx.ejs
@@ -92,7 +92,7 @@ describe('private-route component', () => {
             </PrivateRoute>
           }
         />
-        <Route path="<% if(authenticationTypeOauth2) { %>/oauth2/authorization/oidc<% } else { %>/login<% } %>" element={<div>Login</div>} />
+        <Route path="<% if(authenticationTypeOauth2) { %>/sign-in<% } else { %>/login<% } %>" element={<div>Login</div>} />
       </Routes>,
       {
         isAuthenticated: false,

--- a/generators/react/templates/src/main/webapp/app/shared/auth/private-route.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/auth/private-route.tsx.ejs
@@ -42,7 +42,7 @@ export const PrivateRoute = ({ children, hasAnyAuthorities = [], ...rest }: IOwn
   return (
     <Navigate
       to={{
-        pathname: '<%_ if (authenticationTypeOauth2) { _%>/oauth2/authorization/oidc<%_ } else {_%>/login<%_ } _%>',
+        pathname: '<%_ if (authenticationTypeOauth2) { _%>/sign-in<%_ } else {_%>/login<%_ } _%>',
         search: pageLocation.search,
       }}
       replace

--- a/generators/react/templates/src/main/webapp/app/shared/layout/menus/account.spec.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/layout/menus/account.spec.tsx.ejs
@@ -68,9 +68,7 @@ describe('AccountMenu', () => {
   it('Renders a guest AccountMenu component', () => {
     const html = guestWrapper();
 
-<%_ if (authenticationTypeOauth2) { _%>
-    expect(html).toContain(getLoginUrl());
-<%_ } else { _%>
+<%_ if (!authenticationTypeOauth2) { _%>
     expect(html).toContain('/login');
 <%_ } _%>
     expect(html).not.toContain('/logout');

--- a/generators/react/templates/src/main/webapp/app/shared/layout/menus/account.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/layout/menus/account.tsx.ejs
@@ -27,6 +27,9 @@ import { Translate, translate } from 'react-jhipster';
 import { getLoginUrl } from 'app/shared/util/url-utils';
 <%_ } _%>
 import { NavDropdown } from './menu-components';
+<%_ if (authenticationTypeOauth2) { _%>
+import { useLocation, useNavigate } from 'react-router';
+<%_ } _%>
 
 
 const accountMenuItemsAuthenticated = () => (
@@ -42,18 +45,38 @@ const accountMenuItemsAuthenticated = () => (
   </>
   );
 
+<%_ if (authenticationTypeOauth2) { _%>
+const accountMenuItems = () => {
+  const navigate = useNavigate();
+  const pageLocation = useLocation();
+
+  return (
+    <>
+      <DropdownItem
+        id="login-item"
+        tag="a"
+        data-cy="login"
+        onClick={() =>
+          navigate(getLoginUrl(), {
+            state: { from: pageLocation },
+          })
+        }
+      >
+        <FontAwesomeIcon icon="sign-in-alt" /> <Translate contentKey="global.menu.account.login">Sign in</Translate>
+      </DropdownItem>
+    </>
+  );
+};
+<%_ } else { _%>
 const accountMenuItems = () => (
   <>
-<%_ if (!authenticationTypeOauth2) { _%>
     <MenuItem id="login-item" icon="sign-in-alt" to="/login" data-cy="login"><Translate contentKey="global.menu.account.login">Sign in</Translate></MenuItem>
-<%_ } else { _%>
-    <DropdownItem id="login-item" tag="a" href={getLoginUrl()} data-cy="login"><FontAwesomeIcon icon="sign-in-alt" /> <Translate contentKey="global.menu.account.login">Sign in</Translate></DropdownItem>
-<%_ } _%>
-<%_ if (generateUserManagement) { _%>
+  <%_ if (generateUserManagement) { _%>
     <MenuItem icon="user-plus" to="/account/register" data-cy="register"><Translate contentKey="global.menu.account.register">Register</Translate></MenuItem>
-<%_ } _%>
+  <%_ } _%>
   </>
 );
+<%_ } _%>
 
 export const AccountMenu = ({ isAuthenticated = false }) => (
   <NavDropdown icon="user" name={translate('global.menu.account.main')} id="account-menu" data-cy="accountMenu">

--- a/generators/react/templates/src/main/webapp/app/shared/util/url-utils.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/util/url-utils.ts.ejs
@@ -21,7 +21,7 @@ export const getLoginUrl = () => {
 
   // If you have configured multiple OIDC providers, then, you can update this URL to /login.
   // It will show a Spring Security generated login page with links to configured OIDC providers.
-  return `//${location.hostname}${port}${location.pathname}oauth2/authorization/oidc`;
+  return `//${location.hostname}${port}/sign-in`;
 }
 <%_ if (authenticationTypeOauth2) { _%>
 export const REDIRECT_URL = 'redirectURL';


### PR DESCRIPTION
## Issues

### Description

When creating an application with OAuth2 and React, the following issues were discovered:

> JHipster version is v8.5.0

1. When a user who is not logged in visits the logout page, infinite logout requests are sent to the backend.

   https://github.com/jhipster/generator-jhipster/assets/97726491/d82099cf-e6c3-4294-b7d0-3a243d369575

2. If there is a non-private route, such as the About page (`/about`), and the user clicks login on that page and logs in, the Redirect functionality breaks because the local storage records an incorrect redirect URL.
   
   https://github.com/jhipster/generator-jhipster/assets/97726491/83dc568f-441d-42b9-9033-cb751c4b7764

### JDL

```
application {
  config {
    baseName blog,
    applicationType monolith
    authenticationType oauth2
    packageName com.jhipster.demo.blog
    prodDatabaseType postgresql
    cacheProvider ehcache
    buildTool maven
    clientFramework react
    testFrameworks [cypress]
  }
  entities *
}

entity Blog {
  name String required minlength(3)
  handle String required minlength(2)
}

entity Post {
  title String required
  content TextBlob required
  date Instant required
}

entity Tag {
  name String required minlength(2)
}

relationship ManyToOne {
  Blog{user(login)} to User with builtInEntity
  Post{blog(name)} to Blog
}

relationship ManyToMany {
  Post{tag(name)} to Tag{entry}
}

paginate Post, Tag with infinite-scroll
```

## Fixes

For issue 1, I made the following changes in `logout.tsx`:

- When the user is not logged in, redirect them to the root.

Regarding issue 2, I refactored the frontend login flow:

- In `routes.tsx`, changed the route path of the `LoginRedirect` component to `/sign-in` instead of directly using the `/oauth2/authorization/oidc` endpoint provided by the backend, and then redirected the user to the `oauth2/authorization/oidc` endpoint in the `LoginRedirect` component.
- Based on the above change, in `url-utils.ts`, modified the return value of the `getLoginUrl()` function to `/sign-in` route.
- Replaced the login buttons in `account.tsx` and `home.tsx` with callback functions that use the `useNavigate` hook to redirect to the route returned by `getLoginUrl()`, ensuring the original path of all public routes is preserved.