### PR TITLE
use jhipster-framework release

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'url';
 
 export const BLUEPRINT_API_VERSION = 'jhipster-8';
 // jhipster-bom version
-export const JHIPSTER_DEPENDENCIES_VERSION = '8.7.1-SNAPSHOT';
+export const JHIPSTER_DEPENDENCIES_VERSION = '8.7.0';
 // Version of Java
 export const JAVA_VERSION = '17';
 // Supported Java versions, https://www.oracle.com/java/technologies/java-se-support-roadmap.html

--- a/test-integration/integration-test-constants.js
+++ b/test-integration/integration-test-constants.js
@@ -3,7 +3,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { JHIPSTER_DEPENDENCIES_VERSION } from '../generators/generator-constants.js';
 
-const FORCE_BUILD_JHIPSTER_BOM = false;
+const FORCE_BUILD_JHIPSTER_BOM = true;
 export const JHIPSTER_BOM_BRANCH = 'main';
 export const JHIPSTER_BOM_CICD_VERSION = '0.0.0-CICD';
 export const BUILD_JHIPSTER_BOM = FORCE_BUILD_JHIPSTER_BOM || JHIPSTER_DEPENDENCIES_VERSION.includes('-SNAPSHOT');


### PR DESCRIPTION
Use jhipster-framework release so a generated application using main will work out-of-the-box.

CI still uses jhipster-bom main.

Related to https://github.com/jhipster/generator-jhipster/issues/26628.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
