### PR TITLE
don't reorder plugins inside pom profile

### DIFF
--- a/generators/maven/internal/pom-sort.ts
+++ b/generators/maven/internal/pom-sort.ts
@@ -126,7 +126,8 @@ const sortArtifacts = (artifacts: MavenDependency[]) =>
 
 const sortProfiles = (profiles: MavenProfile[]) => profiles.sort((a, b) => a.id?.localeCompare(b.id) ?? 1);
 
-const sortProjectLike = (projectLike: any): any => {
+const sortProjectLike = (projectLike: any, options: { sortPlugins?: boolean } = {}): any => {
+  const { sortPlugins = true } = options;
   projectLike = sortKeys(projectLike, { compare: comparator(rootAndProfileOrder) });
   if (projectLike.properties) {
     projectLike.properties = sortProperties(projectLike.properties);
@@ -140,7 +141,7 @@ const sortProjectLike = (projectLike: any): any => {
   if (projectLike.build) {
     projectLike.build = sortSection(projectLike.build);
 
-    if (Array.isArray(projectLike.build.plugins?.plugin)) {
+    if (sortPlugins && Array.isArray(projectLike.build.plugins?.plugin)) {
       projectLike.build.plugins.plugin = sortArtifacts(projectLike.build.plugins.plugin);
     }
     if (Array.isArray(projectLike.build.pluginManagement?.plugins?.plugin)) {
@@ -153,9 +154,9 @@ const sortProjectLike = (projectLike: any): any => {
 export const sortPomProject = (project: any): any => {
   project = sortProjectLike(project);
   if (Array.isArray(project.profiles?.profile)) {
-    project.profiles.profile = sortProfiles(project.profiles.profile.map(profile => sortProjectLike(profile)));
+    project.profiles.profile = sortProfiles(project.profiles.profile.map(profile => sortProjectLike(profile, { sortPlugins: false })));
   } else if (project.profiles?.profile) {
-    project.profiles.profile = sortProjectLike(project.profiles.profile);
+    project.profiles.profile = sortProjectLike(project.profiles.profile, { sortPlugins: false });
   }
   return project;
 };

--- a/generators/maven/support/pom-file-sort.spec.ts
+++ b/generators/maven/support/pom-file-sort.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2013-2024 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect } from 'esmocha';
+import { sortPomFile } from './pom-file-sort.js';
+
+describe('sortPomProject', () => {
+  it('should sort a pom file', () => {
+    const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+
+    <properties>
+        <test.version>1.0</test.version>
+    </properties>
+</project>
+`;
+    const sorted = sortPomFile(pomContent);
+    expect(sorted).toBe(pomContent);
+  });
+
+  it('should sort build.plugins', () => {
+    const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>b</groupId>
+                <artifactId>b</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>a</groupId>
+                <artifactId>a</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+`;
+    const sorted = sortPomFile(pomContent);
+    expect(sorted).toBe(`<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>a</groupId>
+                <artifactId>a</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>b</groupId>
+                <artifactId>b</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+`);
+  });
+
+  it('should not sort profiles build.plugins', () => {
+    const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>b</groupId>
+                        <artifactId>b</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>a</groupId>
+                        <artifactId>a</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>
+`;
+    const sorted = sortPomFile(pomContent);
+    expect(sorted).toBe(pomContent);
+  });
+});


### PR DESCRIPTION
It breaks checksum check.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
