### PR TITLE
Sonar: Remove this unused 'longCount' private field.

### DIFF
--- a/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
@@ -210,7 +210,7 @@ import java.util.UUID;
 <%_ } _%>
 <%_ if (!embedded && (primaryKey.hasLong || primaryKey.hasInteger)) { _%>
 import java.util.Random;
-  <%_ if (primaryKey.hasLong) { _%>
+  <%_ if (primaryKey.hasLong && !readOnly && updatableEntity) { _%>
 import java.util.concurrent.atomic.AtomicLong;
   <%_ } else if (primaryKey.hasInteger) { _%>
 import java.util.concurrent.atomic.AtomicInteger;
@@ -449,7 +449,7 @@ if (field.fieldTypeString || field.blobContentTypeText) {
 <%_ if (!embedded && (primaryKey.hasLong || primaryKey.hasInteger)) { _%>
 
     private static Random random = new Random();
-  <%_ if (primaryKey.hasLong) { _%>
+  <%_ if (primaryKey.hasLong && !readOnly && updatableEntity) { _%>
     private static AtomicLong longCount = new AtomicLong(random.nextInt() + ( 2 * Integer.MAX_VALUE ));
   <%_ } else if (primaryKey.hasInteger) { _%>
     private static AtomicInteger intCount = new AtomicInteger(random.nextInt() + ( 2 * Short.MAX_VALUE ));


### PR DESCRIPTION
Related to #25231

Fix:
- https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&resolved=false&id=jhipster-sample-application&open=AZBahc4z7zsW3EZMzl0S

![image](https://github.com/jhipster/generator-jhipster/assets/9989211/89e36dcd-58ef-4efd-bbb0-0d2daa41a820)

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
