### PR TITLE
update the liquibase gradle plugin to version 3.0.1

### DIFF
--- a/generators/server/resources/gradle/libs.versions.toml
+++ b/generators/server/resources/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ gradle-git-properties = { id = 'com.gorylenko.gradle-git-properties', version = 
 
 node-gradle = { id = 'com.github.node-gradle.node', version = '7.0.2' }
 
-gradle-liquibase = { id = 'org.liquibase.gradle', version = '3.0.0' }
+gradle-liquibase = { id = 'org.liquibase.gradle', version = '3.0.1' }
 
 gradle-sonarqube = { id = 'org.sonarqube', version = '5.1.0.4882' }
 


### PR DESCRIPTION
The 3.0.0 release had a classpath related bug that caused liquibase to fail in most cases.  This was fixed in version 3.0.1.  See https://github.com/liquibase/liquibase-gradle-plugin/issues/151 and https://github.com/liquibase/liquibase-gradle-plugin/issues/154

This is a one line change to update the Liquibase plugin to a version that works.  I don't think any documentation needs to be updated, and all the GitHub actions appear to be green.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary (not necessary)
- [x] The JDL part is updated if necessary (not necessary)
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary (I don't think it is necessary)
- [ ] Documentation is added/updated where necessary (I don't think it is necessary)
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
