### PR TITLE
workaround v7 files structure bug

### DIFF
--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -792,9 +792,15 @@ You can ignore this error by passing '--skip-checks' to jhipster command.`);
       let sourceFileFrom;
       if (Array.isArray(rootTemplatesAbsolutePath)) {
         // Look for existing templates
-        const existingTemplates = rootTemplatesAbsolutePath
+        let existingTemplates = rootTemplatesAbsolutePath
           .map(rootPath => this.templatePath(rootPath, sourceFile))
           .filter(templateFile => existsSync(appendEjs ? `${templateFile}.ejs` : templateFile));
+
+        if (existingTemplates.length === 0 && this.getFeatures().jhipster7Migration) {
+          existingTemplates = rootTemplatesAbsolutePath
+            .map(rootPath => this.templatePath(rootPath, appendEjs ? sourceFile : `${sourceFile}.ejs`))
+            .filter(templateFile => existsSync(templateFile));
+        }
 
         if (existingTemplates.length > 1) {
           const moreThanOneMessage = `Multiples templates were found for file ${sourceFile}, using the first


### PR DESCRIPTION
generator-jhipster@7.9.3/7.9.4 has a bug in serverFiles that 2 ejs templates are treated as non ejs templates.
Add workaround to this issue.

Related to https://github.com/jhipster/jhipster-kotlin/issues/378.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
