### PR TITLE
Angular: HttpClientTestingModule is deprecated

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/activate/activate.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/activate/activate.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { TestBed, waitForAsync, tick, fakeAsync, inject } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
 
@@ -30,8 +30,9 @@ describe('ActivateComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, ActivateComponent],
+        imports: [ActivateComponent],
         providers: [
+          provideHttpClient(),
           {
             provide: ActivatedRoute,
             useValue: { queryParams: of({ key: 'ABC123' }) },

--- a/generators/angular/templates/src/main/webapp/app/account/activate/activate.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/activate/activate.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { ActivateService } from './activate.service';
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
@@ -29,7 +30,7 @@ describe('ActivateService Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(ActivateService);

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { ElementRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
@@ -32,8 +32,9 @@ describe('PasswordResetFinishComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, PasswordResetFinishComponent],
+      imports: [PasswordResetFinishComponent],
       providers: [
+        provideHttpClient(),
         FormBuilder,
         {
           provide: ActivatedRoute,

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { PasswordResetFinishService } from './password-reset-finish.service';
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
@@ -29,7 +30,7 @@ describe('PasswordResetFinish Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(PasswordResetFinishService);

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { ElementRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 
@@ -31,8 +31,8 @@ describe('PasswordResetInitComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, PasswordResetInitComponent],
-      providers: [FormBuilder],
+      imports: [PasswordResetInitComponent],
+      providers: [provideHttpClient(), FormBuilder],
     })
       .overrideTemplate(PasswordResetInitComponent, '')
       .createComponent(PasswordResetInitComponent);

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { PasswordResetInitService } from './password-reset-init.service';
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
@@ -29,7 +30,7 @@ describe('PasswordResetInit Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(PasswordResetInitService);

--- a/generators/angular/templates/src/main/webapp/app/account/password/password.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password.component.spec.ts.ejs
@@ -19,8 +19,7 @@
 jest.mock('app/core/auth/account.service');
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 
@@ -37,8 +36,8 @@ describe('PasswordComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, PasswordComponent],
-        providers: [FormBuilder, AccountService],
+        imports: [PasswordComponent],
+        providers: [FormBuilder, AccountService, provideHttpClient()],
       })
         .overrideTemplate(PasswordComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/account/password/password.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password.service.spec.ts.ejs
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { PasswordService } from './password.service';
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
@@ -11,7 +12,7 @@ describe('Password Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(PasswordService);

--- a/generators/angular/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, waitForAsync, inject, tick, fakeAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 <%_ if (enableTranslation) { _%>
@@ -40,10 +40,9 @@ describe('RegisterComponent', () => {
 <%_ if (enableTranslation) { _%>
           TranslateModule.forRoot(),
 <%_ } _%>
-          HttpClientTestingModule,
           RegisterComponent,
         ],
-        providers: [FormBuilder],
+        providers: [provideHttpClient(), FormBuilder],
       })
         .overrideTemplate(RegisterComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/account/register/register.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/register/register.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { RegisterService } from './register.service';
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
@@ -30,7 +31,7 @@ describe('RegisterService Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(RegisterService);

--- a/generators/angular/templates/src/main/webapp/app/account/sessions/sessions.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/sessions/sessions.component.spec.ts.ejs
@@ -19,7 +19,7 @@
 jest.mock('app/core/auth/account.service');
 
 import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
 
 import { AccountService } from 'app/core/auth/account.service';
@@ -46,8 +46,8 @@ describe('SessionsComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, SessionsComponent],
-      providers: [AccountService],
+      imports: [SessionsComponent],
+      providers: [provideHttpClient(), AccountService],
     })
       .overrideTemplate(SessionsComponent, '')
       .createComponent(SessionsComponent);

--- a/generators/angular/templates/src/main/webapp/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/settings/settings.component.spec.ts.ejs
@@ -19,7 +19,7 @@
 jest.mock('app/core/auth/account.service');
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { throwError, of } from 'rxjs';
 <%_ if (enableTranslation) { _%>
@@ -53,10 +53,9 @@ describe('SettingsComponent', () => {
 <%_ if (enableTranslation) { _%>
           TranslateModule.forRoot(),
 <%_ } _%>
-          HttpClientTestingModule,
           SettingsComponent,
         ],
-        providers: [FormBuilder, AccountService],
+        providers: [provideHttpClient(), FormBuilder, AccountService],
       })
         .overrideTemplate(SettingsComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 
 import ConfigurationComponent from './configuration.component';
@@ -32,8 +32,8 @@ describe('ConfigurationComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, ConfigurationComponent],
-        providers: [ConfigurationService],
+        imports: [ConfigurationComponent],
+        providers: [provideHttpClient(), ConfigurationService],
       })
         .overrideTemplate(ConfigurationComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { ConfigurationService } from './configuration.service';
 import { Bean, ConfigProps, Env, PropertySource } from './configuration.model';
@@ -29,7 +30,7 @@ describe('Logs Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     expectedResult = null;

--- a/generators/angular/templates/src/main/webapp/app/admin/health/health.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/health/health.component.spec.ts.ejs
@@ -17,8 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpErrorResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient, HttpErrorResponse } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
 
 import HealthComponent from './health.component';
@@ -33,7 +32,8 @@ describe('HealthComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, HealthComponent],
+        imports: [HealthComponent],
+        providers: [provideHttpClient()],
       })
         .overrideTemplate(HealthComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/health/health.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/health/health.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { HealthService } from './health.service';
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
@@ -29,7 +30,7 @@ describe('HealthService Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(HealthService);

--- a/generators/angular/templates/src/main/webapp/app/admin/health/modal/health-modal.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/health/modal/health-modal.component.spec.ts.ejs
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import HealthModalComponent from './health-modal.component';
@@ -12,8 +12,8 @@ describe('HealthModalComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, HealthModalComponent],
-        providers: [NgbActiveModal],
+        imports: [HealthModalComponent],
+        providers: [provideHttpClient(), NgbActiveModal],
       })
         .overrideTemplate(HealthModalComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/logs/logs.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/logs/logs.component.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 
 import LogsComponent from './logs.component';
@@ -35,8 +36,8 @@ describe('LogsComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, LogsComponent],
-        providers: [LogsService<%= applicationTypeGateway && serviceDiscoveryAny ? ', GatewayRoutesService' : '' %>],
+        imports: [LogsComponent],
+        providers: [provideHttpClient(), provideHttpClientTesting(), LogsService<%= applicationTypeGateway && serviceDiscoveryAny ? ', GatewayRoutesService' : '' %>],
       })
         .overrideTemplate(LogsComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/logs/logs.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/logs/logs.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { LogsService } from './logs.service';
 
@@ -27,7 +28,7 @@ describe('Logs Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(LogsService);

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { MetricsModalThreadsComponent } from './metrics-modal-threads.component';
@@ -30,8 +30,8 @@ describe('MetricsModalThreadsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MetricsModalThreadsComponent],
-      providers: [NgbActiveModal],
+      imports: [MetricsModalThreadsComponent],
+      providers: [provideHttpClient(), NgbActiveModal],
     })
       .overrideTemplate(MetricsModalThreadsComponent, '')
       .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 
 import MetricsComponent from './metrics.component';
@@ -34,7 +34,8 @@ describe('MetricsComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, MetricsComponent],
+        imports: [MetricsComponent],
+        providers: [provideHttpClient()],
       })
         .overrideTemplate(MetricsComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { MetricsService } from './metrics.service';
 import { ThreadDump, ThreadState } from './metrics.model';
@@ -28,7 +29,7 @@ describe('Logs Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
     service = TestBed.inject(MetricsService);
     httpMock = TestBed.inject(HttpTestingController);

--- a/generators/angular/templates/src/main/webapp/app/admin/user-management/delete/user-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/user-management/delete/user-management-delete-dialog.component.spec.ts.ejs
@@ -19,7 +19,7 @@
 jest.mock('@ng-bootstrap/ng-bootstrap');
 
 import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
 
@@ -36,8 +36,8 @@ describe('User Management Delete Component', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, UserManagementDeleteDialogComponent],
-        providers: [NgbActiveModal],
+        imports: [UserManagementDeleteDialogComponent],
+        providers: [provideHttpClient(), NgbActiveModal],
       })
         .overrideTemplate(UserManagementDeleteDialogComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/user-management/list/user-management.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/user-management/list/user-management.component.spec.ts.ejs
@@ -22,8 +22,7 @@ _%>
 jest.mock('app/core/auth/account.service');
 
 import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
-import { HttpHeaders, HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
@@ -52,8 +51,8 @@ describe('User Management Component', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, UserManagementComponent],
-        providers: [{ provide: ActivatedRoute, useValue: { data, queryParamMap } }, AccountService],
+        imports: [UserManagementComponent],
+        providers: [provideHttpClient(), { provide: ActivatedRoute, useValue: { data, queryParamMap } }, AccountService],
       })
         .overrideTemplate(UserManagementComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/admin/user-management/service/user-management.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/user-management/service/user-management.service.spec.ts.ejs
@@ -20,8 +20,8 @@
 const tsKeyId = this.generateTestEntityId(user.primaryKey.type);
 _%>
 import { TestBed } from '@angular/core/testing';
-import { HttpErrorResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient, HttpErrorResponse } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 
 <%_ if (generateBuiltInAuthorityEntity) { _%>
 import { Authority } from 'app/config/authority.constants';
@@ -36,7 +36,7 @@ describe('User Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     service = TestBed.inject(UserManagementService);

--- a/generators/angular/templates/src/main/webapp/app/admin/user-management/update/user-management-update.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/user-management/update/user-management-update.component.spec.ts.ejs
@@ -20,7 +20,7 @@
 const tsKeyId = this.generateTestEntityId(user.primaryKey.type);
 _%>
 import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
@@ -38,8 +38,9 @@ describe('User Management Update Component', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UserManagementUpdateComponent],
+      imports: [UserManagementUpdateComponent],
       providers: [
+        provideHttpClient(),
         FormBuilder,
         {
           provide: ActivatedRoute,

--- a/generators/angular/templates/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
@@ -19,7 +19,8 @@
 jest.mock('app/core/auth/state-storage.service');
 
 import { Router } from '@angular/router';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -62,13 +63,14 @@ describe('Account Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      <%_ if (enableTranslation) { _%>
       imports: [
-        HttpClientTestingModule,
-<%_ if (enableTranslation) { _%>
         TranslateModule.forRoot(),
-<%_ } _%>
       ],
+      <%_ } _%>
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         StateStorageService,
       ],
     });

--- a/generators/angular/templates/src/main/webapp/app/core/auth/auth-jwt.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/auth/auth-jwt.service.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { AuthServerProvider } from 'app/core/auth/auth-jwt.service';
 import { StateStorageService } from './state-storage.service';
 
@@ -28,7 +29,7 @@ describe('Auth JWT', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     mockStorageService = TestBed.inject(StateStorageService);

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/delete/_entityFile_-delete-dialog.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/delete/_entityFile_-delete-dialog.component.spec.ts.ejs
@@ -22,8 +22,7 @@ _%>
 jest.mock('@ng-bootstrap/ng-bootstrap');
 
 import { ComponentFixture, TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient, HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
@@ -39,8 +38,8 @@ describe('<%= entityAngularName %> Management Delete Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, <%= entityAngularName %>DeleteDialogComponent],
-            providers: [NgbActiveModal]
+            imports: [<%= entityAngularName %>DeleteDialogComponent],
+            providers: [provideHttpClient(), NgbActiveModal]
         })
         .overrideTemplate(<%= entityAngularName %>DeleteDialogComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.component.spec.ts.ejs
@@ -29,8 +29,7 @@ import {
   fakeAsync, inject, tick,
 <%_ } _%>
 } from '@angular/core/testing';
-import { HttpHeaders, HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
 import {
   of,
@@ -59,10 +58,10 @@ describe('<%= entityAngularName %> Management Component', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
-              HttpClientTestingModule,
               <%= entityAngularName %>Component,
             ],
             providers: [
+                provideHttpClient(),
                 {
                     provide: ActivatedRoute,
                     useValue: {

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/route/_entityFile_-routing-resolve.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/route/_entityFile_-routing-resolve.service.spec.ts.ejs
@@ -20,8 +20,7 @@
 const tsKeyId = this.generateTestEntityId(primaryKey.type);
 _%>
 import { TestBed } from '@angular/core/testing';
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient, HttpResponse } from '@angular/common/http';
 import { ActivatedRouteSnapshot, ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 
@@ -38,8 +37,8 @@ describe('<%= entityAngularName %> routing resolve service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/service/_entityFile_.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/service/_entityFile_.service.spec.ts.ejs
@@ -21,7 +21,8 @@ const tsKeyId = this.generateTestEntityId(primaryKey.type);
 const enumImports = this.generateEntityClientEnumImports(fields);
 _%>
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 <%_ if (anyFieldIsLocalDate) { _%>
 import { DATE_FORMAT } from 'app/config/input.constants';
@@ -49,8 +50,9 @@ describe('<%= entityAngularName %> Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                HttpClientTestingModule
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting()
             ]
         });
         expectedResult = null;

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-update.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-update.component.spec.ts.ejs
@@ -26,8 +26,7 @@ const testEntityPrimaryKey0 = this.generateTestEntityPrimaryKey(primaryKey, 0);
 const testEntityPrimaryKey1 = this.generateTestEntityPrimaryKey(primaryKey, 1);
 _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient, HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { of, Subject, from } from 'rxjs';
@@ -57,10 +56,10 @@ describe('<%= entityAngularName %> Management Update Component', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
-                HttpClientTestingModule,
                 <%= entityAngularName %>UpdateComponent,
             ],
             providers: [
+              provideHttpClient(),
               FormBuilder,
               {
                 provide: ActivatedRoute,

--- a/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.component.spec.ts.ejs
@@ -19,7 +19,8 @@
 jest.mock('app/login/login.service');
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 <%_ if (enableTranslation) { _%>
 import { TranslateModule } from '@ngx-translate/core';
@@ -54,12 +55,11 @@ describe('Navbar Component', () => {
       TestBed.configureTestingModule({
         imports: [
           NavbarComponent,
-          HttpClientTestingModule,
 <%_ if (enableTranslation) { _%>
           TranslateModule.forRoot(),
 <%_ } _%>
         ],
-        providers: [LoginService],
+        providers: [provideHttpClient(), provideHttpClientTesting(), LoginService],
       })
         .overrideTemplate(NavbarComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/layouts/profiles/page-ribbon.component.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/profiles/page-ribbon.component.spec.ts.ejs
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 
 import { ProfileInfo } from 'app/layouts/profiles/profile-info.model';
@@ -15,7 +15,8 @@ describe('Page Ribbon Component', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, PageRibbonComponent],
+        imports: [PageRibbonComponent],
+        providers: [provideHttpClient()],
       })
         .overrideTemplate(PageRibbonComponent, '')
         .compileComponents();

--- a/generators/angular/templates/src/main/webapp/app/shared/auth/has-any-authority.directive.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/auth/has-any-authority.directive.spec.ts.ejs
@@ -19,7 +19,7 @@
 jest.mock('app/core/auth/account.service');
 
 import { Component, ElementRef, WritableSignal, signal, viewChild } from '@angular/core';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
 import { TranslateModule } from '@ngx-translate/core';
@@ -43,9 +43,9 @@ describe('HasAnyAuthorityDirective tests', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [HasAnyAuthorityDirective, HttpClientTestingModule<%_ if (enableTranslation) { _%>, TranslateModule.forRoot()<%_ } _%>],
+      imports: [HasAnyAuthorityDirective<%_ if (enableTranslation) { _%>, TranslateModule.forRoot()<%_ } _%>],
       declarations: [TestHasAnyAuthorityDirectiveComponent],
-      providers: [AccountService],
+      providers: [provideHttpClient(), AccountService],
     });
   }));
 


### PR DESCRIPTION
![image](https://github.com/jhipster/generator-jhipster/assets/9989211/4bdcbdbb-45a8-4856-9426-e0a6e82e8395)

https://angular.dev/api/common/http/testing/HttpClientTestingModule

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
