### PR TITLE
[Angular] Fix deprecated signature for tableRow.injector.get

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, DebugElement, inject } from '@angular/core';
+import { Component, DebugElement, Type, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { FaIconComponent, FaIconLibrary } from '@fortawesome/angular-fontawesome';
@@ -72,7 +72,7 @@ describe('Directive: SortByDirective', () => {
   it('should have a neutral state for predicate column and undefined order value', () => {
     // GIVEN
     component.sortState.set({ predicate: 'name' });
-    const sortByDirective = tableHead.injector.get(SortByDirective);
+    const sortByDirective = tableHead.injector.get(SortByDirective as Type<SortByDirective>);
 
     // WHEN
     fixture.detectChanges();
@@ -85,7 +85,7 @@ describe('Directive: SortByDirective', () => {
   it('should have an asc state for predicate column and true asc value', () => {
     // GIVEN
     component.sortState.set({ predicate: 'name', order: 'asc' });
-    const sortByDirective = tableHead.injector.get(SortByDirective);
+    const sortByDirective = tableHead.injector.get(SortByDirective as Type<SortByDirective>);
 
     // WHEN
     fixture.detectChanges();
@@ -98,7 +98,7 @@ describe('Directive: SortByDirective', () => {
   it('should have a desc state for predicate column and desc value', () => {
     // GIVEN
     component.sortState.set({ predicate: 'name', order: 'desc' });
-    const sortByDirective = tableHead.injector.get(SortByDirective);
+    const sortByDirective = tableHead.injector.get(SortByDirective as Type<SortByDirective>);
 
     // WHEN
     fixture.detectChanges();
@@ -111,7 +111,7 @@ describe('Directive: SortByDirective', () => {
   it('should have a neutral state for non-predicate column', () => {
     // GIVEN
     component.sortState.set({ predicate: 'non-existing-column', order: 'asc' });
-    const sortByDirective = tableHead.injector.get(SortByDirective);
+    const sortByDirective = tableHead.injector.get(SortByDirective as Type<SortByDirective>);
 
     // WHEN
     fixture.detectChanges();
@@ -123,7 +123,7 @@ describe('Directive: SortByDirective', () => {
 
   it('multiple clicks at same component, should call SortDirective sort', () => {
     // GIVEN
-    const sortDirective = tableHead.injector.get(SortDirective);
+    const sortDirective = tableHead.injector.get(SortDirective as Type<SortDirective>);
     sortDirective.sort = jest.fn();
 
     // WHEN


### PR DESCRIPTION
Related to #26516 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
