### PR TITLE
Docker compose version is obsolete

### DIFF
--- a/generators/ci-cd/__snapshots__/ci-cd.spec.ts.snap
+++ b/generators/ci-cd/__snapshots__/ci-cd.spec.ts.snap
@@ -1118,7 +1118,6 @@ jobs:
   },
   "src/main/docker/docker-registry.yml": {
     "contents": "# Documentation at https://docs.docker.com/registry/deploying
-version: "2"
 services:
   registry:
     image: registry:2
@@ -1354,7 +1353,6 @@ jobs:
   },
   "src/main/docker/docker-registry.yml": {
     "contents": "# Documentation at https://docs.docker.com/registry/deploying
-version: "2"
 services:
   registry:
     image: registry:2
@@ -2294,8 +2292,7 @@ node {
     "stateCleared": "modified",
   },
   "src/main/docker/jenkins.yml": {
-    "contents": "version: "2"
-services:
+    "contents": "services:
   jenkins:
     image: jenkins-placeholder
     ports:
@@ -2527,7 +2524,6 @@ node {
   },
   "src/main/docker/docker-registry.yml": {
     "contents": "# Documentation at https://docs.docker.com/registry/deploying
-version: "2"
 services:
   registry:
     image: registry:2
@@ -2569,8 +2565,7 @@ services:
     "stateCleared": "modified",
   },
   "src/main/docker/jenkins.yml": {
-    "contents": "version: "2"
-services:
+    "contents": "services:
   jenkins:
     image: jenkins-placeholder
     ports:
@@ -2755,8 +2750,7 @@ node {
     "stateCleared": "modified",
   },
   "src/main/docker/jenkins.yml": {
-    "contents": "version: "2"
-services:
+    "contents": "services:
   jenkins:
     image: jenkins-placeholder
     ports:
@@ -2985,7 +2979,6 @@ node {
   },
   "src/main/docker/docker-registry.yml": {
     "contents": "# Documentation at https://docs.docker.com/registry/deploying
-version: "2"
 services:
   registry:
     image: registry:2
@@ -3027,8 +3020,7 @@ services:
     "stateCleared": "modified",
   },
   "src/main/docker/jenkins.yml": {
-    "contents": "version: "2"
-services:
+    "contents": "services:
   jenkins:
     image: jenkins-placeholder
     ports:

--- a/generators/ci-cd/templates/docker-registry.yml.ejs
+++ b/generators/ci-cd/templates/docker-registry.yml.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 # Documentation at https://docs.docker.com/registry/deploying
-version: '2'
 services:
   registry:
     image: registry:2

--- a/generators/ci-cd/templates/jenkins/jenkins.yml.ejs
+++ b/generators/ci-cd/templates/jenkins/jenkins.yml.ejs
@@ -16,7 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-version: '2'
 services:
   jenkins:
     image: <%- dockerContainers.jenkins %>


### PR DESCRIPTION
https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

<img width="1039" alt="image" src="https://github.com/jhipster/generator-jhipster/assets/9989211/a64af5bc-7a12-4b99-8f2e-59219169554c">


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
