### PR TITLE
update vue eslint to v9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -189,10 +189,6 @@ updates:
         patterns:
           - '@eslint/*'
           - 'eslint'
-      vue-eslint:
-        patterns:
-          - '@vue/eslint-config-typescript'
-          - 'eslint-plugin-vue'
       fortawesome:
         patterns:
           - '@fortawesome/fontawesome-svg-core'

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -21,7 +21,6 @@
     "vue-router": "4.4.0"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "8.57.0",
     "@module-federation/utilities": "3.0.3-0",
     "@pinia/testing": "0.1.3",

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -21,7 +21,7 @@
     "vue-router": "4.4.0"
   },
   "devDependencies": {
-    "@eslint/js": "8.57.0",
+    "@eslint/js": "9.7.0",
     "@module-federation/utilities": "3.0.3-0",
     "@pinia/testing": "0.1.3",
     "@tsconfig/node18": "18.2.4",
@@ -36,7 +36,7 @@
     "copy-webpack-plugin": "12.0.2",
     "css-loader": "7.1.2",
     "css-minimizer-webpack-plugin": "7.0.0",
-    "eslint": "8.57.0",
+    "eslint": "9.7.0",
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-vue": "9.27.0",
     "flush-promises": "1.0.2",
@@ -56,8 +56,8 @@
     "terser-webpack-plugin": "5.3.10",
     "ts-loader": "9.5.1",
     "typescript": "5.5.4",
-    "typescript-eslint": "7.17.0",
-    "vite": "5.3.5",
+    "typescript-eslint": "8.0.0-alpha.54",
+    "vite": "5.3.4",
     "vite-plugin-static-copy": "1.0.6",
     "vitest": "2.0.4",
     "vitest-sonar-reporter": "2.0.0",

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -29,7 +29,6 @@
     "@types/node": "20.11.25",
     "@types/sinon": "17.0.3",
     "@vitejs/plugin-vue": "5.1.0",
-    "@vue/eslint-config-typescript": "13.0.0",
     "@vue/test-utils": "2.4.6",
     "@vue/tsconfig": "0.5.1",
     "autoprefixer": "10.4.19",

--- a/generators/vue/templates/eslint.config.js.jhi.vue.ejs
+++ b/generators/vue/templates/eslint.config.js.jhi.vue.ejs
@@ -17,18 +17,8 @@
  limitations under the License.
 -%>
 <&_ if (fragment.importsSection) { -&>
-import { fileURLToPath } from "node:url";
-import { dirname } from "node:path";
-import { FlatCompat } from '@eslint/eslintrc';
-
 import js from '@eslint/js';
-import tseslint from 'typescript-eslint';
 import vue from 'eslint-plugin-vue';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({ baseDirectory: __dirname });
 
 <&_ } -&>
 <&_ if (fragment.configSection) { -&>

--- a/generators/vue/templates/eslint.config.js.jhi.vue.ejs
+++ b/generators/vue/templates/eslint.config.js.jhi.vue.ejs
@@ -57,12 +57,6 @@ const compat = new FlatCompat({ baseDirectory: __dirname });
       globals: { ...globals.browser },
     },
     rules: {
-      ...Object.fromEntries(
-        compat
-          .extends('@vue/eslint-config-typescript/recommended')
-          .map(({ rules }) => (rules ? Object.entries(rules) : []))
-          .flat(),
-      ),
       'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
       'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
       'vue/multi-word-component-names': 'off',

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -91,7 +91,6 @@
     "@tsconfig/node18": null,
     "@vitejs/plugin-vue": "<%= nodeDependencies['@vitejs/plugin-vue'] %>",
     "@vitest/coverage-v8": "<%= nodeDependencies.vitest %>",
-    "@vue/eslint-config-typescript": "<%= nodeDependencies['@vue/eslint-config-typescript'] %>",
     "@vue/test-utils": "<%= nodeDependencies['@vue/test-utils'] %>",
     "@vue/tsconfig": null,
     "axios-mock-adapter": "<%= nodeDependencies['axios-mock-adapter'] %>",

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -83,7 +83,6 @@
     "webpack-merge": "<%= nodeDependencies['webpack-merge'] %>",
     "workbox-webpack-plugin": "<%= nodeDependencies['workbox-webpack-plugin'] %>",
 <%_ } _%>
-    "@eslint/eslintrc": null,
     "@eslint/js": null,
     "@pinia/testing": "<%= nodeDependencies['@pinia/testing'] %>",
     "@types/node": "<%= nodeDependencies['@types/node'] %>",


### PR DESCRIPTION
Drop @vue/eslint-config-typescript, it's just a wrapper around eslint-plugin-vue and typescript-eslint that looks not required anymore.

Related to https://github.com/jhipster/generator-jhipster/issues/26471
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
