### PR TITLE
internal: adjusts to crlf support

### DIFF
--- a/generators/app/__snapshots__/generator.spec.ts.snap
+++ b/generators/app/__snapshots__/generator.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`generator - app help should print expected information 1`] = `
 [Default] Create a new JHipster application based on the selected options
 
 Options:
-  --auto-crlf                              Detect line endings
+  --auto-crlf                              Detect line endings (defaults to true on Windows)
   --defaults                               Execute jhipster with default config
   --skip-client                            Skip the client-side application generation
   --skip-server                            Skip the server-side application generation

--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -37,7 +37,17 @@ import latestVersion from 'latest-version';
 import SharedData from '../base/shared-data.js';
 import { CUSTOM_PRIORITIES, PRIORITY_NAMES, PRIORITY_PREFIX, QUEUES } from '../base/priorities.js';
 import type { Logger } from '../base/support/index.js';
-import { createJHipster7Context, formatDateForChangelog, joinCallbacks, removeFieldsWithNullishValues } from '../base/support/index.js';
+import {
+  CRLF,
+  LF,
+  createJHipster7Context,
+  formatDateForChangelog,
+  hasCrlr,
+  isWin32,
+  joinCallbacks,
+  normalizeLineEndings,
+  removeFieldsWithNullishValues,
+} from '../base/support/index.js';
 
 import type {
   CascatedEditFileCallback,
@@ -257,6 +267,7 @@ export default class CoreGenerator extends YeomanGenerator<JHipsterGeneratorOpti
       skipFakeData: false,
       skipCheckLengthOfIdentifier: false,
       enableGradleEnterprise: false,
+      autoCrlf: isWin32,
       pages: [],
     });
     return configWithDefaults as ApplicationConfiguration;
@@ -1187,16 +1198,18 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
 
     let newContent = originalContent;
     const writeCallback = (...callbacks: EditFileCallback<this>[]): CascatedEditFileCallback<this> => {
+      const { autoCrlf = this.jhipsterConfigWithDefaults.autoCrlf, assertModified } = actualOptions;
       try {
-        newContent = joinCallbacks(...callbacks).call(this, newContent, filePath);
-        if (actualOptions.assertModified && originalContent === newContent) {
+        const fileHasCrlf = autoCrlf && hasCrlr(newContent);
+        newContent = joinCallbacks(...callbacks).call(this, fileHasCrlf ? normalizeLineEndings(newContent, LF) : newContent, filePath);
+        if (assertModified && originalContent === newContent) {
           const errorMessage = `${chalk.yellow('Fail to modify ')}${filePath}.`;
           if (!this.ignoreNeedlesError) {
             throw new Error(errorMessage);
           }
           this.log(errorMessage);
         }
-        this.writeDestination(filePath, newContent);
+        this.writeDestination(filePath, fileHasCrlf ? normalizeLineEndings(newContent, CRLF) : newContent);
       } catch (error: unknown) {
         if (error instanceof Error) {
           throw new Error(`Error editing file ${filePath}: ${error.message} at ${error.stack}`);

--- a/generators/base/api.d.ts
+++ b/generators/base/api.d.ts
@@ -115,7 +115,7 @@ export type NeedleCallback = (content: string) => string;
 
 export type EditFileCallback<Generator = CoreGenerator> = (this: Generator, content: string, filePath: string) => string;
 
-export type EditFileOptions = { create?: boolean; ignoreNonExisting?: boolean | string; assertModified?: boolean };
+export type EditFileOptions = { create?: boolean; ignoreNonExisting?: boolean | string; assertModified?: boolean; autoCrlf?: boolean };
 
 export type CascatedEditFileCallback<Generator = CoreGenerator> = (
   ...callbacks: EditFileCallback<Generator>[]

--- a/generators/base/support/contents.ts
+++ b/generators/base/support/contents.ts
@@ -16,6 +16,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+export const CRLF = '\r\n';
+export const LF = '\n';
+
+/**
+ * Check if a string contains CRLF line endings.
+ *
+ * @param str
+ * @returns
+ */
+export const hasCrlr = (str?: string): boolean => Boolean(str?.includes(CRLF));
+
 /**
  * Replace line endings with the specified one.
  *
@@ -24,7 +36,7 @@
  * @returns normalized line ending string
  */
 
-export function normalizeLineEndings(str: string, lineEnding: '\n' | '\r\n'): string {
+export function normalizeLineEndings(str: string, lineEnding: typeof LF | typeof CRLF): string {
   return str.replace(/\r\n|\r|\n/g, lineEnding);
 }
 

--- a/generators/base/support/needles.ts
+++ b/generators/base/support/needles.ts
@@ -21,7 +21,6 @@ import { escapeRegExp, kebabCase } from 'lodash-es';
 import type CoreGenerator from '../../base-core/index.js';
 import type { CascatedEditFileCallback, EditFileCallback, NeedleCallback } from '../api.js';
 import { joinCallbacks } from './write-files.js';
-import { normalizeLineEndings } from './contents.js';
 
 type NeedleContentToAddCallback = {
   /**
@@ -115,10 +114,6 @@ export const insertContentBeforeNeedle = ({ content, contentToAdd, needle, autoI
   assert(content, 'content is required');
   assert(contentToAdd, 'contentToAdd is required');
 
-  const isCrLr = content.includes('\r\n');
-  content = isCrLr ? normalizeLineEndings(content, '\n') : content;
-  const lineEnding = isCrLr ? '\r\n' : '\n';
-
   needle = needle.includes('jhipster-needle-') ? needle : `jhipster-needle-${needle}`;
 
   const regexp = new RegExp(`(?://|<!--|/\\*|#) ${needle}(?:$|\n| )`, 'g');
@@ -146,7 +141,7 @@ export const insertContentBeforeNeedle = ({ content, contentToAdd, needle, autoI
       needleIndent,
       indentPrefix: ' '.repeat(needleIndent),
     });
-    return isCrLr ? normalizeLineEndings(newContent, lineEnding) : newContent;
+    return newContent;
   }
   contentToAdd = Array.isArray(contentToAdd) ? contentToAdd : [contentToAdd];
   if (autoIndent) {
@@ -178,7 +173,7 @@ export const insertContentBeforeNeedle = ({ content, contentToAdd, needle, autoI
   }
 
   const newContent = `${beforeContent}${contentToAdd.join('\n')}\n${afterContent}`;
-  return isCrLr ? normalizeLineEndings(newContent, lineEnding) : newContent;
+  return newContent;
 };
 
 /**

--- a/generators/base/support/os.ts
+++ b/generators/base/support/os.ts
@@ -16,21 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from '../../../lib/utils/derived-property.js';
-export * from '../../../lib/utils/logger.js';
-export * from '../../../lib/utils/object.js';
-export * from '../../../lib/utils/string.js';
-export * from './basename.js';
-export * from './configuration-helpers/options.js';
-export * from './contents.js';
-export * from './faker.js';
-export { default as getHipster } from './hipster.js';
-export * from './jhipster7-context.js';
-export * from './namespace.js';
-export * from './needles.js';
-export * from './os.js';
-export * from './path.js';
-export { default as httpsGet } from './remote.js';
-export * from './secret.js';
-export * from './timestamp.js';
-export * from './write-files.js';
+import { platform } from 'os';
+
+export const isWin32 = platform() === 'win32';

--- a/generators/base/support/write-files.ts
+++ b/generators/base/support/write-files.ts
@@ -16,12 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { platform } from 'os';
-
 import type { EditFileCallback } from '../api.js';
-import { normalizeLineEndings } from './contents.js';
-
-const isWin32 = platform() === 'win32';
 
 /**
  * TODO move to utils when converted to typescripts
@@ -30,11 +25,6 @@ const isWin32 = platform() === 'win32';
 
 export function joinCallbacks<Generator>(...callbacks: EditFileCallback<Generator>[]): EditFileCallback<Generator> {
   return function (this: Generator, content: string, filePath: string) {
-    if (isWin32 && /\r\n/.exec(content)) {
-      const removeSlashRSlashN: EditFileCallback<Generator> = ct => normalizeLineEndings(ct, '\n');
-      const addSlashRSlashN: EditFileCallback<Generator> = ct => normalizeLineEndings(ct, '\r\n');
-      callbacks = [removeSlashRSlashN, ...callbacks, addSlashRSlashN];
-    }
     for (const callback of callbacks) {
       content = callback.call(this, content, filePath);
     }

--- a/generators/bootstrap-application-base/generator.ts
+++ b/generators/bootstrap-application-base/generator.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 import assert from 'assert';
-import os from 'os';
 import { lowerFirst } from 'lodash-es';
 import chalk from 'chalk';
 import { passthrough } from '@yeoman/transform';
@@ -41,13 +40,11 @@ import { loadAppConfig, loadDerivedAppConfig, loadStoredAppOptions } from '../ap
 import { lookupCommandsConfigs } from '../../lib/command/lookup-commands-configs.js';
 import { loadCommandConfigsIntoApplication, loadCommandConfigsKeysIntoTemplatesContext } from '../../lib/command/load.js';
 import { getConfigWithDefaults } from '../../lib/jhipster/default-application-options.js';
-import { removeFieldsWithNullishValues } from '../base/support/index.js';
+import { isWin32, removeFieldsWithNullishValues } from '../base/support/index.js';
 import { convertFieldBlobType, getBlobContentType, isFieldBinaryType, isFieldBlobType } from '../../lib/application/field-types.js';
 import type { Entity } from '../../lib/types/application/entity.js';
 import { createAuthorityEntity, createUserEntity, createUserManagementEntity } from './utils.js';
 import { exportJDLTransform, importJDLTransform } from './support/index.js';
-
-const isWin32 = os.platform() === 'win32';
 
 export default class BootstrapApplicationBase extends BaseApplicationGenerator {
   constructor(args: any, options: any, features: any) {

--- a/generators/bootstrap/command.ts
+++ b/generators/bootstrap/command.ts
@@ -21,7 +21,7 @@ import type { JHipsterCommandDefinition } from '../../lib/command/index.js';
 const command: JHipsterCommandDefinition = {
   options: {
     autoCrlf: {
-      description: 'Detect line endings',
+      description: 'Detect line endings (defaults to true on Windows)',
       type: Boolean,
       scope: 'storage',
     },

--- a/generators/bootstrap/generator.ts
+++ b/generators/bootstrap/generator.ts
@@ -223,7 +223,7 @@ export default class BootstrapGenerator extends BaseGenerator {
     }
 
     const autoCrlfTransforms: FileTransform<MemFsEditorFile>[] = [];
-    if (this.jhipsterConfig.autoCrlf) {
+    if (this.jhipsterConfigWithDefaults.autoCrlf) {
       autoCrlfTransforms.push(await autoCrlfTransform({ baseDir: this.destinationPath() }));
     }
 

--- a/generators/bootstrap/support/auto-crlf-transform.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.ts
@@ -24,7 +24,7 @@ import { isBinaryFile } from 'isbinaryfile';
 import { simpleGit } from 'simple-git';
 import { isFileStateModified } from 'mem-fs-editor/state';
 import type { MemFsEditorFile } from 'mem-fs-editor';
-import { normalizeLineEndings } from '../../base/support/index.js';
+import { CRLF, normalizeLineEndings } from '../../base/support/index.js';
 
 /**
  * Detect the file first line endings
@@ -80,7 +80,7 @@ const autoCrlfTransform = async ({ baseDir }: { baseDir: string }) => {
         );
 
         if (attrs.eol === 'crlf' || (attrs.binary !== 'set' && attrs.eol !== 'lf' && (await detectCrLf(file.path)))) {
-          file.contents = Buffer.from(normalizeLineEndings(file.contents!.toString(), '\r\n'));
+          file.contents = Buffer.from(normalizeLineEndings(file.contents!.toString(), CRLF));
         }
       }
     } catch {

--- a/generators/init/__snapshots__/generator.spec.ts.snap
+++ b/generators/init/__snapshots__/generator.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`generator - init help should print expected information 1`] = `
 Init project (alpha)
 
 Options:
-  --auto-crlf                   Detect line endings
+  --auto-crlf                   Detect line endings (defaults to true on Windows)
   --skip-cache                  Do not remember prompt answers (default: false)
   --skip-install                Do not automatically install dependencies (default: false)
   --force-install               Fail on install dependencies error (default: false)

--- a/generators/java/generators/node/generator.ts
+++ b/generators/java/generators/node/generator.ts
@@ -19,6 +19,7 @@
 import chalk from 'chalk';
 import type { ExecaError } from 'execa';
 import BaseApplicationGenerator from '../../../base-application/index.js';
+import { isWin32 } from '../../../base/support/os.js';
 
 export default class NodeGenerator extends BaseApplicationGenerator {
   async beforeQueue() {
@@ -117,7 +118,7 @@ export default class NodeGenerator extends BaseApplicationGenerator {
           return;
         }
 
-        const npmCommand = process.platform === 'win32' ? 'npmw' : './npmw';
+        const npmCommand = isWin32 ? 'npmw' : './npmw';
         try {
           await this.spawn(npmCommand, ['install'], { preferLocal: true });
         } catch (error: unknown) {

--- a/generators/jdl/__snapshots__/generator.spec.ts.snap
+++ b/generators/jdl/__snapshots__/generator.spec.ts.snap
@@ -158,7 +158,7 @@ Create entities from the JDL file/URL/content passed in argument.
     Use the '--interactive' flag to generate multiple applications in series.
 
 Options:
-  --auto-crlf                              Detect line endings
+  --auto-crlf                              Detect line endings (defaults to true on Windows)
   --interactive                            Generate multiple applications in series so that questions can be interacted with. This is the default when there is an existing application configuration in any of the folders
   --json-only                              Generate only the JSON files and skip entity regeneration
   --ignore-application                     Ignores application generation

--- a/generators/spring-boot/generator.ts
+++ b/generators/spring-boot/generator.ts
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import os from 'node:os';
 import chalk from 'chalk';
 import { lowerFirst, sortedUniqBy } from 'lodash-es';
 import BaseApplicationGenerator from '../base-application/index.js';
@@ -46,7 +45,7 @@ import {
   javaBeanCase,
 } from '../server/support/index.js';
 import { generateKeyStore } from '../java/support/index.js';
-import { createNeedleCallback, mutateData } from '../base/support/index.js';
+import { createNeedleCallback, isWin32, mutateData } from '../base/support/index.js';
 import {
   APPLICATION_TYPE_MICROSERVICE,
   applicationTypes,
@@ -683,7 +682,7 @@ in your ${chalk.yellow.bold(`${application.srcMainResources}config/application.y
         }
 
         let logMsgComment = '';
-        if (os.platform() === 'win32') {
+        if (isWin32) {
           logMsgComment = ` (${chalk.yellow.bold(buildToolExecutable)} if using Windows Command Prompt)`;
         }
         this.log.log(


### PR DESCRIPTION
 - Windows now defaults to enable autoCrlf
 - make editFile aware of crlf by converting to lf when required
 - remove crlf handling from joinCallbacks and insertContentBeforeNeedle since handling is done by editFile now..
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
