### PR TITLE
Enhance LogoutResource to dynamically resolve OAuth2 client registration

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/LogoutResource_imperative.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/LogoutResource_imperative.java.ejs
@@ -18,44 +18,56 @@
 -%>
 package <%= packageName %>.web.rest;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.annotation.CurrentSecurityContext;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpHeaders;
-import java.util.Map;
 
 /**
  * REST controller for managing global OIDC logout.
  */
 @RestController
 public class LogoutResource {
-    private final ClientRegistration registration;
+    private final ClientRegistrationRepository registrationRepository;
 
-    public LogoutResource(ClientRegistrationRepository registrations) {
-        this.registration = registrations.findByRegistrationId("oidc");
+    public LogoutResource(ClientRegistrationRepository registrationRepository) {
+        this.registrationRepository = registrationRepository;
     }
 
     /**
      * {@code POST  /api/logout} : logout the current user.
      *
      * @param request the {@link HttpServletRequest}.
+     * @param oAuth2AuthenticationToken the OAuth2 authentication token.
      * @param oidcUser the OIDC user.
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and a body with a global logout URL.
      */
     @PostMapping("/api/logout")
-    public ResponseEntity<?> logout(HttpServletRequest request, @AuthenticationPrincipal OidcUser oidcUser) {
+    public ResponseEntity<Map<String, String>> logout(
+        HttpServletRequest request,
+        @CurrentSecurityContext(expression = "authentication") OAuth2AuthenticationToken oAuth2AuthenticationToken,
+        @AuthenticationPrincipal OidcUser oidcUser
+    ) {
         StringBuilder logoutUrl = new StringBuilder();
-
-        logoutUrl.append(this.registration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString());
-
         String originUrl = request.getHeader(HttpHeaders.ORIGIN);
 
-        logoutUrl.append("?id_token_hint=").append(oidcUser.getIdToken().getTokenValue()).append("&post_logout_redirect_uri=").append(originUrl);
+        ClientRegistration clientRegistration = registrationRepository.findByRegistrationId(
+            oAuth2AuthenticationToken.getAuthorizedClientRegistrationId()
+        );
+        logoutUrl
+            .append(clientRegistration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString())
+            .append("?id_token_hint=")
+            .append(oidcUser.getIdToken().getTokenValue())
+            .append("&post_logout_redirect_uri=")
+            .append(originUrl);
 
         request.getSession().invalidate();
         return ResponseEntity.ok().body(Map.of("logoutUrl", logoutUrl.toString()));

--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/LogoutResource_reactive.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/LogoutResource_reactive.java.ejs
@@ -18,7 +18,11 @@
 -%>
 package <%= packageName %>.web.rest;
 
+import java.util.Map;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.annotation.CurrentSecurityContext;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
@@ -26,24 +30,23 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.WebSession;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.core.publisher.Mono;
-import java.util.Map;
 
 /**
  * REST controller for managing global OIDC logout.
  */
 @RestController
 public class LogoutResource {
-    private final Mono<ClientRegistration> registration;
+    private final ReactiveClientRegistrationRepository registrationRepository;
 
-    public LogoutResource(ReactiveClientRegistrationRepository registrations) {
-        this.registration = registrations.findByRegistrationId("oidc");
+    public LogoutResource(ReactiveClientRegistrationRepository registrationRepository) {
+        this.registrationRepository = registrationRepository;
     }
 
     /**
      * {@code POST  /api/logout} : logout the current user.
      *
+     * @param oAuth2AuthenticationToken the OAuth2 authentication token.
      * @param oidcUser the OIDC user.
      * @param request a {@link ServerHttpRequest} request.
      * @param session the current {@link WebSession}.
@@ -51,11 +54,18 @@ public class LogoutResource {
      */
     @PostMapping("/api/logout")
     public Mono<Map<String, String>> logout(
+        @CurrentSecurityContext(expression = "authentication") OAuth2AuthenticationToken oAuth2AuthenticationToken,
         @AuthenticationPrincipal OidcUser oidcUser,
         ServerHttpRequest request,
         WebSession session
     ) {
-        return session.invalidate().then(this.registration.map(oidc -> prepareLogoutUri(request, oidc, oidcUser.getIdToken())));
+        return session
+            .invalidate()
+            .then(
+                registrationRepository
+                    .findByRegistrationId(oAuth2AuthenticationToken.getAuthorizedClientRegistrationId())
+                    .map(oidc -> prepareLogoutUri(request, oidc, (oidcUser.getIdToken())))
+            );
     }
 
     private Map<String, String> prepareLogoutUri(ServerHttpRequest request, ClientRegistration clientRegistration, OidcIdToken idToken) {


### PR DESCRIPTION
## Description

This update enhances the `LogoutResource` to dynamically resolve the OAuth2 client registration based on the currently authenticated user's `OAuth2AuthenticationToken`.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
