### PR TITLE
java: revert supported java version to 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following Java and Node combinations are tested and verified by GitHub Actio
 
 | Java     | Node     | Status |
 | -------- | -------- | ------ |
-| 17/21/24 | 18/20/22 | ✅     |
+| 17/21/23 | 18/20/22 | ✅     |
 
 ## Sponsors
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -26,7 +26,7 @@ export const JHIPSTER_DEPENDENCIES_VERSION = '8.10.0';
 // Version of Java
 export const JAVA_VERSION = '17';
 // Supported Java versions, https://www.oracle.com/java/technologies/java-se-support-roadmap.html
-export const JAVA_COMPATIBLE_VERSIONS = ['17', '21', '24'];
+export const JAVA_COMPATIBLE_VERSIONS = ['17', '21', '23'];
 // Force spring milestone repository. Spring Boot milestones are detected.
 export const ADD_SPRING_MILESTONE_REPOSITORY = false;
 


### PR DESCRIPTION
Gradle still doesn't support java 24
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
