### PR TITLE
Sonar: Immediately return this expression instead of assigning it to the temporary variable

### DIFF
--- a/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
@@ -523,6 +523,12 @@ filterTestableRelationships.filter(rel => !rel.otherEntity.builtInUser).forEach(
      * if they test an entity which requires the current entity.
      */
     public static <%= persistClass %> create<% if (fieldStatus === 'UPDATED_') { _%>Updated<%_ } %>Entity(<% if (databaseTypeSql) { %>EntityManager em<% } %>) {
+<%_ if (!(reactive && databaseTypeSql && primaryKey.typeUUID && !isUsingMapsId 
+        || primaryKey.typeString && !isUsingMapsId && !primaryKey.autoGenerate
+        || fieldsToTest && fieldsToTest.length > 0
+        || persistableRelationships && persistableRelationships.length > 0)) { _%>
+      return new <%= persistClass %>();
+<%_ } else { _%>
   <%_ if (fluentMethods) { _%>
         <%= persistClass %> <%= persistInstance %> = new <%= persistClass %>()
     <%_ if (reactive && databaseTypeSql && primaryKey.typeUUID && !isUsingMapsId) { _%>
@@ -601,6 +607,7 @@ filterTestableRelationships.filter(rel => !rel.otherEntity.builtInUser).forEach(
     <%_ } _%>
   <%_ } _%>
         return <%= persistInstance %>;
+<%_ } _%>
     }
 <%_ }); _%>
 


### PR DESCRIPTION
Related to #25231 

Fix a lot of issues like:
- https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&resolved=false&id=jhipster-sample-application&open=AZBahc1b7zsW3EZMzlzh
- ...

<img width="575" alt="image" src="https://github.com/jhipster/generator-jhipster/assets/9989211/17f918cb-4bd7-44fc-b2fd-196f933c4088">


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
