### PR TITLE
The documentation should tell to use ./npmw instead of requiring to install node

### DIFF
--- a/generators/client/templates/README.md.jhi.client.ejs
+++ b/generators/client/templates/README.md.jhi.client.ejs
@@ -37,7 +37,7 @@ let clientPackageMngrAddDev = 'install --save-dev --save-exact';
 <%_ if (useNpmWrapper) { _%>
 The build system will install automatically the recommended version of node and <%= clientPackageManager %>.
 
-We provide a wrapper to launch <%= clientPackageManager %> to use it.
+We provide a wrapper to launch <%= clientPackageManager %>.
 <%_ } else { _%>
 Before you can build this project, you must install and configure the following dependencies on your machine:
 

--- a/generators/client/templates/README.md.jhi.client.ejs
+++ b/generators/client/templates/README.md.jhi.client.ejs
@@ -28,21 +28,28 @@
 _&>
 <%_
 let clientPackageMngrName = 'Npm';
+let clientPackageMngrWrapper = useNpmWrapper ? './npmw' : clientPackageManager;
 let clientPackageMngrAddGlobal = 'install -g';
 let clientPackageMngrAdd = 'install --save --save-exact';
 let clientPackageMngrAddDev = 'install --save-dev --save-exact';
 -%>
 <&_ if (fragment.developmentSection) { -&>
+<%_ if (useNpmWrapper) { _%>
+The build system will install automatically the recommended version of node and <%= clientPackageManager %>.
+
+We provide a wrapper to launch <%= clientPackageManager %> to use it.
+<%_ } else { _%>
 Before you can build this project, you must install and configure the following dependencies on your machine:
 
 1. [Node.js](https://nodejs.org/): We use Node to run a development web server and build the project.
    Depending on your system, you can install Node either from source or as a pre-packaged bundle.
 
 After installing Node, you should be able to run the following command to install development tools.
+<%_ } _%>
 You will only need to run this command when dependencies change in [package.json](package.json).
 
 ```
-<%= clientPackageManager %> install
+<%= clientPackageMngrWrapper %> install
 ```
 
 We use <%= clientPackageManager %> scripts and <&- fragments.customCliSection(' ') &>[Webpack][] as our build system.
@@ -80,14 +87,14 @@ auto-refreshes when files change on your hard drive.
   <%_ if (buildToolGradle) { _%>
 ./gradlew -x webapp
   <%_ } _%>
-<%= clientPackageManager %> start
+<%= clientPackageMngrWrapper %> start
 ```
 
 <%= clientPackageMngrName %> is also used to manage CSS and JavaScript dependencies used in this application. You can upgrade dependencies by
-specifying a newer version in [package.json](package.json). You can also run `<%= clientPackageManager %> update` and `<%= clientPackageManager %> install` to manage dependencies.
-Add the `help` flag on any command to see how you can use it. For example, `<%= clientPackageManager %> help update`.
+specifying a newer version in [package.json](package.json). You can also run `<%= clientPackageMngrWrapper %> update` and `<%= clientPackageMngrWrapper %> install` to manage dependencies.
+Add the `help` flag on any command to see how you can use it. For example, `<%= clientPackageMngrWrapper %> help update`.
 
-The `<%= clientPackageManager %> run` command will list all of the scripts available to run for this project.
+The `<%= clientPackageMngrWrapper %> run` command will list all of the scripts available to run for this project.
 
 ### PWA Support
 
@@ -121,13 +128,13 @@ ServiceWorkerModule.register('ngsw-worker.js', { enabled: false }),
 For example, to add [Leaflet][] library as a runtime dependency of your application, you would run following command:
 
 ```
-<%= clientPackageManager %> <%= clientPackageMngrAdd %> leaflet
+<%= clientPackageMngrWrapper %> <%= clientPackageMngrAdd %> leaflet
 ```
 
 To benefit from TypeScript type definitions from [DefinitelyTyped][] repository in development, you would run following command:
 
 ```
-<%= clientPackageManager %> <%= clientPackageMngrAddDev %> @types/leaflet
+<%= clientPackageMngrWrapper %> <%= clientPackageMngrAddDev %> @types/leaflet
 ```
 
 Then you would import the JS and CSS files specified in library's installation instructions so that [Webpack][] knows about them:
@@ -159,9 +166,9 @@ Start gateway from source:
 
 ```
 cd gateway
-npm run docker:db:up # start database if necessary
-npm run docker:others:up # start service discovery and authentication service if necessary
-npm run app:start # alias for ./(mvnw|gradlew)
+<%= clientPackageMngrWrapper %> run docker:db:up # start database if necessary
+<%= clientPackageMngrWrapper %> run docker:others:up # start service discovery and authentication service if necessary
+<%= clientPackageMngrWrapper %> run app:start # alias for ./(mvnw|gradlew)
 ```
 
 Microfrontend's `build-watch` script is configured to watch and compile microfrontend's sources and synchronizes with gateway's frontend.
@@ -169,16 +176,16 @@ Start it using:
 
 ```
 cd microfrontend
-npm run docker:db:up # start database if necessary
-npm run build-watch
+<%= clientPackageMngrWrapper %> run docker:db:up # start database if necessary
+<%= clientPackageMngrWrapper %> run build-watch
 ```
 
 It's possible to run microfrontend's frontend standalone using:
 
 ```
 cd microfrontend
-npm run docker:db:up # start database if necessary
-npm watch # alias for `npm start` and `npm run backend:start` in parallel
+<%= clientPackageMngrWrapper %> run docker:db:up # start database if necessary
+<%= clientPackageMngrWrapper %> watch # alias for `npm start` and `npm run backend:start` in parallel
 ```
 
 <%_ } -%>
@@ -190,16 +197,16 @@ npm watch # alias for `npm start` and `npm run backend:start` in parallel
 Unit tests are run by [Jest][]. They're located in [<%= clientTestDir %>](<%= clientTestDir %>) and can be run with:
 
 ```
-<%= clientPackageManager %> test
+<%= clientPackageMngrWrapper %> test
 ```
 
   <%_ if (cypressTests) { _%>
 UI end-to-end tests are powered by [Cypress][]. They're located in [<%= clientTestDir %>cypress](<%= clientTestDir %>cypress)
-and can be run by starting Spring Boot in one terminal (`<% if (buildToolMaven) { %>./mvnw spring-boot:run<% } else { %>./gradlew bootRun<% } %>`) and running the tests (`<%= clientPackageManager %> run e2e`) in a second one.
+and can be run by starting Spring Boot in one terminal (`<% if (buildToolMaven) { %>./mvnw spring-boot:run<% } else { %>./gradlew bootRun<% } %>`) and running the tests (`<%= clientPackageMngrWrapper %> run e2e`) in a second one.
 
 #### Lighthouse audits
 
-You can execute automated [lighthouse audits][https://developers.google.com/web/tools/lighthouse/] with [cypress audits][https://github.com/mfrachet/cypress-audit] by running `<%= clientPackageManager %> run e2e:cypress:audits`.
+You can execute automated [lighthouse audits][https://developers.google.com/web/tools/lighthouse/] with [cypress audits][https://github.com/mfrachet/cypress-audit] by running `<%= clientPackageMngrWrapper %> run e2e:cypress:audits`.
 You should only run the audits when your application is packaged with the production profile.
 The lighthouse report is created in <% if (buildToolMaven) { %>`target/cypress/lhreport.html`<% } else { %>`build/cypress/lhreport.html`<% } %>
   <%_ } _%>

--- a/generators/client/templates/README.md.jhi.client.ejs
+++ b/generators/client/templates/README.md.jhi.client.ejs
@@ -35,7 +35,7 @@ let clientPackageMngrAddDev = 'install --save-dev --save-exact';
 -%>
 <&_ if (fragment.developmentSection) { -&>
 <%_ if (useNpmWrapper) { _%>
-The build system will install automatically the recommended version of node and <%= clientPackageManager %>.
+The build system will install automatically the recommended version of Node and <%= clientPackageManager %>.
 
 We provide a wrapper to launch <%= clientPackageManager %>.
 <%_ } else { _%>


### PR DESCRIPTION
Installing node and running `npm install` duplicates the npm installation. We should use the one done by maven/gradle all the time. Also, asking to install node without telling it should be the version matching the one in pom.xml is unreliable.