### PR TITLE
Introducing JHipster Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Logo][jhipster-image]][jhipster-url]
 
-[![NPM version][npm-image]][npm-url] [![Downloads][npmcharts-image]][npmcharts-url] [![Gitter][gitter-badge-image]][gitter-badge-url] [![Known Vulnerabilities][snyk-image]][snyk-url] [![Package Health][health-image]][health-url]
+[![NPM version][npm-image]][npm-url] [![Downloads][npmcharts-image]][npmcharts-url] [![Gitter][gitter-badge-image]][gitter-badge-url] [![Known Vulnerabilities][snyk-image]][snyk-url] [![Package Health][health-image]][health-url] [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20JHipster%20Guru-006BFF)](https://gurubase.io/g/jhipster)
 
 [![Generator Build Status][github-actions-generator-image]][github-actions-url] [![Angular Build Status][github-actions-angular-image]][github-actions-url] [![React Build Status][github-actions-react-image]][github-actions-url] [![Vue Build Status][github-actions-vue-image]][github-actions-url] [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.jhipster.tech/scans)
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [JHipster Guru](https://gurubase.io/g/jhipster) has been manually added to Gurubase. JHipster Guru uses the data from this repo and data from the [docs](https://www.jhipster.tech) to answer questions by leveraging the LLM.

This PR introduces the "JHipster Guru", showcasing that JHipster now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "JHipster Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the JHipster documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable JHipster Guru in Gurubase, just let us know that's totally fine.
