### PR TITLE
Forward proxy URI from proxy to server to let it pass to oauth2 authentication

### DIFF
--- a/generators/angular/templates/webpack/webpack.custom.js.ejs
+++ b/generators/angular/templates/webpack/webpack.custom.js.ejs
@@ -80,6 +80,13 @@ module.exports = async (config, options, targetOptions) => {
             proxyOptions: {
               changeOrigin: false, //pass the Host header to the backend unchanged  https://github.com/Browsersync/browser-sync/issues/430
             },
+            proxyReq: [
+              function(proxyReq) {
+                // URI that will be retrieved by the ForwardedHeaderFilter on the server side
+                proxyReq.setHeader('X-Forwarded-Host', 'localhost:9000');
+                proxyReq.setHeader('X-Forwarded-Proto', 'https');
+              }
+            ]
           },
           socket: {
             clients: {

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -203,6 +203,8 @@ spring:
 
 server:
   port: <%= serverPort %>
+  # make sure requests the proxy uri instead of the server one
+  forward-headers-strategy: native
 
 # ===================================================================
 # JHipster specific properties


### PR DESCRIPTION
We add special fields on the proxy. They are picked up by the ForwardedHeaderFilter on the server side to modify the incoming request. This is used for the baseUrl when oauth2 is called. The impact is that oauth2 will redirect to 9000 after authentication instead of 8080. Which is what we want.