### PR TITLE
docker: add sleep in mysql healthcheck

### DIFF
--- a/generators/docker-compose/__snapshots__/docker-compose.spec.ts.snap
+++ b/generators/docker-compose/__snapshots__/docker-compose.spec.ts.snap
@@ -126,12 +126,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   mscouchbase:
@@ -317,12 +315,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   mscassandra:
@@ -572,12 +568,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -612,12 +606,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   mspsql:
@@ -956,12 +948,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -1001,12 +991,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   mspsql:
@@ -1384,12 +1372,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -1424,12 +1410,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   mspsql:
@@ -1719,12 +1703,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -1759,12 +1741,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   mspsql:
@@ -2045,12 +2025,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -2085,12 +2063,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   consul:
@@ -2237,12 +2213,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -2277,12 +2251,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   consul:
@@ -2454,12 +2426,10 @@ management:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -2494,12 +2464,10 @@ management:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   consul:
@@ -2735,12 +2703,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   msmysql:
@@ -2775,12 +2741,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   consul:
@@ -2894,12 +2858,10 @@ Launch all your infrastructure by running: \`docker compose up -d\`.
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   samplemysql-elasticsearch:
     image: elasticsearch-placeholder
@@ -3026,12 +2988,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   consul:
@@ -3160,12 +3120,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   consul:
@@ -3292,12 +3250,10 @@ jhipster:
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
       test:
-        - CMD
-        - mysql
-        - -e
-        - SHOW DATABASES;
+        - CMD-SHELL
+        - mysql -e "SHOW DATABASES;" && sleep 5
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10
   
   consul:

--- a/generators/docker/templates/docker/mysql.yml.ejs
+++ b/generators/docker/templates/docker/mysql.yml.ejs
@@ -35,7 +35,7 @@ services:
       - 127.0.0.1:3306:3306
     command: mysqld --lower_case_table_names=1 --skip-mysqlx --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     healthcheck:
-      test: ["CMD", "mysql", "-e", "SHOW DATABASES;"]
+      test: ['CMD-SHELL', 'mysql -e "SHOW DATABASES;" && sleep 5']
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 10


### PR DESCRIPTION
MySql is not ready to receive connections yet.

Related to https://github.com/jhipster/generator-jhipster/issues/27433
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
