### PR TITLE
[React] Fix bump browser-sync from 2.29.3 to 3.0.3

### DIFF
--- a/generators/react/__snapshots__/generator.spec.ts.snap
+++ b/generators/react/__snapshots__/generator.spec.ts.snap
@@ -419,7 +419,17 @@ exports[`generator - react gateway-jwt-skipUserManagement(true)-withAdminUi(fals
 }
 `;
 
-exports[`generator - react gateway-jwt-skipUserManagement(true)-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-clientRoot/-websocket(true) should match source calls snapshot 1`] = `{}`;
+exports[`generator - react gateway-jwt-skipUserManagement(true)-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-clientRoot/-websocket(true) should match source calls snapshot 1`] = `
+{
+  "mergeClientPackageJson": [
+    {
+      "overrides": {
+        "browser-sync": "BROWSER_SYNC_VERSION",
+      },
+    },
+  ],
+}
+`;
 
 exports[`generator - react gateway-oauth2-withAdminUi(true)-skipJhipsterDependencies(true)-enableTranslation(true)-clientRoot/-websocket(true) should match generated files snapshot 1`] = `
 {
@@ -873,7 +883,17 @@ exports[`generator - react gateway-oauth2-withAdminUi(true)-skipJhipsterDependen
 }
 `;
 
-exports[`generator - react gateway-oauth2-withAdminUi(true)-skipJhipsterDependencies(true)-enableTranslation(true)-clientRoot/-websocket(true) should match source calls snapshot 1`] = `{}`;
+exports[`generator - react gateway-oauth2-withAdminUi(true)-skipJhipsterDependencies(true)-enableTranslation(true)-clientRoot/-websocket(true) should match source calls snapshot 1`] = `
+{
+  "mergeClientPackageJson": [
+    {
+      "overrides": {
+        "browser-sync": "BROWSER_SYNC_VERSION",
+      },
+    },
+  ],
+}
+`;
 
 exports[`generator - react microservice-jwt-skipUserManagement(false)-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-clientRoot/-websocket(false) should match generated files snapshot 1`] = `
 {
@@ -1308,6 +1328,11 @@ exports[`generator - react microservice-jwt-skipUserManagement(false)-withAdminU
     },
   ],
   "mergeClientPackageJson": [
+    {
+      "overrides": {
+        "browser-sync": "BROWSER_SYNC_VERSION",
+      },
+    },
     {
       "devDependencies": {
         "@module-federation/enhanced": null,
@@ -1765,6 +1790,11 @@ exports[`generator - react microservice-oauth2-withAdminUi(true)-skipJhipsterDep
     },
   ],
   "mergeClientPackageJson": [
+    {
+      "overrides": {
+        "browser-sync": "BROWSER_SYNC_VERSION",
+      },
+    },
     {
       "devDependencies": {
         "@module-federation/enhanced": null,
@@ -2283,7 +2313,17 @@ exports[`generator - react monolith-jwt-skipUserManagement(false)-withAdminUi(tr
 }
 `;
 
-exports[`generator - react monolith-jwt-skipUserManagement(false)-withAdminUi(true)-skipJhipsterDependencies(true)-enableTranslation(true)--websocket(true) should match source calls snapshot 1`] = `{}`;
+exports[`generator - react monolith-jwt-skipUserManagement(false)-withAdminUi(true)-skipJhipsterDependencies(true)-enableTranslation(true)--websocket(true) should match source calls snapshot 1`] = `
+{
+  "mergeClientPackageJson": [
+    {
+      "overrides": {
+        "browser-sync": "BROWSER_SYNC_VERSION",
+      },
+    },
+  ],
+}
+`;
 
 exports[`generator - react monolith-oauth2-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-websocket(false) should match generated files snapshot 1`] = `
 {
@@ -2704,7 +2744,17 @@ exports[`generator - react monolith-oauth2-withAdminUi(false)-skipJhipsterDepend
 }
 `;
 
-exports[`generator - react monolith-oauth2-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-websocket(false) should match source calls snapshot 1`] = `{}`;
+exports[`generator - react monolith-oauth2-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-websocket(false) should match source calls snapshot 1`] = `
+{
+  "mergeClientPackageJson": [
+    {
+      "overrides": {
+        "browser-sync": "BROWSER_SYNC_VERSION",
+      },
+    },
+  ],
+}
+`;
 
 exports[`generator - react monolith-session-skipUserManagement(true)-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-websocket(true) should match generated files snapshot 1`] = `
 {
@@ -3119,7 +3169,17 @@ exports[`generator - react monolith-session-skipUserManagement(true)-withAdminUi
 }
 `;
 
-exports[`generator - react monolith-session-skipUserManagement(true)-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-websocket(true) should match source calls snapshot 1`] = `{}`;
+exports[`generator - react monolith-session-skipUserManagement(true)-withAdminUi(false)-skipJhipsterDependencies(false)-enableTranslation(false)-websocket(true) should match source calls snapshot 1`] = `
+{
+  "mergeClientPackageJson": [
+    {
+      "overrides": {
+        "browser-sync": "BROWSER_SYNC_VERSION",
+      },
+    },
+  ],
+}
+`;
 
 exports[`generator - react samples matrix should match snapshot 1`] = `
 {

--- a/generators/react/generator.ts
+++ b/generators/react/generator.ts
@@ -118,6 +118,14 @@ export default class ReactGenerator extends BaseApplicationGenerator {
             }),
           );
         };
+        if (application.clientRootDir) {
+          // Overrides only works if added in root package.json
+          this.packageJson.merge({
+            overrides: {
+              'browser-sync': application.nodeDependencies['browser-sync'],
+            },
+          });
+        }
       },
     });
   }
@@ -202,6 +210,14 @@ export default class ReactGenerator extends BaseApplicationGenerator {
 
   get postWriting() {
     return this.asPostWritingTaskGroup({
+      clientBundler({ application, source }) {
+        const { nodeDependencies } = application;
+        source.mergeClientPackageJson!({
+          overrides: {
+            'browser-sync': nodeDependencies['browser-sync'],
+          },
+        });
+      },
       addMicrofrontendDependencies({ application, source }) {
         if (!application.microfrontend) return;
         const { applicationTypeGateway } = application;

--- a/generators/react/generator.ts
+++ b/generators/react/generator.ts
@@ -118,14 +118,6 @@ export default class ReactGenerator extends BaseApplicationGenerator {
             }),
           );
         };
-        if (application.clientRootDir) {
-          // Overrides only works if added in root package.json
-          this.packageJson.merge({
-            overrides: {
-              'browser-sync': application.nodeDependencies['browser-sync'],
-            },
-          });
-        }
       },
     });
   }
@@ -217,6 +209,13 @@ export default class ReactGenerator extends BaseApplicationGenerator {
             'browser-sync': nodeDependencies['browser-sync'],
           },
         });
+        if (application.clientRootDir) {
+          this.packageJson.merge({
+            overrides: {
+              'browser-sync': application.nodeDependencies['browser-sync'],
+            },
+          });
+        }
       },
       addMicrofrontendDependencies({ application, source }) {
         if (!application.microfrontend) return;

--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -42,7 +42,7 @@
     "@types/redux": "3.6.31",
     "@types/webpack-env": "1.18.5",
     "autoprefixer": "10.4.20",
-    "browser-sync": "2.29.3",
+    "browser-sync": "3.0.3",
     "browser-sync-webpack-plugin": "2.3.0",
     "copy-webpack-plugin": "12.0.2",
     "core-js": "3.40.0",

--- a/generators/workspaces/generator.ts
+++ b/generators/workspaces/generator.ts
@@ -19,7 +19,7 @@
 
 import { existsSync } from 'fs';
 
-import { GENERATOR_ANGULAR, GENERATOR_BOOTSTRAP_WORKSPACES, GENERATOR_GIT } from '../generator-list.js';
+import { GENERATOR_ANGULAR, GENERATOR_BOOTSTRAP_WORKSPACES, GENERATOR_GIT, GENERATOR_REACT } from '../generator-list.js';
 
 import BaseWorkspacesGenerator from '../base-workspaces/index.js';
 import { packageJson } from '../../lib/index.js';
@@ -198,6 +198,18 @@ export default class WorkspacesGenerator extends BaseWorkspacesGenerator {
             overrides: {
               'browser-sync': browserSyncVersion,
               webpack: webpackVersion,
+            },
+          });
+        }
+
+        if (applications.some(app => app.clientFrameworkReact)) {
+          const {
+            devDependencies: { 'browser-sync': browserSyncVersion },
+          } = this.fs.readJSON(this.fetchFromInstalledJHipster(GENERATOR_REACT, 'resources', 'package.json'));
+
+          this.packageJson.merge({
+            overrides: {
+              'browser-sync': browserSyncVersion,
             },
           });
         }


### PR DESCRIPTION
Fix #28571 

https://www.npmjs.com/package/browser-sync-webpack-plugin no longer appears to be maintained

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
