### PR TITLE
Don't sort maven dependency imports

### DIFF
--- a/generators/base/support/jhipster7-context.js
+++ b/generators/base/support/jhipster7-context.js
@@ -18,6 +18,30 @@ import { upperFirstCamelCase } from './string.js';
 const { BYTES, BYTE_BUFFER } = fieldTypes.RelationalOnlyDBTypes;
 
 export const jhipster7deprecatedProperties = {
+  devDatabaseType: {
+    behaviorOnlyReason: 'v8: devDatabaseType is only used in jhipster:spring-data-relational generator',
+    get: ({ data }) => {
+      if (data.devDatabaseType === undefined) return data.devDatabaseType;
+      const fallbackValue = data.prodDatabaseType ?? data.databaseType;
+      // eslint-disable-next-line no-console
+      console.log(
+        `JHipster v8 behavior change(devDatabaseType is only used in jhipster:spring-data-relational generator): devDatabaseType is not set, using fallback: ${fallbackValue}`,
+      );
+      return fallbackValue;
+    },
+  },
+  prodDatabaseType: {
+    behaviorOnlyReason: 'v8: prodDatabaseType is only used in jhipster:spring-data-relational generator',
+    get: ({ data }) => data.prodDatabaseType ?? data.databaseType,
+    get: ({ data }) => {
+      if (data.prodDatabaseType === undefined) return data.prodDatabaseType;
+      // eslint-disable-next-line no-console
+      console.log(
+        `JHipster v8 behavior change(prodDatabaseType is only used in jhipster:spring-data-relational generator): devDatabaseType is not set, using fallback: ${data.databaseType}`,
+      );
+      return data.databaseType;
+    },
+  },
   GRADLE_VERSION: {
     replacement: 'gradleVersion',
     get: ({ data }) => data.gradleVersion,
@@ -300,12 +324,14 @@ const getPropertBuilder =
     const { generator, data } = context;
     const value = prop in data ? data[prop] : undefined;
     if (prop in jhipster7deprecatedProperties) {
-      const { replacement, get } = jhipster7deprecatedProperties[prop];
+      const { replacement, get, behaviorOnlyReason } = jhipster7deprecatedProperties[prop];
       const fallBackValue = get(context);
       const valueDesc = prop in data ? `Value: ${value}, ` : '';
-      log(
-        `Template data ${chalk.yellow(String(prop))} was removed and should be replaced with ${chalk.yellow(replacement)}. ${valueDesc}FallbackValue: ${fallBackValue}`,
-      );
+      if (!behaviorOnlyReason) {
+        log(
+          `Template data ${chalk.yellow(String(prop))} was removed and should be replaced with ${chalk.yellow(replacement)}. ${valueDesc}FallbackValue: ${fallBackValue}`,
+        );
+      }
       return value ?? fallBackValue;
     }
     if (prop?.startsWith?.('DOCKER_')) {

--- a/generators/maven/internal/pom-sort.ts
+++ b/generators/maven/internal/pom-sort.ts
@@ -18,7 +18,7 @@
  */
 import sortKeys from 'sort-keys';
 
-import { MavenArtifact, MavenProfile } from '../types.js';
+import { MavenDependency, MavenProfile } from '../types.js';
 
 export const formatPomFirstLevel = content =>
   content.replace(
@@ -97,8 +97,14 @@ const comparator = (order: string[]) => (a: string, b: string) => sortWithTempla
 
 const sortProperties = properties => sortKeys(properties, { compare: comparator(propertiesOrder) });
 
-const sortArtifacts = (artifacts: MavenArtifact[]) =>
-  artifacts.sort((a: MavenArtifact, b: MavenArtifact) => {
+const sortArtifacts = (artifacts: MavenDependency[]) =>
+  artifacts.sort((a: MavenDependency, b: MavenDependency) => {
+    if (a.scope === 'import' || b.scope === 'import') {
+      if (a.scope === b.scope) {
+        return 1;
+      }
+      return a.scope === 'import' ? -1 : 1;
+    }
     if (a.groupId !== b.groupId) {
       if (a.groupId === undefined) {
         return -1;


### PR DESCRIPTION
Dependency management pom import order is first served and will define transitional dependencies version.
Reordering changes the end result, so move to the top and keep insert ordering.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
