### PR TITLE
[Angular] Fix deprecated signature for tableRow.injector.get

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -57,7 +57,7 @@ describe('Directive: SortDirective', () => {
 
   it('should invoke sortChange function', () => {
     // GIVEN
-    const sortDirective = tableRow.injector.get(SortDirective);
+    const sortDirective = tableRow.injector.get(SortDirective as Type<SortDirective>);
 
     // WHEN
     fixture.detectChanges();
@@ -70,7 +70,7 @@ describe('Directive: SortDirective', () => {
 
   it('should change sort order to descending, neutral when same field is sorted again', () => {
     // GIVEN
-    const sortDirective = tableRow.injector.get(SortDirective);
+    const sortDirective = tableRow.injector.get(SortDirective as Type<SortDirective>);
 
     // WHEN
     fixture.detectChanges();
@@ -89,7 +89,7 @@ describe('Directive: SortDirective', () => {
 
   it('should change sort order to ascending when different field is sorted', () => {
     // GIVEN
-    const sortDirective = tableRow.injector.get(SortDirective);
+    const sortDirective = tableRow.injector.get(SortDirective as Type<SortDirective>);
 
     // WHEN
     fixture.detectChanges();


### PR DESCRIPTION
Fix
![image](https://github.com/jhipster/generator-jhipster/assets/9989211/ede1c66c-1553-4d8e-ba71-2e6439b5d175)


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
