### PR TITLE
fix : issue 26946 -  compilation issue when using elastic search as s…

### DIFF
--- a/generators/spring-boot/templates/_global_partials_entity_/save_template.ejs
+++ b/generators/spring-boot/templates/_global_partials_entity_/save_template.ejs
@@ -33,5 +33,5 @@
 <%_ if (dtoMapstruct) { _%>
         <%- returnDirectly ? 'return' : `${dtoInstance} =` %> <%- entityInstance %>Mapper.toDto(<%- persistInstance %>);
 <%_ } else if (returnDirectly && searchEngineElasticsearch) { _%>
-        return <%- entityInstance %>;
+        return <%- persistInstance %>;
 <%_ } _%>


### PR DESCRIPTION
fix : issue 26946 -  compilation issue when using ElasticSearch as search engine.

Fixes https://github.com/jhipster/generator-jhipster/issues/26946 

persistInstance should be returned instead of entityInstance when using ElasticSearch as the search engine.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
