### PR TITLE
npmw created after ./npmw started

### DIFF
--- a/generators/server/generator.ts
+++ b/generators/server/generator.ts
@@ -349,7 +349,7 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
 
           if (field.fieldType === BYTE_BUFFER) {
             this.log.warn(
-              `Cannot use validation in .jhipster/${entityName}.json for field ${stringifyApplicationData(field)} 
+              `Cannot use validation in .jhipster/${entityName}.json for field ${stringifyApplicationData(field)}
 Hibernate JPA 2 Metamodel does not work with Bean Validation 2 for LOB fields, so LOB validation is disabled`,
             );
             field.fieldValidate = false;

--- a/generators/spring-boot/generator.ts
+++ b/generators/spring-boot/generator.ts
@@ -146,8 +146,6 @@ export default class SpringBootGenerator extends BaseApplicationGenerator {
           searchEngine,
           websocket,
           cacheProvider,
-          skipClient,
-          clientFramework,
           testFrameworks,
           feignClient,
           enableSwaggerCodegen,
@@ -156,10 +154,6 @@ export default class SpringBootGenerator extends BaseApplicationGenerator {
         await this.composeWithJHipster(GENERATOR_DOCKER);
         await this.composeWithJHipster('jhipster:java:jib');
         await this.composeWithJHipster('jhipster:java:code-quality');
-
-        if (!skipClient && clientFramework !== 'no') {
-          await this.composeWithJHipster('jhipster:java:node');
-        }
 
         if (enableSwaggerCodegen) {
           await this.composeWithJHipster('jhipster:java:openapi-generator');
@@ -212,6 +206,13 @@ export default class SpringBootGenerator extends BaseApplicationGenerator {
 
   get composingComponent() {
     return this.asComposingComponentTaskGroup({
+      async composing() {
+        const { clientFramework, skipClient } = this.jhipsterConfigWithDefaults;
+        if (!skipClient && clientFramework !== 'no') {
+          // When using prompts, clientFramework will only be known after composing priority.
+          await this.composeWithJHipster('jhipster:java:node');
+        }
+      },
       async composeLanguages() {
         if (this.jhipsterConfigWithDefaults.enableTranslation) {
           await this.composeWithJHipster(GENERATOR_LANGUAGES);


### PR DESCRIPTION
Fix #27244

Actual behavior on the main branch:
`./npmw install` is executed whereas the file `npmw` is not created (it works if we do `jhipster --force` after)

```
 quentin  ~    JHipster  appreactmicro2  jhipster
WARNING! Since JHipster v8, the jhipster command will not use the locally installed generator-jhipster.
    If you want to execute the locally installed generator-jhipster, run: npx jhipster

        ██╗ ██╗   ██╗ ████████╗ ███████╗   ██████╗ ████████╗ ████████╗ ███████╗
        ██║ ██║   ██║ ╚══██╔══╝ ██╔═══██╗ ██╔════╝ ╚══██╔══╝ ██╔═════╝ ██╔═══██╗
        ██║ ████████║    ██║    ███████╔╝ ╚█████╗     ██║    ██████╗   ███████╔╝
  ██╗   ██║ ██╔═══██║    ██║    ██╔════╝   ╚═══██╗    ██║    ██╔═══╝   ██╔══██║
  ╚██████╔╝ ██║   ██║ ████████╗ ██║       ██████╔╝    ██║    ████████╗ ██║  ╚██╗
   ╚═════╝  ╚═╝   ╚═╝ ╚═══════╝ ╚═╝       ╚═════╝     ╚═╝    ╚═══════╝ ╚═╝   ╚═╝
                            https://www.jhipster.tech
Welcome to JHipster v8.7.0

 _______________________________________________________________________________________________________________

  Documentation for creating an application is at https://www.jhipster.tech/creating-an-app/

  Application files will be generated in folder: /Users/quentin/Documents/Tech/JHipster/appreactmicro2
 _______________________________________________________________________________________________________________

? What is the base name of your application? appreactmicro2
? Which *type* of application would you like to create? Microservice application
? What is your default Java package name? com.mycompany.myapp
? Would you like to use Maven or Gradle for building the backend? Gradle
? Do you want to make it reactive with Spring WebFlux? No
? As you are running in a microservice architecture, on which port would like your server to run? It should be unique to avoid port conflicts. 8081
? Which service discovery server do you want to use? Consul (recommended)
? Which *type* of authentication would you like to use? JWT authentication (stateless, with a token)
? Do you want to generate a feign client? Yes
? Besides JUnit, which testing frameworks would you like to use?
? Which *type* of database would you like to use? SQL (H2, PostgreSQL, MySQL, MariaDB, Oracle, MSSQL)
? Which *production* database would you like to use? PostgreSQL
? Which *development* database would you like to use? H2 with disk-based persistence
? Which cache do you want to use? (Spring cache abstraction) Ehcache (local cache, for a single node)
? Do you want to use Hibernate 2nd level cache? Yes
? Which other technologies would you like to use?
? Do you want to enable Gradle Enterprise integration? No
? Which *framework* would you like to use as microfrontend? React
? Besides Jest/Vitest, which testing frameworks would you like to use?
? Do you want to generate the admin UI? No
? Would you like to use a Bootswatch theme (https://bootswatch.com/)? Default JHipster
WARNING! Could not fetch bootswatch themes from API. Using default ones.
? Would you like to enable internationalization support? Yes
? Please choose the native language of the application French
? Please choose additional languages to install
     info Could not remove legacy file .huskyrc
     info Could not remove legacy file .lintstagedrc.js


     info Generating 2 048 bit RSA key pair and self-signed certificate (SHA384withRSA) with a validity of 99 999 days
     info 	for: CN=Java Hipster, OU=Development, O=com.mycompany.myapp, L=, ST=, C=
     info KeyStore '/Users/quentin/Documents/Tech/JHipster/appreactmicro2/src/main/resources/config/tls/keystore.p12' generated successfully.
     info Could not remove legacy file .eslintrc.json
     info Could not remove legacy file .eslintignore
✔ applying multi-step templates
✔ Git repository initialized.
WARNING! liquibaseVersion is required by gradle-liquibase-plugin, make sure to add it to your dependencies
   create .prettierrc
   create .prettierignore
✔ prettier configuration files committed to disk
✔ loading translations
✔ updating package.json dependencies versions
✔ prettifying sonar-project.properties
✔ adding package-info.java files
   create sonar-project.properties
   create .husky/pre-commit
   create src/main/resources/banner.txt
   create .devcontainer/Dockerfile
   create build.gradle
   create settings.gradle
   create gradle.properties
   create gradle/profile_dev.gradle
   create gradle/profile_prod.gradle
   create gradle/war.gradle
   create gradle/zipkin.gradle
   create src/main/resources/logback-spring.xml
   create src/main/resources/i18n/messages.properties
   create src/test/resources/logback.xml
   create src/test/resources/junit-platform.properties
   create gradlew
   create gradlew.bat
   create gradle/wrapper/gradle-wrapper.jar
   create gradle/wrapper/gradle-wrapper.properties
   create buildSrc/build.gradle
   create buildSrc/gradle/libs.versions.toml
   create gradle/libs.versions.toml
   create src/main/docker/jib/entrypoint.sh
   create checkstyle.xml
   create src/main/resources/.h2.server.properties
   create buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle
   create buildSrc/src/main/groovy/jhipster.docker-conventions.gradle
   create buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle
   create gradle/liquibase.gradle
   create src/main/resources/config/liquibase/changelog/00000000000000_initial_schema.xml
   create src/main/resources/config/liquibase/master.xml
   create src/main/webapp/content/images/jhipster_family_member_0.svg
   create src/main/webapp/content/images/jhipster_family_member_0_head-192.png
   create src/main/webapp/content/images/jhipster_family_member_0_head-256.png
   create src/main/webapp/content/images/jhipster_family_member_0_head-384.png
   create src/main/webapp/content/images/jhipster_family_member_0_head-512.png
   create src/main/webapp/content/images/jhipster_family_member_1.svg
   create src/main/webapp/content/images/jhipster_family_member_1_head-192.png
   create src/main/webapp/content/images/jhipster_family_member_1_head-256.png
   create src/main/webapp/content/images/jhipster_family_member_1_head-384.png
   create src/main/webapp/content/images/jhipster_family_member_1_head-512.png
   create src/main/webapp/content/images/jhipster_family_member_2.svg
   create src/main/webapp/content/images/jhipster_family_member_2_head-192.png
   create src/main/webapp/content/images/jhipster_family_member_2_head-256.png
   create src/main/webapp/content/images/jhipster_family_member_2_head-384.png
   create src/main/webapp/content/images/jhipster_family_member_2_head-512.png
   create src/main/webapp/content/images/jhipster_family_member_3.svg
   create src/main/webapp/content/images/jhipster_family_member_3_head-192.png
   create src/main/webapp/content/images/jhipster_family_member_3_head-256.png
   create src/main/webapp/content/images/jhipster_family_member_3_head-384.png
   create src/main/webapp/content/images/jhipster_family_member_3_head-512.png
   create src/main/webapp/content/images/logo-jhipster.png
   create src/main/webapp/favicon.ico
   create src/main/webapp/swagger-ui/dist/images/throbber.gif
   create src/main/webapp/manifest.webapp
   create src/main/webapp/WEB-INF/web.xml
   create src/main/webapp/robots.txt
   create src/main/resources/i18n/messages_fr.properties
   create webpack/logo-jhipster.png
   create .gitignore
   create .gitattributes
   create .editorconfig
   create src/test/resources/META-INF/spring.factories
   create package.json
    force .yo-rc.json
   create .devcontainer/devcontainer.json
   create src/main/resources/templates/error.html
   create src/main/resources/config/application.yml
   create src/main/resources/config/application-dev.yml
   create src/main/resources/config/application-tls.yml
   create src/main/resources/config/application-prod.yml
   create src/main/resources/static/index.html
   create src/main/resources/config/bootstrap.yml
   create src/main/resources/config/bootstrap-prod.yml
   create src/test/resources/config/bootstrap.yml
   create src/test/resources/config/application.yml
   create src/main/docker/postgresql.yml
   create src/main/docker/central-server-config/README.md
   create src/main/docker/consul.yml
   create src/main/docker/config/git2consul.json
   create src/main/docker/central-server-config/application.yml
   create src/main/docker/app.yml
   create src/main/docker/jhipster-control-center.yml
   create src/main/docker/monitoring.yml
   create src/main/docker/grafana/provisioning/dashboards/dashboard.yml
   create src/main/docker/grafana/provisioning/dashboards/JVM.json
   create src/main/docker/grafana/provisioning/datasources/datasource.yml
   create src/main/docker/sonar.yml
   create src/main/docker/prometheus/prometheus.yml
   create src/main/docker/zipkin.yml
   create src/test/resources/config/application-testdev.yml
   create src/test/resources/config/application-testprod.yml
   create src/main/webapp/content/css/loading.css
   create src/main/webapp/404.html
   create src/main/webapp/index.html
   create src/main/webapp/swagger-ui/index.html
   create tsconfig.json
   create tsconfig.test.json
   create src/main/webapp/app/app.scss
   create src/main/webapp/app/_bootstrap-variables.scss
   create src/main/webapp/app/modules/home/home.scss
   create src/main/webapp/app/modules/administration/docs/docs.scss
   create src/main/webapp/app/shared/layout/header/header.scss
   create src/main/webapp/app/shared/layout/footer/footer.scss
   create src/main/webapp/app/shared/layout/password/password-strength-bar.scss
   create README.md
   create src/main/docker/services.yml
   create src/main/webapp/i18n/fr/error.json
   create src/main/webapp/i18n/fr/login.json
   create src/main/webapp/i18n/fr/password.json
   create src/main/webapp/i18n/fr/register.json
   create src/main/webapp/i18n/fr/sessions.json
   create src/main/webapp/i18n/fr/settings.json
   create src/main/webapp/i18n/fr/activate.json
   create src/main/webapp/i18n/fr/global.json
   create src/main/webapp/i18n/fr/home.json
   create src/main/webapp/i18n/fr/reset.json
   create src/test/java/com/mycompany/myapp/domain/AssertUtils.java
   create src/test/java/com/mycompany/myapp/security/SecurityUtilsUnitTest.java
   create src/test/java/com/mycompany/myapp/TechnicalStructureTest.java
   create src/test/java/com/mycompany/myapp/config/AsyncSyncConfiguration.java
   create src/test/java/com/mycompany/myapp/IntegrationTest.java
   create src/test/java/com/mycompany/myapp/config/SpringBootTestClassOrderer.java
   create src/test/java/com/mycompany/myapp/config/StaticResourcesWebConfigurerTest.java
   create src/test/java/com/mycompany/myapp/web/filter/SpaWebFilterIT.java
   create src/test/java/com/mycompany/myapp/web/rest/TestUtil.java
   create src/test/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslatorTestController.java
   create src/test/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslatorIT.java
   create src/test/java/com/mycompany/myapp/web/rest/WithUnauthenticatedMockUser.java
   create src/test/java/com/mycompany/myapp/management/SecurityMetersServiceTests.java
   create src/test/java/com/mycompany/myapp/security/jwt/AuthenticationIntegrationTest.java
   create src/test/java/com/mycompany/myapp/security/jwt/JwtAuthenticationTestUtils.java
   create src/test/java/com/mycompany/myapp/security/jwt/TokenAuthenticationSecurityMetersIT.java
   create src/test/java/com/mycompany/myapp/security/jwt/TokenAuthenticationIT.java
   create src/test/java/com/mycompany/myapp/security/jwt/TestAuthenticationResource.java
   create src/test/java/com/mycompany/myapp/config/CRLFLogConverterTest.java
   create src/test/java/com/mycompany/myapp/config/WebConfigurerTest.java
   create src/test/java/com/mycompany/myapp/config/WebConfigurerTestController.java
   create src/test/java/com/mycompany/myapp/config/timezone/HibernateTimeZoneIT.java
   create src/test/java/com/mycompany/myapp/repository/timezone/DateTimeWrapper.java
   create src/test/java/com/mycompany/myapp/repository/timezone/DateTimeWrapperRepository.java
   create src/test/java/com/mycompany/myapp/config/EmbeddedSQL.java
   create src/test/java/com/mycompany/myapp/config/SqlTestContainer.java
   create src/test/java/com/mycompany/myapp/config/SqlTestContainersSpringContextCustomizerFactory.java
   create src/test/java/com/mycompany/myapp/config/PostgreSqlTestContainer.java
   create src/main/java/com/mycompany/myapp/package-info.java
   create src/main/java/com/mycompany/myapp/GeneratedByJHipster.java
   create src/main/java/com/mycompany/myapp/security/package-info.java
   create src/main/java/com/mycompany/myapp/security/SpringSecurityAuditorAware.java
   create src/main/java/com/mycompany/myapp/security/SecurityUtils.java
   create src/main/java/com/mycompany/myapp/security/AuthoritiesConstants.java
   create src/main/java/com/mycompany/myapp/config/package-info.java
   create src/main/java/com/mycompany/myapp/config/SecurityConfiguration.java
   create src/main/java/com/mycompany/myapp/config/SpringDocConfiguration.java
   create src/main/java/com/mycompany/myapp/Appreactmicro2App.java
   create src/main/java/com/mycompany/myapp/aop/logging/package-info.java
   create src/main/java/com/mycompany/myapp/aop/logging/LoggingAspect.java
   create src/main/java/com/mycompany/myapp/config/AsyncConfiguration.java
   create src/main/java/com/mycompany/myapp/config/CRLFLogConverter.java
   create src/main/java/com/mycompany/myapp/config/DateTimeFormatConfiguration.java
   create src/main/java/com/mycompany/myapp/config/LoggingConfiguration.java
   create src/main/java/com/mycompany/myapp/config/ApplicationProperties.java
   create src/main/java/com/mycompany/myapp/config/JacksonConfiguration.java
   create src/main/java/com/mycompany/myapp/config/LoggingAspectConfiguration.java
   create src/main/java/com/mycompany/myapp/config/WebConfigurer.java
   create src/main/java/com/mycompany/myapp/config/Constants.java
   create src/main/java/com/mycompany/myapp/domain/package-info.java
   create src/main/java/com/mycompany/myapp/domain/AbstractAuditingEntity.java
   create src/main/java/com/mycompany/myapp/web/rest/errors/package-info.java
   create src/main/java/com/mycompany/myapp/web/rest/errors/BadRequestAlertException.java
   create src/main/java/com/mycompany/myapp/web/rest/errors/ErrorConstants.java
   create src/main/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslator.java
   create src/main/java/com/mycompany/myapp/web/rest/errors/FieldErrorVM.java
   create src/main/java/com/mycompany/myapp/config/StaticResourcesWebConfiguration.java
   create src/main/java/com/mycompany/myapp/web/filter/package-info.java
   create src/main/java/com/mycompany/myapp/web/filter/SpaWebFilter.java
   create src/main/java/com/mycompany/myapp/config/SecurityJwtConfiguration.java
   create src/main/java/com/mycompany/myapp/management/package-info.java
   create src/main/java/com/mycompany/myapp/management/SecurityMetersService.java
   create src/main/java/com/mycompany/myapp/ApplicationWebXml.java
   create src/main/java/com/mycompany/myapp/config/FeignConfiguration.java
   create src/main/java/com/mycompany/myapp/client/package-info.java
   create src/main/java/com/mycompany/myapp/client/UserFeignClientInterceptor.java
   create src/main/java/com/mycompany/myapp/config/DatabaseConfiguration.java
   create src/main/java/com/mycompany/myapp/config/CacheConfiguration.java
   create src/main/java/com/mycompany/myapp/config/LiquibaseConfiguration.java
   create .lintstagedrc.cjs
   create jest.conf.js
   create webpack/environment.js
   create webpack/webpack.common.js
   create webpack/webpack.dev.js
   create webpack/webpack.prod.js
   create webpack/utils.js
   create postcss.config.js
   create src/main/webapp/app/app.tsx
   create src/main/webapp/app/index.tsx
   create src/main/webapp/app/routes.tsx
   create src/main/webapp/app/setup-tests.ts
   create src/main/webapp/app/typings.d.ts
   create src/main/webapp/app/config/constants.ts
   create src/main/webapp/app/config/dayjs.ts
   create src/main/webapp/app/config/axios-interceptor.ts
   create src/main/webapp/app/config/error-middleware.ts
   create src/main/webapp/app/config/logger-middleware.ts
   create src/main/webapp/app/config/notification-middleware.ts
   create src/main/webapp/app/config/store.ts
   create src/main/webapp/app/config/icon-loader.ts
   create src/main/webapp/app/config/translation.ts
   create src/main/webapp/app/entities/reducers.ts
   create src/main/webapp/app/entities/menu.tsx
   create src/main/webapp/app/entities/routes.tsx
   create src/main/webapp/app/modules/home/home.tsx
   create src/main/webapp/app/modules/login/logout.tsx
   create src/main/webapp/app/modules/login/login.tsx
   create src/main/webapp/app/modules/login/login-modal.tsx
   create src/main/webapp/app/shared/reducers/index.ts
   create src/main/webapp/app/shared/reducers/reducer.utils.ts
   create src/main/webapp/app/shared/reducers/authentication.ts
   create src/main/webapp/app/shared/reducers/locale.ts
   create src/main/webapp/app/shared/reducers/application-profile.ts
   create src/main/webapp/app/modules/administration/index.tsx
   create src/main/webapp/app/modules/administration/docs/docs.tsx
   create src/main/webapp/app/modules/administration/administration.reducer.ts
   create src/main/webapp/app/shared/layout/footer/footer.tsx
   create src/main/webapp/app/shared/layout/header/header.tsx
   create src/main/webapp/app/shared/layout/menus/index.ts
   create src/main/webapp/app/shared/layout/menus/admin.tsx
   create src/main/webapp/app/shared/layout/header/header-components.tsx
   create src/main/webapp/app/shared/layout/menus/account.tsx
   create src/main/webapp/app/shared/layout/menus/menu-components.tsx
   create src/main/webapp/app/shared/layout/menus/entities.tsx
   create src/main/webapp/app/shared/layout/menus/menu-item.tsx
   create src/main/webapp/app/shared/layout/password/password-strength-bar.tsx
   create src/main/webapp/app/shared/util/date-utils.ts
   create src/main/webapp/app/shared/util/entity-utils.ts
   create src/main/webapp/app/shared/auth/private-route.tsx
   create src/main/webapp/app/shared/error/error-boundary.tsx
   create src/main/webapp/app/shared/util/pagination.constants.ts
   create src/main/webapp/app/shared/error/error-boundary-routes.tsx
   create src/main/webapp/app/shared/error/page-not-found.tsx
   create src/main/webapp/app/shared/DurationFormat.tsx
   create src/main/webapp/app/shared/model/user.model.ts
   create src/main/webapp/app/shared/layout/menus/locale.tsx
   create src/main/webapp/app/main.tsx
   create src/main/webapp/app/shared/error/error-loading.tsx
   create src/main/webapp/app/config/axios-interceptor.spec.ts
   create src/main/webapp/app/config/notification-middleware.spec.ts
   create src/main/webapp/app/shared/reducers/authentication.spec.ts
   create src/main/webapp/app/shared/reducers/application-profile.spec.ts
   create src/main/webapp/app/shared/util/entity-utils.spec.ts
   create src/main/webapp/app/shared/auth/private-route.spec.tsx
   create src/main/webapp/app/shared/error/error-boundary.spec.tsx
   create src/main/webapp/app/shared/error/error-boundary-routes.spec.tsx
   create src/main/webapp/app/shared/layout/header/header.spec.tsx
   create src/main/webapp/app/shared/layout/menus/account.spec.tsx
   create src/main/webapp/app/shared/reducers/locale.spec.ts
   create src/main/webapp/app/modules/administration/administration.reducer.spec.ts
   create src/main/webapp/app/shared/jhipster/problem-details.ts
   create src/main/webapp/app/shared/jhipster/headers.ts
   create webpack/webpack.microfrontend.js
   create eslint.config.mjs
✔ files committed to disk

Changes to package.json were detected.
ERROR! Error executing './npmw install', please execute it yourself. (Command failed with ENOENT: ./npmw install
spawn ./npmw ENOENT)
✔ Application successfully committed to Git from /Users/quentin/Documents/Tech/JHipster/appreactmicro2.
✔ Spring Boot application generated successfully.
  Run your Spring Boot application:
  ./gradlew
✔ React application generated successfully.
  Start your Webpack development server with:
  npm start


Congratulations, JHipster execution is complete!
If you find JHipster useful consider sponsoring the project https://www.jhipster.tech/sponsors/

Thanks for using JHipster!
  quentin  ~    JHipster  appreactmicro2 [ main ≢ ] ./gradlew --stacktrace

FAILURE: Build failed with an exception.

* Where:
Script '/Users/quentin/Documents/Tech/JHipster/appreactmicro2/gradle/profile_dev.gradle' line: 36

* What went wrong:
A problem occurred evaluating script.
> Could not get unknown property 'NpmTask' for root project 'appreactmicro-2' of type org.gradle.api.Project.

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating script.
        at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:93)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.lambda$apply$1(DefaultScriptPluginFactory.java:143)
        at org.gradle.configuration.DefaultScriptTarget.addConfiguration(DefaultScriptTarget.java:74)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:146)
        at org.gradle.configuration.BuildOperationScriptPlugin$1.run(BuildOperationScriptPlugin.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
        at org.gradle.configuration.BuildOperationScriptPlugin.lambda$apply$0(BuildOperationScriptPlugin.java:65)
        at org.gradle.internal.code.DefaultUserCodeApplicationContext.apply(DefaultUserCodeApplicationContext.java:44)
        at org.gradle.configuration.BuildOperationScriptPlugin.apply(BuildOperationScriptPlugin.java:65)
        at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.applyScript(DefaultObjectConfigurationAction.java:150)
        at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.access$000(DefaultObjectConfigurationAction.java:43)
        at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction$1.run(DefaultObjectConfigurationAction.java:76)
        at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.execute(DefaultObjectConfigurationAction.java:184)
        at org.gradle.api.internal.project.AbstractPluginAware.apply(AbstractPluginAware.java:49)
        at org.gradle.api.internal.project.ProjectScript.apply(ProjectScript.java:37)
        at org.gradle.api.Script$apply$0.callCurrent(Unknown Source)
        at build_du13d8npp0lbxykqkezqrbpie.run(/Users/quentin/Documents/Tech/JHipster/appreactmicro2/build.gradle:55)
        at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.lambda$apply$1(DefaultScriptPluginFactory.java:143)
        at org.gradle.configuration.ProjectScriptTarget.addConfiguration(ProjectScriptTarget.java:79)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:146)
        at org.gradle.configuration.BuildOperationScriptPlugin$1.run(BuildOperationScriptPlugin.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
        at org.gradle.configuration.BuildOperationScriptPlugin.lambda$apply$0(BuildOperationScriptPlugin.java:65)
        at org.gradle.internal.code.DefaultUserCodeApplicationContext.apply(DefaultUserCodeApplicationContext.java:44)
        at org.gradle.configuration.BuildOperationScriptPlugin.apply(BuildOperationScriptPlugin.java:65)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.lambda$applyToMutableState$1(DefaultProjectStateRegistry.java:411)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.fromMutableState(DefaultProjectStateRegistry.java:429)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.applyToMutableState(DefaultProjectStateRegistry.java:410)
        at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:46)
        at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:27)
        at org.gradle.configuration.project.ConfigureActionsProjectEvaluator.evaluate(ConfigureActionsProjectEvaluator.java:35)
        at org.gradle.configuration.project.LifecycleProjectEvaluator$EvaluateProject.lambda$run$0(LifecycleProjectEvaluator.java:109)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.lambda$applyToMutableState$1(DefaultProjectStateRegistry.java:411)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.lambda$fromMutableState$2(DefaultProjectStateRegistry.java:434)
        at org.gradle.internal.work.DefaultWorkerLeaseService.withReplacedLocks(DefaultWorkerLeaseService.java:359)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.fromMutableState(DefaultProjectStateRegistry.java:434)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.applyToMutableState(DefaultProjectStateRegistry.java:410)
        at org.gradle.configuration.project.LifecycleProjectEvaluator$EvaluateProject.run(LifecycleProjectEvaluator.java:100)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
        at org.gradle.configuration.project.LifecycleProjectEvaluator.evaluate(LifecycleProjectEvaluator.java:72)
        at org.gradle.api.internal.project.DefaultProject.evaluate(DefaultProject.java:787)
        at org.gradle.api.internal.project.DefaultProject.evaluate(DefaultProject.java:158)
        at org.gradle.api.internal.project.ProjectLifecycleController.lambda$ensureSelfConfigured$2(ProjectLifecycleController.java:85)
        at org.gradle.internal.model.StateTransitionController.lambda$doTransition$14(StateTransitionController.java:255)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:266)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:254)
        at org.gradle.internal.model.StateTransitionController.lambda$maybeTransitionIfNotCurrentlyTransitioning$10(StateTransitionController.java:199)
        at org.gradle.internal.work.DefaultSynchronizer.withLock(DefaultSynchronizer.java:34)
        at org.gradle.internal.model.StateTransitionController.maybeTransitionIfNotCurrentlyTransitioning(StateTransitionController.java:195)
        at org.gradle.api.internal.project.ProjectLifecycleController.ensureSelfConfigured(ProjectLifecycleController.java:85)
        at org.gradle.api.internal.project.DefaultProjectStateRegistry$ProjectStateImpl.ensureConfigured(DefaultProjectStateRegistry.java:385)
        at org.gradle.execution.TaskPathProjectEvaluator.configure(TaskPathProjectEvaluator.java:34)
        at org.gradle.execution.TaskPathProjectEvaluator.configureHierarchy(TaskPathProjectEvaluator.java:48)
        at org.gradle.configuration.DefaultProjectsPreparer.prepareProjects(DefaultProjectsPreparer.java:42)
        at org.gradle.configuration.BuildTreePreparingProjectsPreparer.prepareProjects(BuildTreePreparingProjectsPreparer.java:65)
        at org.gradle.configuration.BuildOperationFiringProjectsPreparer$ConfigureBuild.run(BuildOperationFiringProjectsPreparer.java:52)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
        at org.gradle.configuration.BuildOperationFiringProjectsPreparer.prepareProjects(BuildOperationFiringProjectsPreparer.java:40)
        at org.gradle.initialization.VintageBuildModelController.lambda$prepareProjects$2(VintageBuildModelController.java:84)
        at org.gradle.internal.model.StateTransitionController.lambda$doTransition$14(StateTransitionController.java:255)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:266)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:254)
        at org.gradle.internal.model.StateTransitionController.lambda$transitionIfNotPreviously$11(StateTransitionController.java:213)
        at org.gradle.internal.work.DefaultSynchronizer.withLock(DefaultSynchronizer.java:34)
        at org.gradle.internal.model.StateTransitionController.transitionIfNotPreviously(StateTransitionController.java:209)
        at org.gradle.initialization.VintageBuildModelController.prepareProjects(VintageBuildModelController.java:84)
        at org.gradle.initialization.VintageBuildModelController.prepareToScheduleTasks(VintageBuildModelController.java:71)
        at org.gradle.internal.build.DefaultBuildLifecycleController.lambda$prepareToScheduleTasks$6(DefaultBuildLifecycleController.java:175)
        at org.gradle.internal.model.StateTransitionController.lambda$doTransition$14(StateTransitionController.java:255)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:266)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:254)
        at org.gradle.internal.model.StateTransitionController.lambda$maybeTransition$9(StateTransitionController.java:190)
        at org.gradle.internal.work.DefaultSynchronizer.withLock(DefaultSynchronizer.java:34)
        at org.gradle.internal.model.StateTransitionController.maybeTransition(StateTransitionController.java:186)
        at org.gradle.internal.build.DefaultBuildLifecycleController.prepareToScheduleTasks(DefaultBuildLifecycleController.java:173)
        at org.gradle.internal.buildtree.DefaultBuildTreeWorkPreparer.scheduleRequestedTasks(DefaultBuildTreeWorkPreparer.java:36)
        at org.gradle.internal.cc.impl.VintageBuildTreeWorkController$scheduleAndRunRequestedTasks$1.apply(VintageBuildTreeWorkController.kt:36)
        at org.gradle.internal.cc.impl.VintageBuildTreeWorkController$scheduleAndRunRequestedTasks$1.apply(VintageBuildTreeWorkController.kt:35)
        at org.gradle.composite.internal.DefaultIncludedBuildTaskGraph.withNewWorkGraph(DefaultIncludedBuildTaskGraph.java:112)
        at org.gradle.internal.cc.impl.VintageBuildTreeWorkController.scheduleAndRunRequestedTasks(VintageBuildTreeWorkController.kt:35)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.lambda$scheduleAndRunTasks$1(DefaultBuildTreeLifecycleController.java:77)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.lambda$runBuild$4(DefaultBuildTreeLifecycleController.java:120)
        at org.gradle.internal.model.StateTransitionController.lambda$transition$6(StateTransitionController.java:169)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:266)
        at org.gradle.internal.model.StateTransitionController.lambda$transition$7(StateTransitionController.java:169)
        at org.gradle.internal.work.DefaultSynchronizer.withLock(DefaultSynchronizer.java:44)
        at org.gradle.internal.model.StateTransitionController.transition(StateTransitionController.java:169)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.runBuild(DefaultBuildTreeLifecycleController.java:117)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.scheduleAndRunTasks(DefaultBuildTreeLifecycleController.java:77)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.scheduleAndRunTasks(DefaultBuildTreeLifecycleController.java:72)
        at org.gradle.tooling.internal.provider.ExecuteBuildActionRunner.run(ExecuteBuildActionRunner.java:31)
        at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
        at org.gradle.internal.buildtree.ProblemReportingBuildActionRunner.run(ProblemReportingBuildActionRunner.java:49)
        at org.gradle.launcher.exec.BuildOutcomeReportingBuildActionRunner.run(BuildOutcomeReportingBuildActionRunner.java:65)
        at org.gradle.tooling.internal.provider.FileSystemWatchingBuildActionRunner.run(FileSystemWatchingBuildActionRunner.java:140)
        at org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner.run(BuildCompletionNotifyingBuildActionRunner.java:41)
        at org.gradle.launcher.exec.RootBuildLifecycleBuildActionExecutor.lambda$execute$0(RootBuildLifecycleBuildActionExecutor.java:54)
        at org.gradle.composite.internal.DefaultRootBuildState.run(DefaultRootBuildState.java:130)
        at org.gradle.launcher.exec.RootBuildLifecycleBuildActionExecutor.execute(RootBuildLifecycleBuildActionExecutor.java:54)
        at org.gradle.internal.buildtree.InitDeprecationLoggingActionExecutor.execute(InitDeprecationLoggingActionExecutor.java:62)
        at org.gradle.internal.buildtree.InitProblems.execute(InitProblems.java:36)
        at org.gradle.internal.buildtree.DefaultBuildTreeContext.execute(DefaultBuildTreeContext.java:40)
        at org.gradle.launcher.exec.BuildTreeLifecycleBuildActionExecutor.lambda$execute$0(BuildTreeLifecycleBuildActionExecutor.java:71)
        at org.gradle.internal.buildtree.BuildTreeState.run(BuildTreeState.java:60)
        at org.gradle.launcher.exec.BuildTreeLifecycleBuildActionExecutor.execute(BuildTreeLifecycleBuildActionExecutor.java:71)
        at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$3.call(RunAsBuildOperationBuildActionExecutor.java:61)
        at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$3.call(RunAsBuildOperationBuildActionExecutor.java:57)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor.execute(RunAsBuildOperationBuildActionExecutor.java:57)
        at org.gradle.launcher.exec.RunAsWorkerThreadBuildActionExecutor.lambda$execute$0(RunAsWorkerThreadBuildActionExecutor.java:36)
        at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:263)
        at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:127)
        at org.gradle.launcher.exec.RunAsWorkerThreadBuildActionExecutor.execute(RunAsWorkerThreadBuildActionExecutor.java:36)
        at org.gradle.tooling.internal.provider.continuous.ContinuousBuildActionExecutor.execute(ContinuousBuildActionExecutor.java:110)
        at org.gradle.tooling.internal.provider.SubscribableBuildActionExecutor.execute(SubscribableBuildActionExecutor.java:64)
        at org.gradle.internal.session.DefaultBuildSessionContext.execute(DefaultBuildSessionContext.java:46)
        at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor$ActionImpl.apply(BuildSessionLifecycleBuildActionExecutor.java:92)
        at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor$ActionImpl.apply(BuildSessionLifecycleBuildActionExecutor.java:80)
        at org.gradle.internal.session.BuildSessionState.run(BuildSessionState.java:71)
        at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor.execute(BuildSessionLifecycleBuildActionExecutor.java:62)
        at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor.execute(BuildSessionLifecycleBuildActionExecutor.java:41)
        at org.gradle.internal.buildprocess.execution.StartParamsValidatingActionExecutor.execute(StartParamsValidatingActionExecutor.java:64)
        at org.gradle.internal.buildprocess.execution.StartParamsValidatingActionExecutor.execute(StartParamsValidatingActionExecutor.java:32)
        at org.gradle.internal.buildprocess.execution.SessionFailureReportingActionExecutor.execute(SessionFailureReportingActionExecutor.java:51)
        at org.gradle.internal.buildprocess.execution.SessionFailureReportingActionExecutor.execute(SessionFailureReportingActionExecutor.java:39)
        at org.gradle.internal.buildprocess.execution.SetupLoggingActionExecutor.execute(SetupLoggingActionExecutor.java:47)
        at org.gradle.internal.buildprocess.execution.SetupLoggingActionExecutor.execute(SetupLoggingActionExecutor.java:31)
        at org.gradle.launcher.daemon.server.exec.ExecuteBuild.doBuild(ExecuteBuild.java:70)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.WatchForDisconnection.execute(WatchForDisconnection.java:39)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.ResetDeprecationLogger.execute(ResetDeprecationLogger.java:29)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.RequestStopIfSingleUsedDaemon.execute(RequestStopIfSingleUsedDaemon.java:35)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.ForwardClientInput.lambda$execute$0(ForwardClientInput.java:40)
        at org.gradle.internal.daemon.clientinput.ClientInputForwarder.forwardInput(ClientInputForwarder.java:80)
        at org.gradle.launcher.daemon.server.exec.ForwardClientInput.execute(ForwardClientInput.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.LogAndCheckHealth.execute(LogAndCheckHealth.java:64)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.LogToClient.doBuild(LogToClient.java:63)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment.doBuild(EstablishBuildEnvironment.java:84)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.StartBuildOrRespondWithBusy$1.run(StartBuildOrRespondWithBusy.java:52)
        at org.gradle.launcher.daemon.server.DaemonStateCoordinator.lambda$runCommand$0(DaemonStateCoordinator.java:321)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
Caused by: groovy.lang.MissingPropertyException: Could not get unknown property 'NpmTask' for root project 'appreactmicro-2' of type org.gradle.api.Project.
        at org.gradle.internal.metaobject.AbstractDynamicObject.getMissingProperty(AbstractDynamicObject.java:85)
        at org.gradle.groovy.scripts.BasicScript$ScriptDynamicObject.getMissingProperty(BasicScript.java:160)
        at org.gradle.internal.metaobject.AbstractDynamicObject.getProperty(AbstractDynamicObject.java:62)
        at org.gradle.api.internal.project.DefaultDynamicLookupRoutine.property(DefaultDynamicLookupRoutine.java:31)
        at org.gradle.groovy.scripts.BasicScript.getProperty(BasicScript.java:69)
        at profile_dev_ddvrwpw86z9x12tq37ubfvj3u.run(/Users/quentin/Documents/Tech/JHipster/appreactmicro2/gradle/profile_dev.gradle:36)
        at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
        ... 182 more


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 12s
7 actionable tasks: 7 executed
  quentin  ~    JHipster  appreactmicro2 [ main ≢ ] jhipster --force
WARNING! Since JHipster v8, the jhipster command will not use the locally installed generator-jhipster.
    If you want to execute the locally installed generator-jhipster, run: npx jhipster

        ██╗ ██╗   ██╗ ████████╗ ███████╗   ██████╗ ████████╗ ████████╗ ███████╗
        ██║ ██║   ██║ ╚══██╔══╝ ██╔═══██╗ ██╔════╝ ╚══██╔══╝ ██╔═════╝ ██╔═══██╗
        ██║ ████████║    ██║    ███████╔╝ ╚█████╗     ██║    ██████╗   ███████╔╝
  ██╗   ██║ ██╔═══██║    ██║    ██╔════╝   ╚═══██╗    ██║    ██╔═══╝   ██╔══██║
  ╚██████╔╝ ██║   ██║ ████████╗ ██║       ██████╔╝    ██║    ████████╗ ██║  ╚██╗
   ╚═════╝  ╚═╝   ╚═╝ ╚═══════╝ ╚═╝       ╚═════╝     ╚═╝    ╚═══════╝ ╚═╝   ╚═╝
                            https://www.jhipster.tech
Welcome to JHipster v8.7.0

 _______________________________________________________________________________________________________________

  Documentation for creating an application is at https://www.jhipster.tech/creating-an-app/

  Application files will be generated in folder: /Users/quentin/Documents/Tech/JHipster/appreactmicro2
 _______________________________________________________________________________________________________________

     info KeyStore '/Users/quentin/Documents/Tech/JHipster/appreactmicro2/src/main/resources/config/tls/keystore.p12' already exists. Leaving unchanged.
✔ applying multi-step templates
     info Using existing git repository.
WARNING! liquibaseVersion is required by gradle-liquibase-plugin, make sure to add it to your dependencies
    force .prettierrc
    force .prettierignore
✔ prettier configuration files committed to disk
✔ loading translations
✔ updating package.json dependencies versions
✔ prettifying sonar-project.properties
✔ adding package-info.java files
    force sonar-project.properties
    force .husky/pre-commit
    force src/main/resources/banner.txt
    force .devcontainer/Dockerfile
    force build.gradle
    force settings.gradle
    force gradle.properties
    force gradle/profile_dev.gradle
    force gradle/profile_prod.gradle
    force gradle/war.gradle
    force gradle/zipkin.gradle
    force src/main/resources/logback-spring.xml
    force src/main/resources/i18n/messages.properties
    force src/test/resources/logback.xml
    force src/test/resources/junit-platform.properties
    force gradlew
    force gradlew.bat
    force gradle/wrapper/gradle-wrapper.jar
    force gradle/wrapper/gradle-wrapper.properties
    force buildSrc/build.gradle
    force buildSrc/gradle/libs.versions.toml
    force gradle/libs.versions.toml
    force src/main/docker/jib/entrypoint.sh
    force checkstyle.xml
   create npmw
   create npmw.cmd
    force src/main/resources/.h2.server.properties
    force buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle
    force buildSrc/src/main/groovy/jhipster.docker-conventions.gradle
    force buildSrc/src/main/groovy/jhipster.code-quality-conventions.gradle
   create buildSrc/src/main/groovy/jhipster.node-gradle-conventions.gradle
    force gradle/liquibase.gradle
    force src/main/resources/config/liquibase/changelog/00000000000000_initial_schema.xml
    force src/main/resources/config/liquibase/master.xml
    force src/main/webapp/content/images/jhipster_family_member_0.svg
    force src/main/webapp/content/images/jhipster_family_member_0_head-192.png
    force src/main/webapp/content/images/jhipster_family_member_0_head-256.png
    force src/main/webapp/content/images/jhipster_family_member_0_head-384.png
    force src/main/webapp/content/images/jhipster_family_member_0_head-512.png
    force src/main/webapp/content/images/jhipster_family_member_1.svg
    force src/main/webapp/content/images/jhipster_family_member_1_head-192.png
    force src/main/webapp/content/images/jhipster_family_member_1_head-256.png
    force src/main/webapp/content/images/jhipster_family_member_1_head-384.png
    force src/main/webapp/content/images/jhipster_family_member_1_head-512.png
    force src/main/webapp/content/images/jhipster_family_member_2.svg
    force src/main/webapp/content/images/jhipster_family_member_2_head-192.png
    force src/main/webapp/content/images/jhipster_family_member_2_head-256.png
    force src/main/webapp/content/images/jhipster_family_member_2_head-384.png
    force src/main/webapp/content/images/jhipster_family_member_2_head-512.png
    force src/main/webapp/content/images/jhipster_family_member_3.svg
    force src/main/webapp/content/images/jhipster_family_member_3_head-256.png
    force src/main/webapp/content/images/jhipster_family_member_3_head-192.png
    force src/main/webapp/content/images/jhipster_family_member_3_head-512.png
    force src/main/webapp/content/images/jhipster_family_member_3_head-384.png
    force src/main/webapp/content/images/logo-jhipster.png
    force src/main/webapp/favicon.ico
    force src/main/webapp/swagger-ui/dist/images/throbber.gif
    force src/main/webapp/manifest.webapp
    force src/main/webapp/WEB-INF/web.xml
    force src/main/webapp/robots.txt
    force src/main/resources/i18n/messages_fr.properties
    force webpack/logo-jhipster.png
    force .gitignore
    force .gitattributes
    force .editorconfig
    force src/test/resources/META-INF/spring.factories
    force package.json
    force .yo-rc.json
    force .devcontainer/devcontainer.json
    force src/main/resources/templates/error.html
    force src/main/resources/config/application.yml
    force src/main/resources/config/application-dev.yml
    force src/main/resources/config/application-tls.yml
    force src/main/resources/config/application-prod.yml
    force src/main/resources/static/index.html
    force src/main/resources/config/bootstrap.yml
    force src/main/resources/config/bootstrap-prod.yml
    force src/test/resources/config/bootstrap.yml
    force src/test/resources/config/application.yml
    force src/main/docker/postgresql.yml
    force src/main/docker/consul.yml
    force src/main/docker/central-server-config/application.yml
    force src/main/docker/app.yml
    force src/main/docker/config/git2consul.json
    force src/main/docker/monitoring.yml
    force src/main/docker/grafana/provisioning/dashboards/dashboard.yml
    force src/main/docker/jhipster-control-center.yml
    force src/main/docker/central-server-config/README.md
    force src/main/docker/grafana/provisioning/dashboards/JVM.json
    force src/main/docker/sonar.yml
    force src/main/docker/prometheus/prometheus.yml
    force src/main/docker/grafana/provisioning/datasources/datasource.yml
    force src/main/docker/zipkin.yml
    force src/test/resources/config/application-testdev.yml
    force src/test/resources/config/application-testprod.yml
    force src/main/webapp/content/css/loading.css
    force src/main/webapp/404.html
    force src/main/webapp/index.html
    force src/main/webapp/swagger-ui/index.html
    force tsconfig.json
    force tsconfig.test.json
    force src/main/webapp/app/app.scss
    force src/main/webapp/app/_bootstrap-variables.scss
    force src/main/webapp/app/modules/home/home.scss
    force src/main/webapp/app/modules/administration/docs/docs.scss
    force src/main/webapp/app/shared/layout/header/header.scss
    force src/main/webapp/app/shared/layout/footer/footer.scss
    force src/main/webapp/app/shared/layout/password/password-strength-bar.scss
    force README.md
    force src/main/docker/services.yml
    force src/main/webapp/i18n/fr/error.json
    force src/main/webapp/i18n/fr/login.json
    force src/main/webapp/i18n/fr/password.json
    force src/main/webapp/i18n/fr/register.json
    force src/main/webapp/i18n/fr/sessions.json
    force src/main/webapp/i18n/fr/settings.json
    force src/main/webapp/i18n/fr/activate.json
    force src/test/java/com/mycompany/myapp/domain/AssertUtils.java
    force src/main/webapp/i18n/fr/global.json
    force src/main/webapp/i18n/fr/home.json
    force src/main/webapp/i18n/fr/reset.json
    force src/test/java/com/mycompany/myapp/security/SecurityUtilsUnitTest.java
    force src/test/java/com/mycompany/myapp/TechnicalStructureTest.java
    force src/test/java/com/mycompany/myapp/config/AsyncSyncConfiguration.java
    force src/test/java/com/mycompany/myapp/IntegrationTest.java
    force src/test/java/com/mycompany/myapp/config/SpringBootTestClassOrderer.java
    force src/test/java/com/mycompany/myapp/config/StaticResourcesWebConfigurerTest.java
    force src/test/java/com/mycompany/myapp/web/filter/SpaWebFilterIT.java
    force src/test/java/com/mycompany/myapp/web/rest/TestUtil.java
    force src/test/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslatorTestController.java
    force src/test/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslatorIT.java
    force src/test/java/com/mycompany/myapp/web/rest/WithUnauthenticatedMockUser.java
    force src/test/java/com/mycompany/myapp/management/SecurityMetersServiceTests.java
    force src/test/java/com/mycompany/myapp/security/jwt/AuthenticationIntegrationTest.java
    force src/test/java/com/mycompany/myapp/security/jwt/JwtAuthenticationTestUtils.java
    force src/test/java/com/mycompany/myapp/security/jwt/TokenAuthenticationSecurityMetersIT.java
    force src/test/java/com/mycompany/myapp/security/jwt/TokenAuthenticationIT.java
    force src/test/java/com/mycompany/myapp/security/jwt/TestAuthenticationResource.java
    force src/test/java/com/mycompany/myapp/config/CRLFLogConverterTest.java
    force src/test/java/com/mycompany/myapp/config/WebConfigurerTest.java
    force src/test/java/com/mycompany/myapp/config/WebConfigurerTestController.java
    force src/test/java/com/mycompany/myapp/config/timezone/HibernateTimeZoneIT.java
    force src/test/java/com/mycompany/myapp/repository/timezone/DateTimeWrapper.java
    force src/test/java/com/mycompany/myapp/repository/timezone/DateTimeWrapperRepository.java
    force src/test/java/com/mycompany/myapp/config/EmbeddedSQL.java
    force src/test/java/com/mycompany/myapp/config/SqlTestContainer.java
    force src/test/java/com/mycompany/myapp/config/SqlTestContainersSpringContextCustomizerFactory.java
    force src/test/java/com/mycompany/myapp/config/PostgreSqlTestContainer.java
    force src/main/java/com/mycompany/myapp/GeneratedByJHipster.java
    force src/main/java/com/mycompany/myapp/security/SpringSecurityAuditorAware.java
    force src/main/java/com/mycompany/myapp/security/SecurityUtils.java
    force src/main/java/com/mycompany/myapp/security/AuthoritiesConstants.java
    force src/main/java/com/mycompany/myapp/config/SecurityConfiguration.java
    force src/main/java/com/mycompany/myapp/config/SpringDocConfiguration.java
    force src/main/java/com/mycompany/myapp/Appreactmicro2App.java
    force src/main/java/com/mycompany/myapp/aop/logging/LoggingAspect.java
    force src/main/java/com/mycompany/myapp/config/AsyncConfiguration.java
    force src/main/java/com/mycompany/myapp/config/CRLFLogConverter.java
    force src/main/java/com/mycompany/myapp/config/DateTimeFormatConfiguration.java
    force .lintstagedrc.cjs
    force src/main/java/com/mycompany/myapp/config/LoggingConfiguration.java
    force src/main/java/com/mycompany/myapp/config/ApplicationProperties.java
    force src/main/java/com/mycompany/myapp/config/JacksonConfiguration.java
    force src/main/java/com/mycompany/myapp/config/LoggingAspectConfiguration.java
    force src/main/java/com/mycompany/myapp/config/WebConfigurer.java
    force src/main/java/com/mycompany/myapp/config/Constants.java
    force src/main/java/com/mycompany/myapp/domain/AbstractAuditingEntity.java
    force jest.conf.js
    force webpack/environment.js
    force src/main/java/com/mycompany/myapp/web/rest/errors/BadRequestAlertException.java
    force src/main/java/com/mycompany/myapp/web/rest/errors/ErrorConstants.java
    force src/main/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslator.java
    force src/main/java/com/mycompany/myapp/web/rest/errors/FieldErrorVM.java
    force src/main/java/com/mycompany/myapp/config/StaticResourcesWebConfiguration.java
    force src/main/java/com/mycompany/myapp/web/filter/SpaWebFilter.java
    force webpack/webpack.common.js
    force src/main/java/com/mycompany/myapp/config/SecurityJwtConfiguration.java
    force src/main/java/com/mycompany/myapp/management/SecurityMetersService.java
    force src/main/java/com/mycompany/myapp/ApplicationWebXml.java
    force src/main/java/com/mycompany/myapp/config/FeignConfiguration.java
    force src/main/java/com/mycompany/myapp/client/UserFeignClientInterceptor.java
    force src/main/java/com/mycompany/myapp/config/DatabaseConfiguration.java
    force webpack/webpack.dev.js
    force src/main/java/com/mycompany/myapp/config/CacheConfiguration.java
    force src/main/java/com/mycompany/myapp/config/LiquibaseConfiguration.java
    force webpack/webpack.prod.js
    force webpack/utils.js
    force postcss.config.js
    force src/main/webapp/app/app.tsx
    force src/main/webapp/app/index.tsx
    force src/main/webapp/app/routes.tsx
    force src/main/webapp/app/setup-tests.ts
    force src/main/webapp/app/typings.d.ts
    force src/main/webapp/app/config/constants.ts
    force src/main/webapp/app/config/dayjs.ts
    force src/main/webapp/app/config/axios-interceptor.ts
    force src/main/webapp/app/config/error-middleware.ts
    force src/main/webapp/app/config/logger-middleware.ts
    force src/main/webapp/app/config/notification-middleware.ts
    force src/main/webapp/app/config/store.ts
    force src/main/webapp/app/config/translation.ts
    force src/main/webapp/app/config/icon-loader.ts
    force src/main/webapp/app/entities/reducers.ts
    force src/main/webapp/app/entities/menu.tsx
    force src/main/webapp/app/entities/routes.tsx
    force src/main/webapp/app/modules/home/home.tsx
    force src/main/webapp/app/modules/login/logout.tsx
    force src/main/webapp/app/modules/login/login.tsx
    force src/main/webapp/app/modules/login/login-modal.tsx
    force src/main/webapp/app/shared/reducers/index.ts
    force src/main/webapp/app/shared/reducers/reducer.utils.ts
    force src/main/webapp/app/shared/reducers/application-profile.ts
    force src/main/webapp/app/shared/reducers/authentication.ts
    force src/main/webapp/app/shared/reducers/locale.ts
    force src/main/webapp/app/modules/administration/index.tsx
    force src/main/webapp/app/modules/administration/administration.reducer.ts
    force src/main/webapp/app/modules/administration/docs/docs.tsx
    force src/main/webapp/app/shared/layout/footer/footer.tsx
    force src/main/webapp/app/shared/layout/header/header.tsx
    force src/main/webapp/app/shared/layout/header/header-components.tsx
    force src/main/webapp/app/shared/layout/menus/index.ts
    force src/main/webapp/app/shared/layout/menus/admin.tsx
    force src/main/webapp/app/shared/layout/menus/account.tsx
    force src/main/webapp/app/shared/layout/menus/entities.tsx
    force src/main/webapp/app/shared/layout/menus/menu-components.tsx
    force src/main/webapp/app/shared/layout/menus/menu-item.tsx
    force src/main/webapp/app/shared/layout/password/password-strength-bar.tsx
    force src/main/webapp/app/shared/util/date-utils.ts
    force src/main/webapp/app/shared/util/pagination.constants.ts
    force src/main/webapp/app/shared/util/entity-utils.ts
    force src/main/webapp/app/shared/auth/private-route.tsx
    force src/main/webapp/app/shared/error/error-boundary.tsx
    force src/main/webapp/app/shared/error/error-boundary-routes.tsx
    force src/main/webapp/app/shared/error/page-not-found.tsx
    force src/main/webapp/app/shared/DurationFormat.tsx
    force src/main/webapp/app/shared/model/user.model.ts
    force src/main/webapp/app/shared/layout/menus/locale.tsx
    force src/main/webapp/app/main.tsx
    force src/main/webapp/app/shared/error/error-loading.tsx
    force src/main/webapp/app/config/axios-interceptor.spec.ts
    force src/main/webapp/app/config/notification-middleware.spec.ts
    force src/main/webapp/app/shared/reducers/application-profile.spec.ts
    force src/main/webapp/app/shared/reducers/authentication.spec.ts
    force src/main/webapp/app/shared/util/entity-utils.spec.ts
    force src/main/webapp/app/shared/auth/private-route.spec.tsx
    force src/main/webapp/app/shared/error/error-boundary.spec.tsx
    force src/main/webapp/app/shared/error/error-boundary-routes.spec.tsx
    force src/main/webapp/app/shared/layout/header/header.spec.tsx
    force src/main/webapp/app/shared/layout/menus/account.spec.tsx
    force src/main/webapp/app/modules/administration/administration.reducer.spec.ts
    force src/main/webapp/app/shared/reducers/locale.spec.ts
    force src/main/webapp/app/shared/jhipster/problem-details.ts
    force src/main/webapp/app/shared/jhipster/headers.ts
    force webpack/webpack.microfrontend.js
    force eslint.config.mjs
✔ files committed to disk

Changes to package.json were detected.
Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details

> Task :npmSetup

added 1 package in 2s

22 packages are looking for funding
  run `npm fund` for details

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 37s
12 actionable tasks: 5 executed, 7 up-to-date
Using node installed locally v20.17.0
Using npm installed locally 10.8.3
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@5.0.15: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.1.1: Glob versions prior to v9 are no longer supported
npm warn deprecated domexception@4.0.0: Use your platform's native DOMException instead
npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm warn deprecated istanbul@0.4.5: This module is no longer maintained, try this instead:
npm warn deprecated   npm i nyc
npm warn deprecated Visit https://istanbul.js.org/integrations for other alternatives.

> appreactmicro-2@0.0.1-SNAPSHOT prepare
> husky


added 1453 packages, and audited 2475 packages in 1m

391 packages are looking for funding
  run `npm fund` for details

10 vulnerabilities (5 moderate, 3 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
     info Found .yo-rc.json in Git from /Users/quentin/Documents/Tech/JHipster/appreactmicro2. So we assume this is application regeneration. Therefore automatic Git commit is not done. You can do Git commit manually.
✔ Spring Boot application generated successfully.
  Run your Spring Boot application:
  ./gradlew
✔ React application generated successfully.
  Start your Webpack development server with:
  npm start


Congratulations, JHipster execution is complete!
If you find JHipster useful consider sponsoring the project https://www.jhipster.tech/sponsors/

Thanks for using JHipster!
  quentin  ~    JHipster  appreactmicro2 [ main ≢
```

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
