### PR TITLE
fix(generator,gatling): remove deprecated plugin configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,11 @@ test-integration/**/*.png
 
 # allow customizations without having a dirty tree
 .devcontainer
+
+# NetBeans 
+nbproject/
+build/
+nbbuild/
+nbdist/
+.nb-gradle/
+

--- a/generators/gatling/generator.ts
+++ b/generators/gatling/generator.ts
@@ -78,7 +78,6 @@ export default class GatlingGenerator extends BaseApplicationGenerator {
                 additionalContent: `
 <configuration>
     <runMultipleSimulations>true</runMultipleSimulations>
-    <resourcesFolder>\${project.basedir}/src/test/gatling/conf</resourcesFolder>
 </configuration>
 `,
               },


### PR DESCRIPTION
The Gatling Maven Plugin deprecated the use of the `resourcesFolder` configuration option. See commit,

https://github.com/gatling/gatling-maven-plugin/commit/99faad8d54a0ad59bcd0a839a642da4c67a5b5ad

Add exclusion for NetBeans (we're still out there...)

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->

Fixes #26492 