### PR TITLE
react: remove eslint rule name

### DIFF
--- a/generators/react/templates/src/main/webapp/app/entities/menu.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/menu.tsx.ejs
@@ -17,9 +17,9 @@
  limitations under the License.
 -%>
 import React<%_ if (applicationTypeMicroservice) { %>, { useEffect, useState } <% } %> from 'react';
-import { Translate } from 'react-jhipster';<% if (!hasNonBuiltInEntity) { %> // eslint-disable-line unused-imports/no-unused-imports<% } %>
+import { Translate } from 'react-jhipster';<% if (!hasNonBuiltInEntity) { %> // eslint-disable-line<% } %>
 
-import MenuItem from 'app/shared/layout/menus/menu-item';<% if (!hasNonBuiltInEntity) { %> // eslint-disable-line unused-imports/no-unused-imports<% } %>
+import MenuItem from 'app/shared/layout/menus/menu-item';<% if (!hasNonBuiltInEntity) { %> // eslint-disable-line<% } %>
 <%_ if (applicationTypeMicroservice) { _%>
 import { addTranslationSourcePrefix } from 'app/shared/reducers/locale';
 import { useAppDispatch, useAppSelector } from 'app/config/store';

--- a/generators/react/templates/src/main/webapp/app/entities/routes.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/routes.tsx.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import React from 'react';
-import { Route } from 'react-router';<% if (!hasNonBuiltInEntity) { %>// eslint-disable-line unused-imports/no-unused-imports<% } %>
+import { Route } from 'react-router';<% if (!hasNonBuiltInEntity) { %>// eslint-disable-line<% } %>
 
 import ErrorBoundaryRoutes from 'app/shared/error/error-boundary-routes';
 


### PR DESCRIPTION
Unused imports eslint plugin is not added to generated application resulting in unknown rule error.

Related to https://github.com/jhipster/generator-jhipster/pull/29048.

Should fix failures in daily builds.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
