### PR TITLE
Improve CSRF Token Handling for SPA

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
@@ -45,9 +45,6 @@ import org.springframework.security.web.SecurityFilterChain;
 <%_ if (!skipClient || authenticationUsesCsrf) { _%>
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 <%_ } _%>
-<%_ if (authenticationUsesCsrf) { _%>
-import tech.jhipster.web.filter.CookieCsrfFilter;
-<%_ } _%>
 <%_ if (!skipClient) { _%>
 import <%= packageName %>.web.filter.SpaWebFilter;
 <%_ } _%>
@@ -182,11 +179,6 @@ public class SecurityConfiguration {
 <%_ } _%>
 <%_ if (!skipClient) { _%>
             .addFilterAfter(new SpaWebFilter(), BasicAuthenticationFilter.class)
-<%_ } _%>
-<%_ if (!applicationTypeMicroservice) { _%>
-  <%_ if (authenticationUsesCsrf) { _%>
-            .addFilterAfter(new CookieCsrfFilter(), BasicAuthenticationFilter.class)
-  <%_ } _%>
 <%_ } _%>
 <%_ if (!skipClient) { _%>
             .headers(headers -> headers
@@ -384,15 +376,15 @@ public class SecurityConfiguration {
 <%_ if (authenticationUsesCsrf && !applicationTypeMicroservice) { _%>
 
     /**
-     * Custom CSRF handler to provide BREACH protection.
+     * Custom CSRF handler to provide BREACH protection for Single-Page Applications (SPA).
      *
      * @see <a href="https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa">Spring Security Documentation - Integrating with CSRF Protection</a>
      * @see <a href="https://github.com/jhipster/generator-jhipster/pull/25907">JHipster - use customized SpaCsrfTokenRequestHandler to handle CSRF token</a>
      * @see <a href="https://stackoverflow.com/q/74447118/65681">CSRF protection not working with Spring Security 6</a>
      */
-    static final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
-
-        private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
+    static final class SpaCsrfTokenRequestHandler implements CsrfTokenRequestHandler {
+        private final CsrfTokenRequestHandler plain = new CsrfTokenRequestAttributeHandler();
+        private final CsrfTokenRequestHandler xor = new XorCsrfTokenRequestAttributeHandler();
 
         @Override
         public void handle(HttpServletRequest request, HttpServletResponse response, Supplier<CsrfToken> csrfToken) {
@@ -400,7 +392,10 @@ public class SecurityConfiguration {
              * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection of
              * the CsrfToken when it is rendered in the response body.
              */
-            this.delegate.handle(request, response, csrfToken);
+            this.xor.handle(request, response, csrfToken);
+
+            // Render the token value to a cookie by causing the deferred token to be loaded.
+            csrfToken.get();
         }
 
         @Override
@@ -412,7 +407,7 @@ public class SecurityConfiguration {
              * raw CsrfToken.
              */
             if (StringUtils.hasText(request.getHeader(csrfToken.getHeaderName()))) {
-                return super.resolveCsrfTokenValue(request, csrfToken);
+                return this.plain.resolveCsrfTokenValue(request, csrfToken);
             }
             /*
              * In all other cases (e.g. if the request contains a request parameter), use
@@ -420,7 +415,7 @@ public class SecurityConfiguration {
              * when a server-side rendered form includes the _csrf request parameter as a
              * hidden input.
              */
-            return this.delegate.resolveCsrfTokenValue(request, csrfToken);
+            return this.xor.resolveCsrfTokenValue(request, csrfToken);
         }
     }
 <%_ } _%>


### PR DESCRIPTION
## Description

From Spring Security 6 onwards, the CSRF Token is stored in `HttpSession` by default, and CSRF Token is lazy-loaded to improve performance.

However, for SPA applications, we store the CSRF Token in a cookie. Since SPA applications must include the CSRF Token in the request header when calling protected APIs, lazy-loading the CSRF Token on the server side causes the client to fail to retrieve the CSRF Token from the cookie on the first call to a protected API, resulting in a `403 Forbidden` error (due to CSRF Token validation failure).

JHipster uses `CookieCsrfFilter` to ensure the CSRF Token is written to the cookie, but I believe the current implementation has the following issue:

- The implementation and name of the `CookieCsrfFilter` are confusing because the filter extracts the CSRF Token from the request attribute and writes it to the response header. However, the primary purpose of this filter should be to write the CSRF Token to the cookie immediately, and writing the CSRF Token to the response header is unnecessary (since the server already uses `CookieCsrfTokenRepository` to write the CSRF Token to the cookie).

Based on the above reason, I modified the `SpaCsrfTokenRequestHandler` to render the token value to a cookie by causing the deferred token to be loaded via `csrfToken.get()` and removed the use of `CookieCsrfFilter`.

I believe this change simplifies the CSRF Token handling process.