### PR TITLE
Update GitLab CI Docker push job

### DIFF
--- a/generators/ci-cd/__snapshots__/ci-cd.spec.ts.snap
+++ b/generators/ci-cd/__snapshots__/ci-cd.spec.ts.snap
@@ -1576,16 +1576,15 @@ gradle-package:
             - build/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - gradle-package
 #    script:
-#        - ./gradlew jib -Pprod -PnodeInstall -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username="gitlab-ci-token"  -Djib.to.auth.password=$CI_BUILD_TOKEN
+#        - ./gradlew jib -Pprod -PnodeInstall -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD
 
 ",
     "stateCleared": "modified",
@@ -1708,16 +1707,15 @@ maven-package:
             - target/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - maven-package
 #    script:
-#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
+#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD -Dmaven.repo.local=$MAVEN_USER_HOME
 
 deploy-to-production:
     stage: deploy
@@ -1841,16 +1839,15 @@ maven-package:
             - target/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - maven-package
 #    script:
-#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
+#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD -Dmaven.repo.local=$MAVEN_USER_HOME
 
 ",
     "stateCleared": "modified",
@@ -1965,16 +1962,15 @@ maven-package:
             - target/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - maven-package
 #    script:
-#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
+#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD -Dmaven.repo.local=$MAVEN_USER_HOME
 
 deploy-to-production:
     stage: deploy
@@ -2106,16 +2102,15 @@ maven-package:
             - target/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - maven-package
 #    script:
-#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
+#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD -Dmaven.repo.local=$MAVEN_USER_HOME
 
 ",
     "stateCleared": "modified",
@@ -2209,16 +2204,15 @@ maven-package:
             - target/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - maven-package
 #    script:
-#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
+#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD -Dmaven.repo.local=$MAVEN_USER_HOME
 
 cache:
     paths:

--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -155,16 +155,15 @@ gradle-package:
             - build/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - gradle-package
 #    script:
-#        - ./gradlew jib -Pprod -PnodeInstall -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username="gitlab-ci-token"  -Djib.to.auth.password=$CI_BUILD_TOKEN
+#        - ./gradlew jib -Pprod -PnodeInstall -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD
 
     <%_ if (ciCdIntegrationsHeroku) { _%>
 deploy-to-production:
@@ -284,16 +283,15 @@ maven-package:
             - target/classes
         expire_in: 1 day
 
-# Uncomment the following line to use gitlabs container registry. You need to adapt the REGISTRY_URL in case you are not using gitlab.com
+# Uncomment the following section to enable pushing the Docker image to the GitLab Container Registry
 #docker-push:
 #    stage: release
 #    variables:
-#        REGISTRY_URL: registry.gitlab.com
 #        IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHA
 #    dependencies:
 #        - maven-package
 #    script:
-#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
+#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=$CI_REGISTRY_USER -Djib.to.auth.password=$CI_REGISTRY_PASSWORD -Dmaven.repo.local=$MAVEN_USER_HOME
 
     <%_ if (ciCdIntegrationsHeroku) { _%>
 deploy-to-production:


### PR DESCRIPTION
## Description

This pull request includes the following changes:

1. Remove the unnecessary `REGISTRY_URL` variable, as the predefined `CI_REGISTRY` can be used instead.
2. Update the Docker push configuration to use the predefined `CI_REGISTRY_USER` and `CI_REGISTRY_PASSWORD` variables instead of `"gitlab-ci-token"` and `CI_BUILD_TOKEN`.
3. Update comments to reflect changes and improve clarity.