### PR TITLE
don't convert blob types in jdl

### DIFF
--- a/generators/base-application/generator.ts
+++ b/generators/base-application/generator.ts
@@ -32,7 +32,6 @@ import {
 import type { TaskTypes as DefaultTaskTypes } from '../../lib/types/application/tasks.js';
 import type { ApplicationType } from '../../lib/types/application/application.js';
 import type { Entity } from '../../lib/types/application/entity.js';
-import type { Entity as BaseEntity } from '../../lib/types/base/entity.js';
 import type { GenericTaskGroup } from '../../lib/types/base/tasks.js';
 import type { ApplicationConfiguration } from '../../lib/types/application/yo-rc.js';
 import type SharedData from '../base/shared-data.js';
@@ -188,16 +187,16 @@ export default class BaseApplicationGenerator<
   /**
    * get sorted list of entities according to changelog date (i.e. the order in which they were added)
    */
-  getExistingEntities(): { name: string; definition: BaseEntity }[] {
+  getExistingEntities(): { name: string; definition: E }[] {
     function isBefore(e1, e2) {
       return (e1.definition.annotations?.changelogDate ?? 0) - (e2.definition.annotations?.changelogDate ?? 0);
     }
 
     const configDir = this.getEntitiesConfigPath();
 
-    const entities: { name: string; definition: BaseEntity }[] = [];
+    const entities: { name: string; definition: E }[] = [];
     for (const entityName of [...new Set(((this.jhipsterConfig.entities as string[]) || []).concat(getEntitiesFromDir(configDir)))]) {
-      const definition: BaseEntity = this.getEntityConfig(entityName)?.getAll() as BaseEntity;
+      const definition: E = this.getEntityConfig(entityName)?.getAll() as unknown as E;
       if (definition) {
         entities.push({ name: entityName, definition });
       }

--- a/generators/base-application/support/prepare-field.ts
+++ b/generators/base-application/support/prepare-field.ts
@@ -166,9 +166,9 @@ function generateFakeDataForField(this: CoreGenerator, field, faker, changelogDa
         data = data.substr(0, data.length - 3);
       }
     }
-  } else if (field.fieldType === BYTES && field.fieldTypeBlobContent !== TEXT) {
+  } else if (field.fieldTypeBinary && field.fieldTypeBlobContent !== TEXT) {
     data = '../fake-data/blob/hipster.png';
-  } else if (field.fieldType === BYTES && field.fieldTypeBlobContent === TEXT) {
+  } else if (field.fieldTypeBinary && field.fieldTypeBlobContent === TEXT) {
     data = '../fake-data/blob/hipster.txt';
   } else if (field.fieldType === STRING) {
     data = field.id ? faker.string.uuid() : faker.helpers.fake(fakeStringTemplateForFieldName(field.columnName));

--- a/generators/base-application/support/prepare-field.ts
+++ b/generators/base-application/support/prepare-field.ts
@@ -24,7 +24,7 @@ import { mutateData } from '../../../lib/utils/object.js';
 import type CoreGenerator from '../../base-core/generator.js';
 import type { Field } from '../../../lib/types/application/field.js';
 import type { Entity } from '../../../lib/types/application/entity.js';
-import { fieldTypeValues, isBlobType, isFieldEnum } from '../../../lib/application/field-types.js';
+import { fieldTypeValues, isFieldEnumType } from '../../../lib/application/field-types.js';
 import { prepareProperty } from './prepare-property.js';
 
 const { BlobTypes, CommonDBTypes, RelationalOnlyDBTypes } = fieldTypes;
@@ -283,17 +283,6 @@ function prepareCommonFieldForTemplates(entityWithConfig: Entity, field: Field, 
     tsType: ({ fieldType }) => getTypescriptType(fieldType),
   });
 
-  if (isBlobType(field.fieldType)) {
-    field.fieldType = 'byte[]';
-    if (field.fieldType === 'ImageBlob') {
-      field.fieldTypeBlobContent = 'image';
-    } else if (field.fieldType === 'TextBlob') {
-      field.fieldTypeBlobContent = 'text';
-    } else if (field.fieldType === 'AnyBlob') {
-      field.fieldTypeBlobContent = 'any';
-    }
-  }
-
   prepareProperty(field);
 
   defaults(field, {
@@ -301,11 +290,12 @@ function prepareCommonFieldForTemplates(entityWithConfig: Entity, field: Field, 
   });
   const fieldType = field.fieldType;
 
-  if (isFieldEnum(field)) {
+  const fieldIsEnum = isFieldEnumType(field);
+  field.fieldIsEnum = fieldIsEnum;
+  if (fieldIsEnum) {
     if (fieldTypeValues.includes(fieldType)) {
       throw new Error(`Field type '${fieldType}' is a reserved keyword and can't be used as an enum name.`);
     }
-    field.fieldIsEnum = true;
     field.enumFileName = kebabCase(field.fieldType);
     field.enumValues = getEnumValuesWithCustomValues(field.fieldValues!);
   }

--- a/generators/base-application/support/prepare-property.ts
+++ b/generators/base-application/support/prepare-property.ts
@@ -18,8 +18,10 @@
  */
 import { snakeCase, upperFirst } from 'lodash-es';
 import { mutateData } from '../../../lib/utils/object.js';
+import type { Field } from '../../../lib/types/application/field.js';
+import type { Relationship } from '../../../lib/types/application/relationship.js';
 
-export const prepareProperty = (property: any) => {
+export const prepareProperty = (property: Field | Relationship) => {
   mutateData(property, {
     __override__: false,
     propertyNameCapitalized: ({ propertyName }) => upperFirst(propertyName),

--- a/generators/bootstrap-application-base/generator.ts
+++ b/generators/bootstrap-application-base/generator.ts
@@ -43,7 +43,7 @@ import { lookupCommandsConfigs } from '../../lib/command/lookup-commands-configs
 import { loadCommandConfigsIntoApplication, loadCommandConfigsKeysIntoTemplatesContext } from '../../lib/command/load.js';
 import { getConfigWithDefaults } from '../../lib/jhipster/default-application-options.js';
 import { removeFieldsWithNullishValues } from '../base/support/index.js';
-import { getBlobContentType, isFieldBinaryType, isFieldBlobType } from '../../lib/application/field-types.js';
+import { convertFieldBlobType, getBlobContentType, isFieldBinaryType, isFieldBlobType } from '../../lib/application/field-types.js';
 import { createAuthorityEntity, createUserEntity, createUserManagementEntity } from './utils.js';
 import { exportJDLTransform, importJDLTransform } from './support/index.js';
 
@@ -226,19 +226,7 @@ export default class BootstrapApplicationBase extends BaseApplicationGenerator {
         entityStorage.defaults({ fields: [], relationships: [], annotations: {} });
 
         for (const field of entityConfig.fields!.filter(field => field.fieldType === 'byte[]')) {
-          // Convert fieldTypes to correct fieldTypes
-          if (field.fieldTypeBlobContent === 'image') {
-            field.fieldType = 'ImageBlob';
-            field.fieldTypeBlobContent = undefined;
-          } else if (field.fieldTypeBlobContent === 'any') {
-            field.fieldType = 'AnyBlob';
-            field.fieldTypeBlobContent = undefined;
-          } else if (field.fieldTypeBlobContent === 'text') {
-            field.fieldType = 'TextBlob';
-            field.fieldTypeBlobContent = undefined;
-          } else {
-            field.fieldType = 'Blob';
-          }
+          convertFieldBlobType(field);
           entityStorage.save();
         }
 

--- a/generators/bootstrap-application-base/generator.ts
+++ b/generators/bootstrap-application-base/generator.ts
@@ -43,6 +43,7 @@ import { lookupCommandsConfigs } from '../../lib/command/lookup-commands-configs
 import { loadCommandConfigsIntoApplication, loadCommandConfigsKeysIntoTemplatesContext } from '../../lib/command/load.js';
 import { getConfigWithDefaults } from '../../lib/jhipster/default-application-options.js';
 import { removeFieldsWithNullishValues } from '../base/support/index.js';
+import { getBlobContentType, isFieldBinaryType, isFieldBlobType } from '../../lib/application/field-types.js';
 import { createAuthorityEntity, createUserEntity, createUserManagementEntity } from './utils.js';
 import { exportJDLTransform, importJDLTransform } from './support/index.js';
 
@@ -360,6 +361,16 @@ export default class BootstrapApplicationBase extends BaseApplicationGenerator {
         this.validateResult(loadEntitiesOtherSide(entities, { application }));
 
         for (const entity of entities) {
+          for (const field of entity.fields) {
+            if (isFieldBinaryType(field)) {
+              field.fieldTypeBlobContent ??= getBlobContentType(field.fieldType);
+              if (application.databaseTypeCassandra || entity.databaseType === 'cassandra') {
+                field.fieldType = 'ByteBuffer';
+              } else if (isFieldBlobType(field)) {
+                field.fieldType = 'byte[]' as any;
+              }
+            }
+          }
           for (const relationship of entity.relationships) {
             if (relationship.ownerSide === undefined) {
               // ownerSide backward compatibility

--- a/generators/bootstrap-application-base/generator.ts
+++ b/generators/bootstrap-application-base/generator.ts
@@ -224,6 +224,23 @@ export default class BootstrapApplicationBase extends BaseApplicationGenerator {
       configureEntity({ entityStorage, entityConfig }) {
         entityStorage.defaults({ fields: [], relationships: [], annotations: {} });
 
+        for (const field of entityConfig.fields!.filter(field => field.fieldType === 'byte[]')) {
+          // Convert fieldTypes to correct fieldTypes
+          if (field.fieldTypeBlobContent === 'image') {
+            field.fieldType = 'ImageBlob';
+            field.fieldTypeBlobContent = undefined;
+          } else if (field.fieldTypeBlobContent === 'any') {
+            field.fieldType = 'AnyBlob';
+            field.fieldTypeBlobContent = undefined;
+          } else if (field.fieldTypeBlobContent === 'text') {
+            field.fieldType = 'TextBlob';
+            field.fieldTypeBlobContent = undefined;
+          } else {
+            field.fieldType = 'Blob';
+          }
+          entityStorage.save();
+        }
+
         if (entityConfig.changelogDate) {
           entityConfig.annotations.changelogDate = entityConfig.changelogDate;
           delete entityConfig.changelogDate;

--- a/generators/client/support/template-utils.spec.ts
+++ b/generators/client/support/template-utils.spec.ts
@@ -74,7 +74,7 @@ describe('generator - client - support - template-utils', () => {
   describe('generateTestEntityId', () => {
     describe('when called with int', () => {
       it('return 123', () => {
-        expect(generateTestEntityId('int')).to.equal(123);
+        expect(generateTestEntityId('Integer')).to.equal(123);
       });
     });
     describe('when called with String', () => {

--- a/generators/client/support/template-utils.ts
+++ b/generators/client/support/template-utils.ts
@@ -20,6 +20,7 @@ import path from 'path';
 
 import { clientFrameworkTypes, fieldTypes } from '../../../lib/jhipster/index.js';
 import type { PrimaryKey } from '../../../lib/types/application/entity.js';
+import type { FieldType } from '../../../lib/application/field-types.js';
 import { getEntryIfTypeOrTypeAttribute } from './types-utils.js';
 
 const { STRING: TYPE_STRING, UUID: TYPE_UUID } = fieldTypes.CommonDBTypes;
@@ -100,7 +101,7 @@ export const generateEntityClientEnumImports = (fields, clientFramework) => {
  * @param {boolean} [wrapped=true] - wrapped values for required types.
  */
 
-export const generateTestEntityId = (primaryKey: string | PrimaryKey, index: string | number = 0, wrapped = true) => {
+export const generateTestEntityId = (primaryKey: FieldType | PrimaryKey, index: string | number = 0, wrapped = true) => {
   primaryKey = getEntryIfTypeOrTypeAttribute(primaryKey);
   let value;
   if (primaryKey === TYPE_STRING) {
@@ -110,7 +111,7 @@ export const generateTestEntityId = (primaryKey: string | PrimaryKey, index: str
   } else {
     value = index === 0 ? 123 : 456;
   }
-  if (wrapped && [TYPE_UUID, TYPE_STRING].includes(primaryKey)) {
+  if (wrapped && [TYPE_UUID, TYPE_STRING].includes(primaryKey as any)) {
     return `'${value}'`;
   }
   return value;

--- a/generators/client/support/types-utils.ts
+++ b/generators/client/support/types-utils.ts
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { FieldType } from '../../../lib/application/field-types.js';
 import { fieldTypes } from '../../../lib/jhipster/index.js';
 import type { PrimaryKey } from '../../../lib/types/application/entity.js';
 import { fieldIsEnum } from '../../base-application/support/index.js';
@@ -37,7 +38,7 @@ const {
  * @param key
  * @returns {*}
  */
-export const getEntryIfTypeOrTypeAttribute = (key: string | PrimaryKey) => {
+export const getEntryIfTypeOrTypeAttribute = (key: FieldType | PrimaryKey): FieldType => {
   if (typeof key === 'object') {
     return key.type;
   }
@@ -50,7 +51,7 @@ export const getEntryIfTypeOrTypeAttribute = (key: string | PrimaryKey) => {
  * @param {string | object} primaryKey - primary key definition
  * @returns {string} primary key type in Typescript
  */
-const getTypescriptKeyType = primaryKey => {
+const getTypescriptKeyType = (primaryKey: FieldType | PrimaryKey) => {
   if ([TYPE_INTEGER, TYPE_LONG, TYPE_FLOAT, TYPE_DOUBLE, TYPE_BIG_DECIMAL].includes(getEntryIfTypeOrTypeAttribute(primaryKey))) {
     return 'number';
   }

--- a/generators/info/generator.ts
+++ b/generators/info/generator.ts
@@ -28,6 +28,7 @@ import type { JHipsterGeneratorFeatures, JHipsterGeneratorOptions } from '../bas
 import { YO_RC_FILE } from '../generator-constants.js';
 import { applicationsLookup } from '../workspaces/support/applications-lookup.js';
 import type { Entity } from '../../lib/types/base/entity.js';
+import { convertFieldBlobType } from '../../lib/application/field-types.js';
 import { replaceSensitiveConfig } from './support/utils.js';
 
 const isInfoCommand = commandName => commandName === 'info' || undefined;
@@ -142,8 +143,13 @@ export default class InfoGenerator extends BaseApplicationGenerator {
     let jdlObject;
     const entities = new Map<string, Entity>();
     try {
-      this.getExistingEntities().forEach(entity => {
-        entities.set(entity.name, entity.definition);
+      this.getExistingEntities().forEach(({ name, definition: entity }) => {
+        if (entity.fields) {
+          for (const field of entity.fields) {
+            convertFieldBlobType(field);
+          }
+        }
+        entities.set(name, entity);
       });
       jdlObject = JSONToJDLEntityConverter.convertEntitiesToJDL(entities);
       JSONToJDLOptionConverter.convertServerOptionsToJDL({ 'generator-jhipster': this.config.getAll() }, jdlObject);

--- a/generators/info/generator.ts
+++ b/generators/info/generator.ts
@@ -146,7 +146,9 @@ export default class InfoGenerator extends BaseApplicationGenerator {
       this.getExistingEntities().forEach(({ name, definition: entity }) => {
         if (entity.fields) {
           for (const field of entity.fields) {
-            convertFieldBlobType(field);
+            if (field.fieldType === 'byte[]') {
+              convertFieldBlobType(field);
+            }
           }
         }
         entities.set(name, entity);

--- a/generators/server/generator.ts
+++ b/generators/server/generator.ts
@@ -82,13 +82,13 @@ const { SUPPORTED_VALIDATION_RULES } = validations;
 const { isReservedTableName } = reservedKeywords;
 const { ANGULAR, REACT, VUE } = clientFrameworkTypes;
 const { GRADLE, MAVEN } = buildToolTypes;
-const { CASSANDRA, SQL, NO: NO_DATABASE } = databaseTypes;
+const { SQL, NO: NO_DATABASE } = databaseTypes;
 const { GATEWAY } = applicationTypes;
 
 const { NO: NO_SEARCH_ENGINE } = searchEngineTypes;
 const { CommonDBTypes, RelationalOnlyDBTypes } = fieldTypes;
 const { INSTANT } = CommonDBTypes;
-const { BYTES, BYTE_BUFFER } = RelationalOnlyDBTypes;
+const { BYTE_BUFFER } = RelationalOnlyDBTypes;
 const { PaginationTypes, ServiceTypes } = entityOptions;
 const {
   Validations: { MAX, MIN, MAXLENGTH, MINLENGTH, MAXBYTES, MINBYTES, PATTERN },
@@ -333,16 +333,12 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
       },
 
       configureFields({ application, entityConfig, entityName }) {
-        const databaseType = entityConfig.databaseType ?? application.databaseType;
         // Validate entity json field content
         const fields = entityConfig.fields;
         fields!.forEach(field => {
           // Migration from JodaTime to Java Time
           if (field.fieldType === 'DateTime' || field.fieldType === 'Date') {
             field.fieldType = INSTANT;
-          }
-          if (field.fieldType === BYTES && databaseType === CASSANDRA) {
-            field.fieldType = BYTE_BUFFER;
           }
 
           this._validateField(entityName, field);

--- a/generators/server/generator.ts
+++ b/generators/server/generator.ts
@@ -343,14 +343,6 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
 
           this._validateField(entityName, field);
 
-          if (field.fieldType === BYTE_BUFFER) {
-            this.log.warn(
-              `Cannot use validation in .jhipster/${entityName}.json for field ${stringifyApplicationData(field)}
-Hibernate JPA 2 Metamodel does not work with Bean Validation 2 for LOB fields, so LOB validation is disabled`,
-            );
-            field.fieldValidate = false;
-            field.fieldValidateRules = [];
-          }
           if (entityConfig.pagination && entityConfig.pagination !== NO_PAGINATION && isReservedPaginationWords(field.fieldName)) {
             throw new Error(
               `Field name '${field.fieldName}' found in ${entityConfig.name} is a reserved keyword, as it is used by Spring for pagination in the URL.`,
@@ -412,6 +404,22 @@ Hibernate JPA 2 Metamodel does not work with Bean Validation 2 for LOB fields, s
 
   get [BaseApplicationGenerator.PREPARING_EACH_ENTITY]() {
     return this.delegateTasksToBlueprint(() => this.preparingEachEntity);
+  }
+
+  get preparingEachEntityField() {
+    return this.asPreparingEachEntityFieldTaskGroup({
+      prepareField({ field }) {
+        if (field.fieldType === BYTE_BUFFER) {
+          this.log.warn(`Cannot use validation in .jhipster/${entityName}.json for field ${stringifyApplicationData(field)}`);
+          field.fieldValidate = false;
+          field.fieldValidateRules = [];
+        }
+      },
+    });
+  }
+
+  get [BaseApplicationGenerator.PREPARING_EACH_ENTITY_FIELD]() {
+    return this.delegateTasksToBlueprint(() => this.preparingEachEntityField);
   }
 
   get postPreparingEachEntity() {

--- a/generators/server/generator.ts
+++ b/generators/server/generator.ts
@@ -391,6 +391,26 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
     return this.delegateTasksToBlueprint(() => this.configuringEachEntity);
   }
 
+  get loadingEntities() {
+    return this.asLoadingEntitiesTaskGroup({
+      loadEntityConfig({ entitiesToLoad }) {
+        for (const { entityName, entityBootstrap } of entitiesToLoad) {
+          for (const fields of entityBootstrap.fields) {
+            if (field.fieldType === BYTE_BUFFER) {
+              this.log.warn(`Cannot use validation in .jhipster/${entityName}.json for field ${stringifyApplicationData(field)}`);
+              field.fieldValidate = false;
+              field.fieldValidateRules = [];
+            }
+          }
+        }
+      },
+    });
+  }
+
+  get [BaseApplicationGenerator.LOADING_ENTITIES]() {
+    return this.delegateTasksToBlueprint(() => this.loadingEntities);
+  }
+
   get preparingEachEntity() {
     return this.asPreparingEachEntityTaskGroup({
       prepareEntity({ entity }) {
@@ -404,22 +424,6 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
 
   get [BaseApplicationGenerator.PREPARING_EACH_ENTITY]() {
     return this.delegateTasksToBlueprint(() => this.preparingEachEntity);
-  }
-
-  get preparingEachEntityField() {
-    return this.asPreparingEachEntityFieldTaskGroup({
-      prepareField({ field }) {
-        if (field.fieldType === BYTE_BUFFER) {
-          this.log.warn(`Cannot use validation in .jhipster/${entityName}.json for field ${stringifyApplicationData(field)}`);
-          field.fieldValidate = false;
-          field.fieldValidateRules = [];
-        }
-      },
-    });
-  }
-
-  get [BaseApplicationGenerator.PREPARING_EACH_ENTITY_FIELD]() {
-    return this.delegateTasksToBlueprint(() => this.preparingEachEntityField);
   }
 
   get postPreparingEachEntity() {

--- a/generators/server/generator.ts
+++ b/generators/server/generator.ts
@@ -395,7 +395,7 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
     return this.asLoadingEntitiesTaskGroup({
       loadEntityConfig({ entitiesToLoad }) {
         for (const { entityName, entityBootstrap } of entitiesToLoad) {
-          for (const fields of entityBootstrap.fields) {
+          for (const field of entityBootstrap.fields) {
             if (field.fieldType === BYTE_BUFFER) {
               this.log.warn(`Cannot use validation in .jhipster/${entityName}.json for field ${stringifyApplicationData(field)}`);
               field.fieldValidate = false;

--- a/generators/server/support/build-specification-mapper.ts
+++ b/generators/server/support/build-specification-mapper.ts
@@ -1,3 +1,4 @@
+import type { FieldType } from '../../../lib/application/field-types.js';
 import { fieldTypes } from '../../../lib/jhipster/index.js';
 
 const {
@@ -17,7 +18,7 @@ const {
  * Return the method name which converts the filter to specification
  * @param {string} fieldType
  */
-export const getSpecificationBuildForType = (fieldType: string) => {
+export const getSpecificationBuildForType = (fieldType: FieldType) => {
   if (
     [
       TYPE_INTEGER,

--- a/generators/spring-boot/generator.ts
+++ b/generators/spring-boot/generator.ts
@@ -60,6 +60,7 @@ import {
   websocketTypes,
 } from '../../lib/jhipster/index.js';
 import { getPomVersionProperties, parseMavenPom } from '../maven/support/index.js';
+import type { FieldType } from '../../lib/application/field-types.js';
 import { writeFiles as writeEntityFiles } from './entity-files.js';
 import cleanupTask from './cleanup.js';
 import { serverFiles } from './files.js';
@@ -346,7 +347,7 @@ public void set${javaBeanCase(propertyName)}(${propertyType} ${propertyName}) {
   get preparingEachEntityField() {
     return this.asPreparingEachEntityFieldTaskGroup({
       prepareEntity({ field }) {
-        field.fieldJavaBuildSpecification = getSpecificationBuildForType(field.fieldType);
+        field.fieldJavaBuildSpecification = getSpecificationBuildForType(field.fieldType as FieldType);
 
         field.filterableField = ![TYPE_BYTES, TYPE_BYTE_BUFFER].includes(field.fieldType) && !field.transient;
         if (field.filterableField) {

--- a/lib/application/field-types.ts
+++ b/lib/application/field-types.ts
@@ -60,3 +60,22 @@ export const isFieldBinaryType = (field: Field): field is SetFieldType<Field, 'f
 export const isFieldEnumType = (field: Field): field is SetRequired<Field, 'enumFileName' | 'enumValues'> => Boolean(field.fieldValues);
 
 export const isFieldNotEnumType = (field: Field): field is SetFieldType<Field, 'fieldType', FieldType> => !field.fieldValues;
+
+export const convertFieldBlobType = (field: Field): Field => {
+  // Convert fieldTypes to correct fieldTypes
+  if (field.fieldTypeBlobContent === 'image') {
+    field.fieldType = 'ImageBlob';
+    field.fieldTypeBlobContent = undefined;
+  } else if (field.fieldTypeBlobContent === 'any') {
+    field.fieldType = 'AnyBlob';
+    field.fieldTypeBlobContent = undefined;
+  } else if (field.fieldTypeBlobContent === 'text') {
+    field.fieldType = 'TextBlob';
+    field.fieldTypeBlobContent = undefined;
+  } else {
+    // Unknown type is not supported.
+    // Fallback to ByteBuffer for cassandra databases.
+    field.fieldType = 'ByteBuffer';
+  }
+  return field;
+};

--- a/lib/application/field-types.ts
+++ b/lib/application/field-types.ts
@@ -1,3 +1,4 @@
+import type { SetFieldType, SetRequired } from 'type-fest';
 import type { Field } from '../types/application/field.js';
 
 const blobFieldTypes = {
@@ -34,20 +35,28 @@ export const fieldTypeValues: string[] = Object.values(fieldTypes);
 
 export type FieldType = (typeof fieldTypes)[keyof typeof fieldTypes];
 
-export const isBlobType = (fieldType: string): fieldType is (typeof blobFieldTypes)[keyof typeof blobFieldTypes] => {
-  return blobFieldTypesValues.includes(fieldType);
+type FieldBlobType = (typeof blobFieldTypes)[keyof typeof blobFieldTypes];
+
+type FieldBinaryType = (typeof blobFieldTypes)[keyof typeof blobFieldTypes] | 'byte[]';
+
+export const isBlobType = (fieldType: string): fieldType is FieldBlobType => blobFieldTypesValues.includes(fieldType);
+
+export const getBlobContentType = (fieldType: FieldBlobType) => {
+  if (fieldType === 'AnyBlob') {
+    return 'any';
+  } else if (fieldType === 'ImageBlob') {
+    return 'image';
+  } else if (fieldType === 'TextBlob') {
+    return 'text';
+  }
+  return undefined;
 };
 
-type EnumField =
-  | {
-      fieldType: string;
-      fieldIsEnum: true;
-      enumValues: { name: string; value: string }[];
-      enumFileName: string;
-    }
-  | {
-      fieldIsEnum: false;
-      fieldType: FieldType;
-    };
+export const isFieldBlobType = (field: Field): field is SetFieldType<Field, 'fieldType', FieldBlobType> => isBlobType(field.fieldType);
 
-export const isFieldEnum = (field: Field): field is Field & EnumField => Boolean(field.fieldValues);
+export const isFieldBinaryType = (field: Field): field is SetFieldType<Field, 'fieldType', FieldBinaryType> =>
+  isBlobType(field.fieldType) || field.fieldType === 'byte[]';
+
+export const isFieldEnumType = (field: Field): field is SetRequired<Field, 'enumFileName' | 'enumValues'> => Boolean(field.fieldValues);
+
+export const isFieldNotEnumType = (field: Field): field is SetFieldType<Field, 'fieldType', FieldType> => !field.fieldValues;

--- a/lib/application/field-types.ts
+++ b/lib/application/field-types.ts
@@ -1,0 +1,53 @@
+import type { Field } from '../types/application/field.js';
+
+const blobFieldTypes = {
+  BLOB: 'Blob',
+  ANY_BLOB: 'AnyBlob',
+  IMAGE_BLOB: 'ImageBlob',
+  TEXT_BLOB: 'TextBlob',
+} as const;
+
+const blobFieldTypesValues: string[] = Object.values(blobFieldTypes);
+
+const fieldTypes = {
+  STRING: 'String',
+  INTEGER: 'Integer',
+  LONG: 'Long',
+  BIG_DECIMAL: 'BigDecimal',
+  FLOAT: 'Float',
+  DOUBLE: 'Double',
+  UUID: 'UUID',
+  ENUM: 'Enum',
+  BOOLEAN: 'Boolean',
+  LOCAL_DATE: 'LocalDate',
+  ZONED_DATE_TIME: 'ZonedDateTime',
+  INSTANT: 'Instant',
+  DURATION: 'Duration',
+  BYTES: 'byte[]', // Supported by mongodb at CI samples
+  BYTE_BUFFER: 'ByteBuffer',
+  ...blobFieldTypes,
+} as const;
+
+export default fieldTypes;
+
+export const fieldTypeValues: string[] = Object.values(fieldTypes);
+
+export type FieldType = (typeof fieldTypes)[keyof typeof fieldTypes];
+
+export const isBlobType = (fieldType: string): fieldType is (typeof blobFieldTypes)[keyof typeof blobFieldTypes] => {
+  return blobFieldTypesValues.includes(fieldType);
+};
+
+type EnumField =
+  | {
+      fieldType: string;
+      fieldIsEnum: true;
+      enumValues: { name: string; value: string }[];
+      enumFileName: string;
+    }
+  | {
+      fieldIsEnum: false;
+      fieldType: FieldType;
+    };
+
+export const isFieldEnum = (field: Field): field is Field & EnumField => Boolean(field.fieldValues);

--- a/lib/command/__snapshots__/jdl.spec.ts.snap
+++ b/lib/command/__snapshots__/jdl.spec.ts.snap
@@ -22,7 +22,16 @@ exports[`getDefaultJDLApplicationConfig() should return the default JDL applicat
       "type": "boolean",
     },
   },
-  "optionsValues": {},
+  "optionsValues": {
+    "databaseMigration": {
+      "liquibase": "liquibase",
+    },
+    "messageBroker": {
+      "kafka": "kafka",
+      "no": "no",
+      "pulsar": "pulsar",
+    },
+  },
   "quotedOptionNames": [],
   "tokenConfigs": [
     {

--- a/lib/jdl/__snapshots__/jdl-importer.spec.ts.snap
+++ b/lib/jdl/__snapshots__/jdl-importer.spec.ts.snap
@@ -42,18 +42,15 @@ exports[`jdl - JDLImporter import when not parsing applications should return th
         },
         {
           "fieldName": "description",
-          "fieldType": "byte[]",
-          "fieldTypeBlobContent": "text",
+          "fieldType": "TextBlob",
         },
         {
           "fieldName": "advertisement",
-          "fieldType": "byte[]",
-          "fieldTypeBlobContent": "any",
+          "fieldType": "Blob",
         },
         {
           "fieldName": "logo",
-          "fieldType": "byte[]",
-          "fieldTypeBlobContent": "image",
+          "fieldType": "ImageBlob",
         },
       ],
       "fluentMethods": undefined,

--- a/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.spec.ts
+++ b/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.spec.ts
@@ -111,23 +111,19 @@ describe('jdl - JDLToJSONFieldConverter', () => {
 [
   {
     "fieldName": "anyBlobField",
-    "fieldType": "byte[]",
-    "fieldTypeBlobContent": "any",
+    "fieldType": "AnyBlob",
   },
   {
     "fieldName": "textBlobField",
-    "fieldType": "byte[]",
-    "fieldTypeBlobContent": "text",
+    "fieldType": "TextBlob",
   },
   {
     "fieldName": "blobField",
-    "fieldType": "byte[]",
-    "fieldTypeBlobContent": "any",
+    "fieldType": "Blob",
   },
   {
     "fieldName": "imageBlobField",
-    "fieldType": "byte[]",
-    "fieldTypeBlobContent": "image",
+    "fieldType": "ImageBlob",
   },
 ]
 `);
@@ -343,8 +339,7 @@ describe('jdl - JDLToJSONFieldConverter', () => {
   },
   {
     "fieldName": "blobField",
-    "fieldType": "byte[]",
-    "fieldTypeBlobContent": "any",
+    "fieldType": "AnyBlob",
     "fieldValidateRules": [
       "minbytes",
       "maxbytes",

--- a/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
+++ b/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
@@ -25,15 +25,11 @@ import type JDLObject from '../../core/models/jdl-object.js';
 import type { JSONField } from '../../core/types/json-config.js';
 import type { JDLEntity } from '../../core/models/index.js';
 import type JDLField from '../../core/models/jdl-field.js';
-import { fieldTypes } from '../../../jhipster/index.js';
+import type { FieldType } from '../../../application/field-types.js';
 
 const {
   Validations: { UNIQUE, REQUIRED },
 } = validations;
-const { isBlobType } = fieldTypes;
-const { ANY_BLOB, BLOB, IMAGE_BLOB, TEXT_BLOB } = fieldTypes.CommonDBTypes;
-const { ANY, IMAGE, TEXT } = fieldTypes.BlobTypes;
-const { BYTES } = fieldTypes.RelationalOnlyDBTypes;
 
 export default { convert };
 
@@ -59,7 +55,7 @@ function getConvertedFieldsForEntity(jdlEntity: JDLEntity, jdlObject: JDLObject)
   jdlEntity.forEachField((jdlField: JDLField) => {
     let fieldData: JSONField = {
       fieldName: camelCase(jdlField.name),
-      fieldType: jdlField.type,
+      fieldType: jdlField.type as FieldType,
     };
     const comment = formatComment(jdlField.comment);
     if (comment) {
@@ -75,13 +71,6 @@ function getConvertedFieldsForEntity(jdlEntity: JDLEntity, jdlObject: JDLObject)
       if (fieldValuesJavadocs && Object.keys(fieldValuesJavadocs).length > 0) {
         fieldData.fieldValuesJavadocs = fieldValuesJavadocs;
       }
-    }
-    if (fieldData.fieldType && isBlobType(fieldData.fieldType)) {
-      const blobFieldData = getBlobFieldData(fieldData.fieldType);
-      fieldData = {
-        ...fieldData,
-        ...blobFieldData,
-      };
     }
     if (jdlField.validationQuantity() !== 0) {
       const fieldValidations = getFieldValidations(jdlField);
@@ -100,27 +89,6 @@ function getConvertedFieldsForEntity(jdlEntity: JDLEntity, jdlObject: JDLObject)
     convertedEntityFields.push(fieldData);
   });
   return convertedEntityFields;
-}
-
-function getBlobFieldData(fieldType: string): { fieldType: 'bytes'; fieldTypeBlobContent: 'image' | 'any' | 'text' } {
-  const blobFieldData: any = {
-    fieldType: BYTES,
-  };
-  switch (fieldType) {
-    case IMAGE_BLOB:
-      blobFieldData.fieldTypeBlobContent = IMAGE;
-      break;
-    case BLOB:
-    case ANY_BLOB:
-      blobFieldData.fieldTypeBlobContent = ANY;
-      break;
-    case TEXT_BLOB:
-      blobFieldData.fieldTypeBlobContent = TEXT;
-      break;
-    default:
-      throw new Error(`Unrecognised Blob type: ${fieldType}.`);
-  }
-  return blobFieldData;
 }
 
 function getFieldValidations(jdlField: JDLField) {

--- a/lib/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.spec.ts
+++ b/lib/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.spec.ts
@@ -613,23 +613,19 @@ JSONEntity {
   "fields": [
     {
       "fieldName": "anyBlobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "any",
+      "fieldType": "AnyBlob",
     },
     {
       "fieldName": "textBlobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "text",
+      "fieldType": "TextBlob",
     },
     {
       "fieldName": "blobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "any",
+      "fieldType": "Blob",
     },
     {
       "fieldName": "imageBlobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "image",
+      "fieldType": "ImageBlob",
     },
   ],
   "fluentMethods": undefined,
@@ -881,8 +877,7 @@ JSONEntity {
     },
     {
       "fieldName": "blobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "any",
+      "fieldType": "AnyBlob",
       "fieldValidateRules": [
         "minbytes",
         "maxbytes",

--- a/lib/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.spec.ts
+++ b/lib/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.spec.ts
@@ -569,23 +569,19 @@ JSONEntity {
   "fields": [
     {
       "fieldName": "anyBlobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "any",
+      "fieldType": "AnyBlob",
     },
     {
       "fieldName": "textBlobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "text",
+      "fieldType": "TextBlob",
     },
     {
       "fieldName": "blobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "any",
+      "fieldType": "Blob",
     },
     {
       "fieldName": "imageBlobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "image",
+      "fieldType": "ImageBlob",
     },
   ],
   "fluentMethods": undefined,
@@ -822,8 +818,7 @@ JSONEntity {
     },
     {
       "fieldName": "blobField",
-      "fieldType": "byte[]",
-      "fieldTypeBlobContent": "any",
+      "fieldType": "AnyBlob",
       "fieldValidateRules": [
         "minbytes",
         "maxbytes",

--- a/lib/jdl/converters/json-to-jdl-entity-converter.spec.ts
+++ b/lib/jdl/converters/json-to-jdl-entity-converter.spec.ts
@@ -223,14 +223,6 @@ describe('jdl - JSONToJDLEntityConverter', () => {
           });
         });
       });
-
-      describe('when parsing an unrecognised blob-typed field', () => {
-        it('should fail', () => {
-          expect(() => convertEntitiesToJDL(new Map([['InvalidBlobType', readJsonEntity('InvalidBlobType')]]))).to.throw(
-            "Unrecognised blob type: 'unknown'",
-          );
-        });
-      });
     });
     describe('when parsing relationships including the User entity', () => {
       let entities;

--- a/lib/jdl/converters/json-to-jdl-entity-converter.ts
+++ b/lib/jdl/converters/json-to-jdl-entity-converter.ts
@@ -31,15 +31,10 @@ import { lowerFirst, upperFirst } from '../core/utils/string-utils.js';
 import { binaryOptions, relationshipOptions, unaryOptions } from '../core/built-in-options/index.js';
 import { asJdlRelationshipType } from '../core/basic-types/relationship-types.js';
 import type { JSONEntity, JSONField, JSONRelationship } from '../core/types/json-config.js';
-import { fieldTypes } from '../../jhipster/index.js';
 
-const { BlobTypes, CommonDBTypes, RelationalOnlyDBTypes } = fieldTypes;
 const { BUILT_IN_ENTITY } = relationshipOptions;
 const { FILTER, NO_FLUENT_METHOD, READ_ONLY, EMBEDDED } = unaryOptions;
 const { ANGULAR_SUFFIX, CLIENT_ROOT_FOLDER, DTO, MICROSERVICE, PAGINATION, SEARCH, SERVICE } = binaryOptions.Options;
-
-const { ANY, IMAGE, TEXT } = BlobTypes;
-const { BYTES } = RelationalOnlyDBTypes;
 
 export default {
   convertEntitiesToJDL,
@@ -104,18 +99,8 @@ function convertJSONToJDLField(field: JSONField): JDLField {
     type: field.fieldType,
     comment: field.documentation,
   });
-  if (jdlField.type === BYTES) {
-    jdlField.type = getTypeForBlob(field.fieldTypeBlobContent!);
-  }
   addValidations(jdlField, field);
   return jdlField;
-}
-
-function getTypeForBlob(blobContentType: any): string {
-  if ([ANY, IMAGE, TEXT].includes(blobContentType)) {
-    return CommonDBTypes[`${blobContentType.toUpperCase()}_BLOB`];
-  }
-  throw new Error(`Unrecognised blob type: '${blobContentType}'`);
 }
 
 function addValidations(jdlField: JDLField, field: JSONField): void {

--- a/lib/jhipster/field-types.spec.ts
+++ b/lib/jhipster/field-types.spec.ts
@@ -129,25 +129,4 @@ describe('jdl - FieldTypes', () => {
       });
     });
   });
-  describe('isBlobType', () => {
-    describe('when not passing anything', () => {
-      it('should return false', () => {
-        expect(fieldTypes.isBlobType()).to.be.false;
-      });
-    });
-    describe('when passing a type containing blob without it being one', () => {
-      it('should return false', () => {
-        expect(fieldTypes.isBlobType('NotABlob')).to.be.false;
-      });
-    });
-    Object.keys(fieldTypes.CommonDBTypes).forEach(dbTypeKey => {
-      const commonDBType = fieldTypes.CommonDBTypes[dbTypeKey];
-      describe(`when passing ${commonDBType}`, () => {
-        const typeHasBlobInItsName = commonDBType.toLowerCase().includes('blob');
-        it(`should return ${typeHasBlobInItsName}`, () => {
-          expect(fieldTypes.isBlobType(commonDBType)).to.equal(typeHasBlobInItsName);
-        });
-      });
-    });
-  });
 });

--- a/lib/jhipster/field-types.ts
+++ b/lib/jhipster/field-types.ts
@@ -86,7 +86,6 @@ export default {
   isCommonDBType,
   hasValidation,
   getIsType,
-  isBlobType,
   BlobTypes,
 };
 
@@ -96,15 +95,6 @@ export function isCommonDBType(type): boolean {
   }
 
   return snakeCase(type).toUpperCase() in CommonDBTypes || type instanceof JDLEnum;
-}
-
-export function isBlobType(type?: any): boolean {
-  if (!type) {
-    return false;
-  }
-  return (
-    CommonDBTypes.BLOB === type || CommonDBTypes.ANY_BLOB === type || CommonDBTypes.IMAGE_BLOB === type || CommonDBTypes.TEXT_BLOB === type
-  );
 }
 
 export function hasValidation(type: any, validation, isAnEnum?: boolean): boolean {

--- a/lib/types/application/entity.d.ts
+++ b/lib/types/application/entity.d.ts
@@ -22,6 +22,7 @@ import type { Entity as BaseEntity } from '../base/entity.js';
 import type { SpringEntity } from '../../../generators/server/types.js';
 import type { Field as BaseField } from '../base/field.js';
 import type { Relationship as BaseRelationship } from '../base/relationship.js';
+import type { FieldType } from '../../application/field-types.ts';
 import type { Field } from './field.js';
 import type { Relationship } from './relationship.js';
 
@@ -34,7 +35,7 @@ export type PrimaryKey<F extends BaseField = Field> = {
   name: string;
   fields: F[];
   derivedFields: F[];
-  type: string;
+  type: FieldType;
   composite: boolean;
   derived: boolean;
   javaValueGenerator?: string;
@@ -45,6 +46,7 @@ export interface Entity<F extends BaseField = Field, R extends BaseRelationship 
   extends Omit<Required<BaseEntity<F>>, 'relationships'>,
     SpringEntity,
     AngularEntity {
+  changelogDateForRecent: any;
   relationships: (IsNever<R> extends true ? Relationship<Omit<Entity, 'relationships'>> : R)[];
   otherRelationships: (IsNever<R> extends true ? Relationship<Omit<Entity, 'relationships'>> : R)[];
 
@@ -144,4 +146,6 @@ export interface Entity<F extends BaseField = Field, R extends BaseRelationship 
   dtoMapstruct: boolean;
 
   propertyJavaFilteredType?: string;
+
+  faker: any;
 }

--- a/lib/types/application/field.d.ts
+++ b/lib/types/application/field.d.ts
@@ -3,18 +3,32 @@ import type { Field as BaseField } from '../../../lib/types/base/field.js';
 export interface Field extends BaseField {
   propertyName: string;
 
-  enumFileName?: string;
   documentation?: string;
+
+  enumFileName?: string;
+  enumValues?: { name: string; value: string }[];
   fieldIsEnum?: boolean;
 
+  // Annotations
   skipClient?: boolean;
   skipServer?: boolean;
-
-  blobContentTypeText?: string;
 
   filterableField?: boolean;
   transient?: boolean;
   columnRequired?: boolean;
+  id?: boolean;
+
+  // Validation
+  fieldValidate?: boolean;
+  unique?: boolean;
+  fieldValidateRules?: string[];
+  fieldValidateRulesPattern?: string | RegExp;
+  fieldValidateRulesMaxlength?: number;
+  maxlength?: any;
+
+  // Faker
+  uniqueValue?: any[];
+  createRandexp: () => any;
 
   // Java specific
   propertyJavaBeanName?: string;
@@ -31,6 +45,12 @@ export interface Field extends BaseField {
 
   generateFakeData?: () => any;
 
+  // Blob
+  fieldWithContentType?: boolean;
+  contentTypeFieldName?: string;
+  blobContentTypeText?: string;
+
+  // Derived properties
   fieldTypeDuration?: boolean;
   fieldTypeBoolean: boolean;
   /** @deprecated */
@@ -39,4 +59,8 @@ export interface Field extends BaseField {
   fieldTypeCharSequence: boolean;
   /** @deprecated */
   fieldTypeNumeric: boolean;
+
+  /** @deprecated */
+  reference?: any;
+  relationshipsPath?: string[];
 }

--- a/lib/types/base/field.d.ts
+++ b/lib/types/base/field.d.ts
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { FieldType } from '../../application/field-types.ts';
 
 type FieldEnum = {
   fieldValues: string;
@@ -30,7 +31,7 @@ type FieldBlob = {
 export type Field = Partial<FieldEnum> &
   Partial<FieldBlob> & {
     fieldName: string;
-    fieldType: string;
+    fieldType: FieldType | string;
     documentation?: string;
     options?: Record<string, boolean | string | number>;
     fieldValidateRules?: string[];


### PR DESCRIPTION
JDL currently converts *Blob types to `byte[]` and contentType.
Move conversion to generators.

Improve field types.

I think we can close https://github.com/jhipster/generator-jhipster/issues/27136 and https://github.com/jhipster/generator-jhipster/issues/26114.
Close https://github.com/jhipster/generator-jhipster/issues/26114
Close https://github.com/jhipster/generator-jhipster/issues/27136
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
