### PR TITLE
cypress: add logout test

### DIFF
--- a/generators/cypress/__snapshots__/generator.spec.ts.snap
+++ b/generators/cypress/__snapshots__/generator.spec.ts.snap
@@ -17,6 +17,9 @@ exports[`generator - cypress jwt-cypressAudit(false)-angular-withAdminUi(false)-
   "clientRoot/src/test/javascript/cypress/e2e/account/login-page.cy.ts": {
     "stateCleared": "modified",
   },
+  "clientRoot/src/test/javascript/cypress/e2e/account/logout.cy.ts": {
+    "stateCleared": "modified",
+  },
   "clientRoot/src/test/javascript/cypress/e2e/account/password-page.cy.ts": {
     "stateCleared": "modified",
   },
@@ -88,6 +91,9 @@ exports[`generator - cypress jwt-cypressAudit(true)-vue-withAdminUi(true)-cypres
   "clientRoot/src/test/javascript/cypress/e2e/account/login-page.cy.ts": {
     "stateCleared": "modified",
   },
+  "clientRoot/src/test/javascript/cypress/e2e/account/logout.cy.ts": {
+    "stateCleared": "modified",
+  },
   "clientRoot/src/test/javascript/cypress/e2e/account/password-page.cy.ts": {
     "stateCleared": "modified",
   },
@@ -156,6 +162,9 @@ exports[`generator - cypress oauth2-cypressAudit(false)-angular-withAdminUi(fals
   "package.json": {
     "stateCleared": "modified",
   },
+  "src/test/javascript/cypress/e2e/account/logout.cy.ts": {
+    "stateCleared": "modified",
+  },
   "src/test/javascript/cypress/e2e/administration/administration.cy.ts": {
     "stateCleared": "modified",
   },
@@ -207,6 +216,9 @@ exports[`generator - cypress oauth2-cypressAudit(true)-vue-withAdminUi(true)-cyp
     "stateCleared": "modified",
   },
   "package.json": {
+    "stateCleared": "modified",
+  },
+  "src/test/javascript/cypress/e2e/account/logout.cy.ts": {
     "stateCleared": "modified",
   },
   "src/test/javascript/cypress/e2e/administration/administration.cy.ts": {
@@ -339,6 +351,9 @@ exports[`generator - cypress session-cypressAudit(false)-angular-withAdminUi(fal
   "src/test/javascript/cypress/e2e/account/login-page.cy.ts": {
     "stateCleared": "modified",
   },
+  "src/test/javascript/cypress/e2e/account/logout.cy.ts": {
+    "stateCleared": "modified",
+  },
   "src/test/javascript/cypress/e2e/account/password-page.cy.ts": {
     "stateCleared": "modified",
   },
@@ -408,6 +423,9 @@ exports[`generator - cypress session-cypressAudit(true)-vue-withAdminUi(true)-cy
     "stateCleared": "modified",
   },
   "src/test/javascript/cypress/e2e/account/login-page.cy.ts": {
+    "stateCleared": "modified",
+  },
+  "src/test/javascript/cypress/e2e/account/logout.cy.ts": {
     "stateCleared": "modified",
   },
   "src/test/javascript/cypress/e2e/account/password-page.cy.ts": {

--- a/generators/cypress/files.ts
+++ b/generators/cypress/files.ts
@@ -53,6 +53,12 @@ export const cypressFiles: WriteFileSection = {
       ],
     },
     {
+      condition: generator => !generator.applicationTypeMicroservice,
+      path: CYPRESS_TEMPLATE_SOURCE_DIR,
+      renameTo: (ctx, file) => `${ctx.cypressDir}${file}`,
+      templates: ['e2e/account/logout.cy.ts'],
+    },
+    {
       condition: generator => !generator.authenticationTypeOauth2,
       path: CYPRESS_TEMPLATE_SOURCE_DIR,
       renameTo: (ctx, file) => `${ctx.cypressDir}${file}`,

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/login-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/login-page.cy.ts.ejs
@@ -24,7 +24,7 @@ import {
   submitLoginSelector,
 } from '../../support/commands';
 
-describe('login modal', () => {
+describe('login page', () => {
   const username = Cypress.env('E2E_USERNAME') ?? '<%= skipUserManagement && (applicationTypeMonolith || applicationTypeGateway) ? 'admin' : 'user' %>';
   const password = Cypress.env('E2E_PASSWORD') ?? '<%= skipUserManagement && (applicationTypeMonolith || applicationTypeGateway) ? 'admin' : 'user' %>';
 
@@ -78,7 +78,7 @@ describe('login modal', () => {
     cy.get(errorLoginSelector).should('be.visible');
   });
 
-  it('go to login page when successfully logs in', () => {
+  it('go to home page when successfully logs in', () => {
     cy.get(usernameLoginSelector).type(username);
     cy.get(passwordLoginSelector).type(password);
     cy.get(submitLoginSelector).click();

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/logout.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/logout.cy.ts.ejs
@@ -1,0 +1,39 @@
+<%#
+ Copyright 2013-2024 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import {
+  accountMenuSelector,
+  navbarSelector,
+  loginItemSelector,
+} from '../../support/commands';
+
+describe('logout', () => {
+  const username = Cypress.env('E2E_USERNAME') ?? 'user';
+  const password = Cypress.env('E2E_PASSWORD') ?? 'user';
+
+  it<%- clientFrameworkReact ? '.skip' : '' %>('go to home page when successfully logs out', () => {
+    cy.login(username, password);
+    cy.visit('');
+    cy.clickOnLogoutItem();
+    // Wait logout
+    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.visit('');
+    cy.get(navbarSelector).get(accountMenuSelector).click();
+    cy.get(navbarSelector).get(accountMenuSelector).get(loginItemSelector).should('be.visible');
+  });
+});


### PR DESCRIPTION
There isn't a logout test. React logout is not stable in oauth2 and dev.

Related to https://github.com/jhipster/generator-jhipster/issues/25875
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
