### PR TITLE
generate-blueprint: don't generate gitDependency by default

### DIFF
--- a/generators/generate-blueprint/command.ts
+++ b/generators/generate-blueprint/command.ts
@@ -42,10 +42,9 @@ const command = {
     },
     gitDependency: {
       cli: {
-        description: 'Use git dependency',
+        description: 'Use git dependency (eg: github:jhipster/generator-jhipster#main)',
         type: String,
       },
-      default: 'github:jhipster/generator-jhipster#main',
       scope: 'generator',
     },
     cliName: {


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/28291
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
