### PR TITLE
[Angular] Sonar: Fields that are only assigned in the constructor should be readonly

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/jvm-threads/jvm-threads.component.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/jvm-threads/jvm-threads.component.ts.ejs
@@ -67,7 +67,7 @@ export class JvmThreadsComponent {
 
   private _threads: Thread[] | undefined;
 
-  private modalService = inject(NgbModal);
+  private readonly modalService = inject(NgbModal);
 
   open(): void {
     const modalRef = this.modalService.open(MetricsModalThreadsComponent);

--- a/generators/angular/templates/src/main/webapp/app/app-page-title-strategy.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/app-page-title-strategy.ts.ejs
@@ -25,7 +25,7 @@ import { TranslateService } from "@ngx-translate/core";
 @Injectable()
 export class AppPageTitleStrategy extends TitleStrategy {
 <%_ if (enableTranslation) { _%>
-  private translateService = inject(TranslateService);
+  private readonly translateService = inject(TranslateService);
 <%_ } _%>
 
   override updateTitle(routerState: RouterStateSnapshot): void {

--- a/generators/angular/templates/src/main/webapp/app/config/uib-pagination.config.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/config/uib-pagination.config.ts.ejs
@@ -23,7 +23,7 @@ import { ITEMS_PER_PAGE } from 'app/config/pagination.constants';
 
 @Injectable({ providedIn: 'root' })
 export class PaginationConfig {
-  private config = inject(NgbPaginationConfig);
+  private readonly config = inject(NgbPaginationConfig);
   constructor() {
     this.config.boundaryLinks = true;
     this.config.maxSize = 5;

--- a/generators/angular/templates/src/main/webapp/app/core/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/interceptor/auth-expired.interceptor.ts.ejs
@@ -27,9 +27,9 @@ import { StateStorageService } from 'app/core/auth/state-storage.service';
 
 @Injectable()
 export class AuthExpiredInterceptor implements HttpInterceptor {
-  private loginService = inject(LoginService);
-  private stateStorageService = inject(StateStorageService);
-  private router = inject(Router);
+  private readonly loginService = inject(LoginService);
+  private readonly stateStorageService = inject(StateStorageService);
+  private readonly router = inject(Router);
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(

--- a/generators/angular/templates/src/main/webapp/app/core/interceptor/auth.interceptor.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/interceptor/auth.interceptor.ts.ejs
@@ -25,8 +25,8 @@ import { ApplicationConfigService } from '../config/application-config.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  private stateStorageService = inject(StateStorageService);
-  private applicationConfigService = inject(ApplicationConfigService);
+  private readonly stateStorageService = inject(StateStorageService);
+  private readonly applicationConfigService = inject(ApplicationConfigService);
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const serverApiUrl = this.applicationConfigService.getEndpointFor('');

--- a/generators/angular/templates/src/main/webapp/app/core/interceptor/error-handler.interceptor.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/interceptor/error-handler.interceptor.ts.ejs
@@ -25,7 +25,7 @@ import { EventManager, EventWithContent } from 'app/core/util/event-manager.serv
 
 @Injectable()
 export class ErrorHandlerInterceptor implements HttpInterceptor {
-  private eventManager = inject(EventManager);
+  private readonly eventManager = inject(EventManager);
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(

--- a/generators/angular/templates/src/main/webapp/app/layouts/error/error.component.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/error/error.component.ts.ejs
@@ -38,9 +38,9 @@ export default class ErrorComponent implements OnInit<% if (enableTranslation) {
 <%_ } _%>
 
 <%_ if (enableTranslation) { _%>
-  private translateService = inject(TranslateService);
+  private readonly translateService = inject(TranslateService);
 <%_ } _%>
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
 
   ngOnInit(): void {
     this.route.data.subscribe(routeData => {

--- a/generators/angular/templates/src/main/webapp/app/layouts/navbar/active-menu.directive.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/navbar/active-menu.directive.ts.ejs
@@ -26,9 +26,9 @@ import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
 export default class ActiveMenuDirective implements OnInit {
   <%= jhiPrefix %>ActiveMenu = input();
 
-  private el = inject(ElementRef);
-  private renderer = inject(Renderer2);
-  private translateService = inject(TranslateService);
+  private readonly el = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private readonly translateService = inject(TranslateService);
 
   ngOnInit(): void {
     this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {

--- a/generators/angular/templates/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
@@ -23,7 +23,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'findLanguageFromKey',
 })
 export default class FindLanguageFromKeyPipe implements PipeTransform {
-  private languages: { [key: string]: { name: string; rtl?: boolean } } = {
+  private readonly languages: { [key: string]: { name: string; rtl?: boolean } } = {
     // jhipster-needle-i18n-language-key-pipe - JHipster will add/remove languages in this object
   };
 

--- a/generators/angular/templates/src/main/webapp/app/shared/language/translation.module.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/language/translation.module.ts.ejs
@@ -71,8 +71,8 @@ export class LazyTranslationModule {
   ],
 })
 export class TranslationModule {
-  private translateService = inject(TranslateService);
-  private stateStorageService = inject(StateStorageService);
+  private readonly translateService = inject(TranslateService);
+  private readonly stateStorageService = inject(StateStorageService);
 
   constructor() {
     this.translateService.setDefaultLang('<%= nativeLanguage %>');


### PR DESCRIPTION
Fix these issues:
![image](https://github.com/jhipster/generator-jhipster/assets/9989211/5806aead-a9b7-4b17-bee2-13e1cf4bd72d)


<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
