### PR TITLE
Fix: Address User-Controlled Data Risk in isAuthenticated()

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/AuthenticateController.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/AuthenticateController.java.ejs
@@ -121,7 +121,7 @@ public class AuthenticateController {
     /**
      * {@code GET /authenticate} : check if the user is authenticated.
      *
-     * @return the {@link ResponseEntity} with status {@code 204 (No Content)},
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and body "authenticated" if authenticated,
      * or with status {@code 401 (Unauthorized)} if not authenticated.
      */
     @GetMapping("/authenticate")

--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/AuthenticateController.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/AuthenticateController.java.ejs
@@ -125,9 +125,12 @@ public class AuthenticateController {
      * or with status {@code 401 (Unauthorized)} if not authenticated.
      */
     @GetMapping("/authenticate")
-    public ResponseEntity<Void> isAuthenticated(Principal principal) {
+    public ResponseEntity<String> isAuthenticated(Principal principal) {
         LOG.debug("REST request to check if the current user is authenticated");
-        return ResponseEntity.status(principal == null ? HttpStatus.UNAUTHORIZED : HttpStatus.NO_CONTENT).build();
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        return ResponseEntity.ok("authenticated");
     }
 
     public String createToken(Authentication authentication, boolean rememberMe) {

--- a/generators/spring-boot/templates/src/test/java/_package_/security/jwt/TestAuthenticationResource.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/security/jwt/TestAuthenticationResource.java.ejs
@@ -16,7 +16,7 @@ public class TestAuthenticationResource {
      * {@code GET  /authenticate} : check if the authentication token correctly validates
      */
     @GetMapping("/authenticate")
-    public ResponseEntity<Void> isAuthenticated() {
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    public ResponseEntity<String> isAuthenticated() {
+        return ResponseEntity.ok("authenticated");
     }
 }

--- a/generators/spring-boot/templates/src/test/java/_package_/security/jwt/TokenAuthenticationIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/security/jwt/TokenAuthenticationIT.java.ejs
@@ -57,7 +57,9 @@ class TokenAuthenticationIT {
 <%_ if (reactive) { %>
 
     private void expectOk(String token) {
-        webTestClient.get().uri("/api/authenticate").headers(headers -> headers.setBearerAuth(token)).exchange().expectStatus().isNoContent();
+        webTestClient.get().uri("/api/authenticate").headers(headers -> headers.setBearerAuth(token)).exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("authenticated");
     }
 
     private void expectUnauthorized(String token) {
@@ -72,7 +74,9 @@ class TokenAuthenticationIT {
 <%_ } else { _%>
 
     private void expectOk(String token) throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get("/api/authenticate").header(AUTHORIZATION, BEARER + token)).andExpect(status().isNoContent());
+        mvc.perform(MockMvcRequestBuilders.get("/api/authenticate").header(AUTHORIZATION, BEARER + token))
+            .andExpect(status().isOk())
+            .andExpect(content().string("authenticated"));
     }
 
     private void expectUnauthorized(String token) throws Exception {

--- a/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
@@ -186,17 +186,17 @@ class AccountResourceIT {
 
     @Test
     @WithMockUser(TEST_USER_LOGIN)
+    void testAuthenticatedUser() <% if (!reactive) { %>throws Exception <% } %>{
 <%_ if (reactive) { _%>
-    void testAuthenticatedUser() {
         accountWebTestClient
             .get().uri("/api/authenticate")
             .exchange()
-            .expectStatus().isNoContent();
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("authenticated");
 <%_ } else { _%>
-    void testAuthenticatedUser() throws Exception {
-        restAccountMockMvc
-            .perform(get("/api/authenticate").with(request -> request))
-            .andExpect(status().isNoContent());
+        restAccountMockMvc.perform(get("/api/authenticate").with(request -> request))
+            .andExpect(status().isOk())
+            .andExpect(content().string("authenticated"));
 <%_ } _%>
     }
 

--- a/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT_skipUserManagement.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT_skipUserManagement.java.ejs
@@ -131,10 +131,12 @@ class AccountResourceIT {
         accountWebTestClient
             .get().uri("/api/authenticate")
             .exchange()
-            .expectStatus().isNoContent();
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("authenticated");
 <%_ } else { _%>
         restAccountMockMvc.perform(get("/api/authenticate").with(request -> request))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isOk())
+            .andExpect(content().string("authenticated"));
 <%_ } _%>
     }
 }


### PR DESCRIPTION
<!--
PR description.
-->
Related to https://github.com/jhipster/generator-jhipster/issues/27051

For enhancing application security and improving API clarity, this PR modifies the isAuthenticated() endpoint to return a clear "authenticated" message with a 200 OK status when the user is authenticated, instead of returning a 204 No Content status. This change provides a more explicit response to clients while maintaining security by not exposing any user-specific information in the response.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

If the PR is not ready for review, please consider converting it to a Draft. You can also add the `skip-ci` label to prevent CI build on branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->