### PR TITLE
generate-blueprint: ignore package-lock files inside generators folder

### DIFF
--- a/generators/generate-blueprint/files.ts
+++ b/generators/generate-blueprint/files.ts
@@ -25,6 +25,7 @@ export const files = asWriteFilesSection<any>({
       condition: ctx => !ctx[LOCAL_BLUEPRINT_OPTION],
       templates: [
         '.github/workflows/generator.yml',
+        '.gitignore.jhi.blueprint',
         '.prettierignore.jhi.blueprint',
         { sourceFile: 'eslint.config.js.jhi.blueprint', destinationFile: ctx => `${ctx.eslintConfigFile}.jhi.blueprint` },
         'README.md',

--- a/generators/generate-blueprint/templates/.gitignore.jhi.blueprint.ejs
+++ b/generators/generate-blueprint/templates/.gitignore.jhi.blueprint.ejs
@@ -1,0 +1,22 @@
+<%#
+ Copyright 2013-2024 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<&_ if (!fragment.section) { -&>
+# added by generate-blueprint:
+generators/**/package-lock.json
+<&_ } -&>


### PR DESCRIPTION
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
