### PR TITLE
vue: move login modal handling to login-modal using a store instead o…

### DIFF
--- a/generators/vue/__snapshots__/generator.spec.ts.snap
+++ b/generators/vue/__snapshots__/generator.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`generator - vue gateway-jwt-skipUserManagement(true)-withAdminUi(false)
   "clientRoot/src/app/account/login-form/login-form.vue": {
     "stateCleared": "modified",
   },
-  "clientRoot/src/app/account/login.service.ts": {
+  "clientRoot/src/app/account/login-modal.ts": {
     "stateCleared": "modified",
   },
   "clientRoot/src/app/admin/docs/docs.component.ts": {
@@ -1080,7 +1080,7 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "clientRoot/src/app/account/login-form/login-form.vue": {
     "stateCleared": "modified",
   },
-  "clientRoot/src/app/account/login.service.ts": {
+  "clientRoot/src/app/account/login-modal.ts": {
     "stateCleared": "modified",
   },
   "clientRoot/src/app/admin/docs/docs.component.ts": {
@@ -2125,7 +2125,7 @@ exports[`generator - vue monolith-jwt-skipUserManagement(false)-withAdminUi(true
   "src/main/webapp/app/account/login-form/login-form.vue": {
     "stateCleared": "modified",
   },
-  "src/main/webapp/app/account/login.service.ts": {
+  "src/main/webapp/app/account/login-modal.ts": {
     "stateCleared": "modified",
   },
   "src/main/webapp/app/account/register/register.component.spec.ts": {
@@ -3192,6 +3192,12 @@ exports[`generator - vue monolith-session-skipUserManagement(true)-withAdminUi(f
     "stateCleared": "modified",
   },
   "src/main/webapp/app/account/login-form/login-form.vue": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/app/account/login-modal.ts": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/app/account/login.service.spec.ts": {
     "stateCleared": "modified",
   },
   "src/main/webapp/app/account/login.service.ts": {

--- a/generators/vue/cleanup.ts
+++ b/generators/vue/cleanup.ts
@@ -23,7 +23,7 @@ import { asWritingTask } from '../base-application/support/task-type-inference.j
  * Removes files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default asWritingTask(function cleanupOldFilesTask({ application }) {
+export default asWritingTask(async function cleanupOldFilesTask({ application, control }) {
   if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
     this.removeFile(`${application.clientSrcDir}app/admin/audits/audits.component.ts`);
     this.removeFile(`${application.clientSrcDir}app/admin/audits/audits.service.ts`);
@@ -108,4 +108,11 @@ export default asWritingTask(function cleanupOldFilesTask({ application }) {
     this.removeFile('vite.config.ts');
     this.removeFile('vitest.config.ts');
   }
+
+  await control.cleanupFiles({
+    '8.10.1': [
+      [application.authenticationTypeJwt, `${application.clientSrcDir}app/account/login.service.ts`],
+      [application.authenticationTypeJwt, `${application.clientSrcDir}app/account/login.service.spec.ts`],
+    ],
+  });
 });

--- a/generators/vue/files-vue.ts
+++ b/generators/vue/files-vue.ts
@@ -149,7 +149,7 @@ export const vueFiles = {
         'account/login-form/login-form.vue',
         'account/login-form/login-form.component.ts',
         'account/login-form/login-form.component.spec.ts',
-        'account/login.service.ts',
+        'account/login-modal.ts',
         'router/account.ts',
       ],
     },
@@ -182,15 +182,10 @@ export const vueFiles = {
     {
       condition: generator => generator.authenticationTypeSession && generator.generateUserManagement,
       ...clientApplicationTemplatesBlock(),
-      templates: [
-        'account/sessions/sessions.vue',
-        'account/sessions/sessions.component.ts',
-        'account/sessions/sessions.component.spec.ts',
-        'account/login.service.spec.ts',
-      ],
+      templates: ['account/sessions/sessions.vue', 'account/sessions/sessions.component.ts', 'account/sessions/sessions.component.spec.ts'],
     },
     {
-      condition: generator => generator.authenticationTypeOauth2,
+      condition: generator => generator.authenticationUsesCsrf,
       ...clientApplicationTemplatesBlock(),
       templates: ['account/login.service.ts', 'account/login.service.spec.ts'],
     },

--- a/generators/vue/templates/src/main/webapp/app/account/activate/activate.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/activate/activate.component.spec.ts.ejs
@@ -1,10 +1,28 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import { vitest } from 'vitest';
-import { shallowMount, type ComponentMountingOptions } from '@vue/test-utils';
+import { type ComponentMountingOptions, shallowMount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
 import axios from 'axios';
 import sinon from 'sinon';
 
 import Activate from './activate.vue';
-import LoginService from '../login.service';
 
 type ActivateComponentType = InstanceType<typeof Activate>;
 
@@ -21,16 +39,12 @@ const axiosStub = {
 
 describe('Activate Component', () => {
   let activate: ActivateComponentType;
-  let loginService: LoginService;
   let mountOptions: ComponentMountingOptions<ActivateComponentType>;
 
   beforeEach(() => {
-    loginService = new LoginService({ emit: vitest.fn() });
     mountOptions = {
       global: {
-        provide: {
-          loginService,
-        },
+        plugins: [createTestingPinia()],
       },
     };
   });

--- a/generators/vue/templates/src/main/webapp/app/account/activate/activate.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/activate/activate.component.ts.ejs
@@ -1,14 +1,32 @@
-import { defineComponent, inject, onMounted, ref, type Ref } from 'vue';
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { type Ref, defineComponent, inject, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type LoginService from '@/account/login.service';
-import ActivateService from './activate.service';
 import { useRoute } from 'vue-router';
+import { useLoginModal } from '@/account/login-modal';
+import ActivateService from './activate.service';
 
 export default defineComponent({
   compatConfig: { MODE: 3 },
   setup() {
     const activateService = inject('activateService', () => new ActivateService(), true);
-    const loginService = inject<LoginService>('loginService');
+    const { showLogin } = useLoginModal();
     const route = useRoute();
 
     const success: Ref<boolean> = ref(false);
@@ -26,13 +44,9 @@ export default defineComponent({
       }
     });
 
-    const openLogin = () => {
-      loginService.openLogin();
-    };
-
     return {
       activateService,
-      openLogin,
+      showLogin,
       success,
       error,
       t$: useI18n().t,

--- a/generators/vue/templates/src/main/webapp/app/account/activate/activate.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/activate/activate.vue.ejs
@@ -5,7 +5,7 @@
         <h1 v-text="t$('activate.title')">Activation</h1>
         <div class="alert alert-success" v-if="success">
           <span v-html="t$('activate.messages.success')"><strong>Your user account has been activated.</strong> Please </span>
-          <a class="alert-link" @click="openLogin" v-text="t$('global.messages.info.authenticated.link')">sign in</a>.
+          <a class="alert-link" @click="showLogin()" v-text="t$('global.messages.info.authenticated.link')">sign in</a>.
         </div>
         <div class="alert alert-danger" v-if="error" v-html="t$('activate.messages.error')">
           <strong>Your user could not be activated.</strong> Please use the registration form to sign up.

--- a/generators/vue/templates/src/main/webapp/app/account/login-form/login-form.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/login-form/login-form.component.spec.ts.ejs
@@ -1,15 +1,31 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import { vitest } from 'vitest';
-import { shallowMount, type MountingOptions } from '@vue/test-utils';
+import { type MountingOptions, shallowMount } from '@vue/test-utils';
 import axios from 'axios';
 import sinon from 'sinon';
 import { type RouteLocation } from 'vue-router';
-import { PiniaVuePlugin } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
-import LoginService from '../login.service';
 import AccountService from '../account.service';
-import { useStore } from '@/store';
 import LoginForm from './login-form.vue';
+import { useStore } from '@/store';
 
 type LoginFormComponentType = InstanceType<typeof LoginForm>;
 
@@ -19,10 +35,6 @@ vitest.mock('vue-router', () => ({
   useRoute: () => route,
   useRouter: () => ({ go: routerGoMock }),
 }));
-
-const pinia = createTestingPinia();
-
-const store = useStore();
 
 const axiosStub = {
   get: sinon.stub(axios, 'get'),
@@ -37,7 +49,8 @@ describe('LoginForm Component', () => {
     axiosStub.get.resolves({});
     axiosStub.post.reset();
 
-    const loginService = new LoginService({ emit: vitest.fn() });
+    const pinia = createTestingPinia();
+    const store = useStore();
 
     const globalOptions: MountingOptions<LoginFormComponentType>['global'] = {
       stubs: {
@@ -51,7 +64,6 @@ describe('LoginForm Component', () => {
       },
       plugins: [pinia],
       provide: {
-        loginService,
         accountService: new AccountService(store),
       },
     };

--- a/generators/vue/templates/src/main/webapp/app/account/login-form/login-form.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/login-form/login-form.component.ts.ejs
@@ -1,11 +1,29 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import axios from 'axios';
-import { defineComponent, inject, ref, type Ref } from 'vue';
+import { type Ref, defineComponent, inject, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n';
 <%_ } _%>
+import { useLoginModal } from '@/account/login-modal';
 import type AccountService from '../account.service';
-import type LoginService from '@/account/login.service';
 
 export default defineComponent({
   compatConfig: { MODE: 3 },
@@ -14,13 +32,14 @@ export default defineComponent({
     const login: Ref<string> = ref(null);
     const password: Ref<string> = ref(null);
     const rememberMe: Ref<boolean> = ref(false);
+
+    const { hideLogin } = useLoginModal();
     const route = useRoute();
     const router = useRouter();
 
     const previousState = () => router.go(-1);
 
     const accountService = inject<AccountService>('accountService');
-    const loginService = inject<LoginService>('loginService');
 
     const doLogin = async () => {
 <%_ if (authenticationTypeJwt) { _%>
@@ -49,7 +68,7 @@ export default defineComponent({
 <%_ } _%>
 
         authenticationError.value = false;
-        loginService.hideLogin();
+        hideLogin();
         await accountService.retrieveAccount();
         if (route.path === '/forbidden') {
           previousState();

--- a/generators/vue/templates/src/main/webapp/app/account/login-modal.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/login-modal.ts.ejs
@@ -16,27 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<template>
-  <div id="app">
-    <ribbon></ribbon>
-    <div id="app-header">
-      <jhi-navbar></jhi-navbar>
-    </div>
-    <div class="container-fluid">
-      <div class="card jh-card">
-        <router-view></router-view>
-      </div>
-<%_ if (!authenticationTypeOauth2) { _%>
-      <b-modal id="login-page" v-model="loginModalOpen" hide-footer lazy>
-        <template #modal-title>
-          <span data-cy="loginTitle" id="login-title" v-text="t$('login.title')">Sign in</span>
-        </template>
-        <login-form></login-form>
-      </b-modal>
-<%_ } %>
-      <jhi-footer></jhi-footer>
-    </div>
-  </div>
-</template>
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
 
-<script lang="ts" src="./app.component.ts"></script>
+export const useLoginModal = defineStore('login', () => {
+  const loginModalOpen = ref(false);
+
+  function showLogin() {
+    loginModalOpen.value = true;
+  }
+
+  function hideLogin() {
+    loginModalOpen.value = false;
+  }
+
+  return {
+    loginModalOpen,
+    showLogin,
+    hideLogin,
+  };
+});

--- a/generators/vue/templates/src/main/webapp/app/account/login.service.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/login.service.spec.ts.ejs
@@ -1,5 +1,4 @@
 import LoginService from './login.service';
-<%_ if (!authenticationTypeJwt) { _%>
 import axios from 'axios';
 import sinon from 'sinon';
 
@@ -7,7 +6,6 @@ const axiosStub = {
   get: sinon.stub(axios, 'get'),
   post: sinon.stub(axios, 'post'),
 };
-<%_ } _%>
 
 describe('Login Service test suite', () => {
   let loginService: LoginService;
@@ -66,11 +64,9 @@ describe('Login Service test suite', () => {
   });
 <%_ } _%>
 
-<%_ if (!authenticationTypeJwt) { _%>
   it('should call global logout when asked to', () => {
     loginService.logout();
 
     expect(axiosStub.post.calledWith('api/logout')).toBeTruthy();
   });
-<%_ } _%>
 });

--- a/generators/vue/templates/src/main/webapp/app/account/login.service.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/login.service.ts.ejs
@@ -1,27 +1,7 @@
-<%_ if (!authenticationTypeOauth2) { _%>
-import Vue from 'vue';
-<%_ } _%>
-<%_ if (!authenticationTypeJwt) { _%>
 import axios, { type AxiosPromise } from 'axios';
-<%_ } _%>
 
 export default class LoginService {
-<%_ if (!authenticationTypeOauth2) { _%>
-  private readonly emit: (event: string, ...args: any[]) => void;
-
-  constructor({ emit }: { emit: (event: string, ...args: any[]) => void }) {
-    this.emit = emit;
-  }
-
-  public openLogin(): void {
-    this.emit('bv::show::modal', 'login-page');
-  }
-
-  public hideLogin(): void {
-    this.emit('bv::hide::modal', 'login-page');
-  }
-<%_ } else { _%>
-
+<%_ if (authenticationTypeOauth2) { _%>
   public login(loc: { href: string; hostname: string; pathname: string; port?: string } = window.location) {
     const port = loc.port ? `:${loc.port}` : '';
     let contextPath = loc.pathname;
@@ -39,10 +19,8 @@ export default class LoginService {
     loc.href = `//${loc.hostname}${port}${contextPath}oauth2/authorization/oidc`;
   }
 <%_ } _%>
-<%_ if (!authenticationTypeJwt) { _%>
 
   public logout(): AxiosPromise<any> {
     return axios.post('api/logout');
   }
-<%_ } _%>
 }

--- a/generators/vue/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
@@ -72,7 +72,7 @@ describe('Register Component', () => {
   it('should open login modal when asked to', () => {
     const login = useLoginModal();
     register.showLogin();
-    expect(login.showLogin).toBeCalledTimes(1);
+    expect(login.showLogin).toHaveBeenCalledOnce();
   });
 
   it('should register when password match', async () => {

--- a/generators/vue/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/register/register.component.spec.ts.ejs
@@ -1,13 +1,31 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import { vitest } from 'vitest';
 import { computed } from 'vue';
 import { shallowMount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
 import axios from 'axios';
 import sinon from 'sinon';
 
 import { EMAIL_ALREADY_USED_TYPE, LOGIN_ALREADY_USED_TYPE } from '@/constants';
+import { useLoginModal } from '@/account/login-modal';
 import Register from './register.vue';
-import RegisterService from './register.service';
-import LoginService from '../login.service';
 
 type RegisterComponentType = InstanceType<typeof Register>;
 
@@ -18,7 +36,6 @@ const axiosStub = {
 
 describe('Register Component', () => {
   let register: RegisterComponentType;
-  let loginService: LoginService;
   const filledRegisterAccount = {
     email: 'jhi@pster.net',
     langKey: '<%= nativeLanguage %>',
@@ -29,13 +46,11 @@ describe('Register Component', () => {
   beforeEach(() => {
     axiosStub.get.resolves({});
     axiosStub.post.reset();
-    loginService = new LoginService({ emit: vitest.fn() });
-    vitest.spyOn(loginService, 'openLogin');
 
     const wrapper = shallowMount(Register, {
       global: {
+        plugins: [createTestingPinia()],
         provide: {
-          loginService,
           currentLanguage: computed(() => '<%= nativeLanguage %>'),
         },
       },
@@ -55,8 +70,9 @@ describe('Register Component', () => {
   });
 
   it('should open login modal when asked to', () => {
-    register.openLogin();
-    expect(loginService.openLogin).toBeCalledTimes(1);
+    const login = useLoginModal();
+    register.showLogin();
+    expect(login.showLogin).toBeCalledTimes(1);
   });
 
   it('should register when password match', async () => {

--- a/generators/vue/templates/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -1,10 +1,28 @@
-import { computed, defineComponent, inject, ref, type Ref } from 'vue';
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { type Ref, computed, defineComponent, inject, ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n';
 <%_ } _%>
-import { useVuelidate } from '@vuelidate/core'
+import { useVuelidate } from '@vuelidate/core';
 import { email, helpers, maxLength, minLength, required, sameAs } from '@vuelidate/validators';
-import type LoginService from '@/account/login.service';
+import { useLoginModal } from '@/account/login-modal';
 import RegisterService from '@/account/register/register.service';
 import { EMAIL_ALREADY_USED_TYPE, LOGIN_ALREADY_USED_TYPE } from '@/constants';
 
@@ -43,7 +61,7 @@ export default defineComponent({
     };
   },
   setup() {
-    const loginService = inject<LoginService>('loginService');
+    const { showLogin } = useLoginModal();
     const registerService = inject('registerService', () => new RegisterService(), true);
     const currentLanguage = inject('currentLanguage', () => computed(() => navigator.language ?? '<%- nativeLanguage %>'), true);
 
@@ -59,12 +77,8 @@ export default defineComponent({
       password: undefined,
     });
 
-    const openLogin = () => {
-      loginService.openLogin();
-    };
-
     return {
-      openLogin,
+      showLogin,
       currentLanguage,
       registerService,
       error,

--- a/generators/vue/templates/src/main/webapp/app/account/register/register.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/register/register.vue.ejs
@@ -209,7 +209,7 @@
         <p></p>
         <div class="alert alert-warning">
           <span v-text="t$('global.messages.info.authenticated.prefix')">If you want to </span>
-          <a class="alert-link" @click="openLogin()" v-text="t$('global.messages.info.authenticated.link')">sign in</a
+          <a class="alert-link" @click="showLogin()" v-text="t$('global.messages.info.authenticated.link')">sign in</a
           ><span v-html="t$('global.messages.info.authenticated.suffix')"
             >, you can try the default accounts:<br />- Administrator (login="admin" and password="admin") <br />- User (login="user" and
             password="user").</span

--- a/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.component.spec.ts.ejs
@@ -1,8 +1,26 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import axios from 'axios';
 import sinon from 'sinon';
 import { shallowMount } from '@vue/test-utils';
 import ResetPasswordFinish from './reset-password-finish.vue';
-import LoginService from '@/login.service';
+import { createTestingPinia } from '@pinia/testing';
 
 type ResetPasswordFinishComponentType = InstanceType<typeof ResetPasswordFinish>;
 
@@ -18,9 +36,7 @@ describe('Reset Component Finish', () => {
     axiosStub.post.reset();
     const wrapper = shallowMount(ResetPasswordFinish, {
       global: {
-        provide: {
-          loginService: {},
-        },
+        plugins: [createTestingPinia()],
       },
     });
     resetPasswordFinish = wrapper.vm;

--- a/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.component.ts.ejs
@@ -1,11 +1,27 @@
-import { defineComponent, inject, ref, type Ref } from 'vue';
-<%_ if (enableTranslation) { _%>
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { type Ref, defineComponent, inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-<%_ } _%>
 import axios from 'axios';
-import { useVuelidate } from '@vuelidate/core'
+import { useVuelidate } from '@vuelidate/core';
 import { maxLength, minLength, required, sameAs } from '@vuelidate/validators';
-import type LoginService from '@/account/login.service';
+import { useLoginModal } from '@/account/login-modal';
 
 export default defineComponent({
   compatConfig: { MODE: 3 },
@@ -31,7 +47,7 @@ export default defineComponent({
     this.keyMissing = !this.key;
   },
   setup() {
-    const loginService = inject<LoginService>('loginService');
+    const { showLogin } = useLoginModal();
 
     const doNotMatch: Ref<string> = ref(null);
     const success: Ref<string> = ref(null);
@@ -43,12 +59,8 @@ export default defineComponent({
       confirmPassword: null,
     });
 
-    const openLogin = () => {
-      loginService.openLogin();
-    };
-
     return {
-      openLogin,
+      showLogin,
       doNotMatch,
       success,
       error,
@@ -56,9 +68,7 @@ export default defineComponent({
       key,
       resetAccount,
       v$: useVuelidate(),
-<%_ if (enableTranslation) { _%>
       t$: useI18n().t,
-<%_ } _%>
     };
   },
   methods: {

--- a/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.vue.ejs
@@ -16,7 +16,7 @@
 
         <div class="alert alert-success" v-if="success">
           <span v-html="t$('reset.finish.messages.success')"><strong>Your password had been reset.</strong> Please </span>
-          <a class="alert-link" @click="openLogin" v-text="t$('global.messages.info.authenticated.link')">sign in</a>
+          <a class="alert-link" @click="showLogin()" v-text="t$('global.messages.info.authenticated.link')">sign in</a>
         </div>
         <div class="alert alert-danger" v-if="doNotMatch">
           <p v-text="t$('global.messages.error.dontmatch')">The password and its confirmation do not match!</p>

--- a/generators/vue/templates/src/main/webapp/app/app.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/app.component.ts.ejs
@@ -1,15 +1,33 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import { defineComponent, provide } from 'vue';
-<%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
+
+<%_ if (!authenticationTypeOauth2) { _%>
+import { useLoginModal } from '@/account/login-modal';
+import LoginForm from '@/account/login-form/login-form.vue';
 <%_ } _%>
 import Ribbon from '@/core/ribbon/ribbon.vue';
 import JhiFooter from '@/core/jhi-footer/jhi-footer.vue';
 import JhiNavbar from '@/core/jhi-navbar/jhi-navbar.vue';
-<%_ if (!authenticationTypeOauth2) { _%>
-import LoginForm from '@/account/login-form/login-form.vue';
-<%_ } %>
 import { useAlertService } from '@/shared/alert/alert.service';
-
 import '@/shared/config/dayjs';
 
 export default defineComponent({
@@ -25,11 +43,15 @@ export default defineComponent({
   },
   setup() {
     provide('alertService', useAlertService());
+<%_ if (!authenticationTypeOauth2) { _%>
+    const { loginModalOpen } = storeToRefs(useLoginModal());
+<%_ } _%>
 
     return {
-<%_ if (enableTranslation) { _%>
-      t$: useI18n().t,
+<%_ if (!authenticationTypeOauth2) { _%>
+      loginModalOpen,
 <%_ } _%>
+      t$: useI18n().t,
     };
   },
 });

--- a/generators/vue/templates/src/main/webapp/app/core/error/error.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/error/error.component.spec.ts.ejs
@@ -84,7 +84,7 @@ describe('Error component', () => {
     expect(error.error403).toBeFalsy();
     expect(error.error404).toBeFalsy();
 <%_ if (generateUserManagement) { _%>
-    expect(login.showLogin).toHaveBeenCalledTimes(0);
+    expect(login.showLogin).not.toHaveBeenCalled();
 <%_ } else { _%>
     expect(loginService.login).toHaveBeenCalledTimes(0);
 <%_ } _%>
@@ -124,7 +124,7 @@ describe('Error component', () => {
     expect(error.error403).toBeFalsy();
     expect(error.error404).toBeTruthy();
 <%_ if (generateUserManagement) { _%>
-    expect(login.showLogin).toHaveBeenCalledTimes(0);
+    expect(login.showLogin).not.toHaveBeenCalled();
 <%_ } else { _%>
     expect(loginService.login).toHaveBeenCalledTimes(0);
 <%_ } _%>
@@ -141,7 +141,7 @@ describe('Error component', () => {
     expect(error.error403).toBeFalsy();
     expect(error.error404).toBeFalsy();
 <%_ if (generateUserManagement) { _%>
-    expect(login.showLogin).toHaveBeenCalledTimes(0);
+    expect(login.showLogin).not.toHaveBeenCalled();
 <%_ } else { _%>
     expect(loginService.login).toHaveBeenCalledTimes(0);
 <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/core/error/error.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/error/error.component.spec.ts.ejs
@@ -1,11 +1,32 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import { vitest } from 'vitest';
 import { type Ref, ref } from 'vue';
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, type ComponentMountingOptions } from '@vue/test-utils';
 import { type RouteLocation } from 'vue-router';
+import { createTestingPinia } from '@pinia/testing';
 
+<%_ if (generateUserManagement) { _%>
+import { useLoginModal } from '@/account/login-modal';
+
+<%_ } _%>
 import Error from './error.vue';
-
-import <% if (authenticationTypeOauth2) { %>type <% } %>LoginService from '@/account/login.service';
 
 type ErrorComponentType = InstanceType<typeof Error>;
 
@@ -19,22 +40,32 @@ const customErrorMsg = 'An error occurred.';
 
 describe('Error component', () => {
   let error: ErrorComponentType;
+<%_ if (authenticationTypeOauth2) { _%>
   let loginService: LoginService;
+<%_ } _%>
+<%_ if (generateUserManagement) { _%>
+  let login: ReturnType<typeof useLoginModal>;
+<%_ } _%>
   let authenticated: Ref<boolean>;
+  let mountOptions: ComponentMountingOptions<ErrorComponentType>;
 
   beforeEach(() => {
     route = {};
     authenticated = ref(false);
-<%_ if (authenticationTypeJwt) { _%>
-    loginService = new LoginService({ emit: vitest.fn() });
-    vitest.spyOn(loginService, 'openLogin');
-<%_ } else if (authenticationTypeSession) { _%>
-    loginService = new LoginService({ emit: vitest.fn() });
-    vitest.spyOn(loginService, 'openLogin');
-    vitest.spyOn(loginService, 'logout');
-<%_ } else if (authenticationTypeOauth2) { _%>
+<%_ if (authenticationTypeOauth2) { _%>
     loginService = { login: vitest.fn(), logout: vitest.fn() };
 <%_ } _%>
+    mountOptions = {
+      global: {
+        plugins: [createTestingPinia()],
+        provide: {
+<%_ if (authenticationTypeOauth2) { _%>
+          loginService,
+<%_ } _%>
+          authenticated,
+        },
+      },
+    };
   });
 
   it('should have retrieve custom error on routing', () => {
@@ -43,21 +74,17 @@ describe('Error component', () => {
       name: 'CustomMessage',
       meta: { errorMessage: customErrorMsg },
     };
-    const wrapper = shallowMount(Error, {
-      global: {
-        provide: {
-          loginService,
-          authenticated,
-        },
-      },
-    });
+    const wrapper = shallowMount(Error, mountOptions);
     error = wrapper.vm;
+<%_ if (generateUserManagement) { _%>
+    login = useLoginModal();
+<%_ } _%>
 
     expect(error.errorMessage).toBe(customErrorMsg);
     expect(error.error403).toBeFalsy();
     expect(error.error404).toBeFalsy();
-<%_ if (!authenticationTypeOauth2) { _%>
-    expect(loginService.openLogin).toHaveBeenCalledTimes(0);
+<%_ if (generateUserManagement) { _%>
+    expect(login.showLogin).toHaveBeenCalledTimes(0);
 <%_ } else { _%>
     expect(loginService.login).toHaveBeenCalledTimes(0);
 <%_ } _%>
@@ -67,21 +94,17 @@ describe('Error component', () => {
     route = {
       meta: { error403: true },
     };
-    const wrapper = shallowMount(Error, {
-      global: {
-        provide: {
-          loginService,
-          authenticated,
-        },
-      },
-    });
+    const wrapper = shallowMount(Error, mountOptions);
     error = wrapper.vm;
+<%_ if (generateUserManagement) { _%>
+    login = useLoginModal();
+<%_ } _%>
 
     expect(error.errorMessage).toBeNull();
     expect(error.error403).toBeTruthy();
     expect(error.error404).toBeFalsy();
-<%_ if (!authenticationTypeOauth2) { _%>
-    expect(loginService.openLogin).toHaveBeenCalled();
+<%_ if (generateUserManagement) { _%>
+    expect(login.showLogin).toHaveBeenCalled();
 <%_ } else { _%>
     expect(loginService.login).toHaveBeenCalled();
 <%_ } _%>
@@ -91,42 +114,34 @@ describe('Error component', () => {
     route = {
       meta: { error404: true },
     };
-    const wrapper = shallowMount(Error, {
-      global: {
-        provide: {
-          loginService,
-          authenticated,
-        },
-      },
-    });
+    const wrapper = shallowMount(Error, mountOptions);
     error = wrapper.vm;
+<%_ if (generateUserManagement) { _%>
+    login = useLoginModal();
+<%_ } _%>
 
     expect(error.errorMessage).toBeNull();
     expect(error.error403).toBeFalsy();
     expect(error.error404).toBeTruthy();
-<%_ if (!authenticationTypeOauth2) { _%>
-    expect(loginService.openLogin).toHaveBeenCalledTimes(0);
+<%_ if (generateUserManagement) { _%>
+    expect(login.showLogin).toHaveBeenCalledTimes(0);
 <%_ } else { _%>
     expect(loginService.login).toHaveBeenCalledTimes(0);
 <%_ } _%>
   });
 
   it('should have set default on no error', () => {
-    const wrapper = shallowMount(Error, {
-      global: {
-        provide: {
-          loginService,
-          authenticated,
-        },
-      },
-    });
+    const wrapper = shallowMount(Error, mountOptions);
     error = wrapper.vm;
+<%_ if (generateUserManagement) { _%>
+    login = useLoginModal();
+<%_ } _%>
 
     expect(error.errorMessage).toBeNull();
     expect(error.error403).toBeFalsy();
     expect(error.error404).toBeFalsy();
-<%_ if (!authenticationTypeOauth2) { _%>
-    expect(loginService.openLogin).toHaveBeenCalledTimes(0);
+<%_ if (generateUserManagement) { _%>
+    expect(login.showLogin).toHaveBeenCalledTimes(0);
 <%_ } else { _%>
     expect(loginService.login).toHaveBeenCalledTimes(0);
 <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/core/error/error.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/error/error.component.ts.ejs
@@ -1,15 +1,41 @@
-import { type ComputedRef, defineComponent, inject, type Ref, ref } from 'vue';
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { type ComputedRef, type Ref, defineComponent, inject, ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n';
 <%_ } _%>
-import type LoginService from '@/account/login.service';
 import { useRoute } from 'vue-router';
+<%_ if (authenticationTypeOauth2) { _%>
+import type LoginService from '@/account/login.service';
+<%_ } else { _%>
+import { useLoginModal } from '@/account/login-modal';
+<%_ } _%>
 
 export default defineComponent({
   compatConfig: { MODE: 3 },
   name: 'Error',
   setup() {
-    const loginService = inject<LoginService>('loginService');
+<%_ if (authenticationTypeOauth2) { _%>
+    const { login } = inject<LoginService>('loginService');
+<%_ } else { _%>
+    const { showLogin } = useLoginModal();
+<%_ } _%>
     const authenticated = inject<ComputedRef<boolean>>('authenticated');
     const errorMessage: Ref<string> = ref(null);
     const error403: Ref<boolean> = ref(false);
@@ -21,11 +47,7 @@ export default defineComponent({
       error403.value = route.meta.error403 ?? false;
       error404.value = route.meta.error404 ?? false;
       if (!authenticated.value && error403.value) {
-<%_ if (!authenticationTypeOauth2) { _%>
-        loginService.openLogin();
-<%_ } else { %>
-        loginService.login();
-<%_ } %>
+        <% if (authenticationTypeOauth2) { %>login<% } else { %>showLogin<% } %>();
       }
     }
 

--- a/generators/vue/templates/src/main/webapp/app/core/home/home.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/home/home.component.spec.ts.ejs
@@ -1,6 +1,28 @@
-import { vitest } from 'vitest';
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { beforeEach, describe, expect, it } from 'vitest';
 import { ref } from 'vue';
 import { shallowMount } from '@vue/test-utils';
+<%_ if (!authenticationTypeOauth2) { _%>
+import { createTestingPinia } from '@pinia/testing';
+import { useLoginModal } from '@/account/login-modal';
+<%_ } _%>
 import Home from './home.vue';
 
 type HomeComponentType = InstanceType<typeof Home>;
@@ -9,30 +31,37 @@ describe('Home', () => {
   let home: HomeComponentType;
   let authenticated;
   let currentUsername;
-<%_ if (authenticationTypeJwt) { _%>
-  const loginService = { openLogin: vitest.fn() };
-<%_ } else if (authenticationTypeSession) { _%>
-  const loginService = { openLogin: vitest.fn(), logout: vitest.fn() };
-<%_ } else if (authenticationTypeOauth2) { _%>
-  const loginService = { login: vitest.fn(), logout: vitest.fn() };
+<%_ if (!authenticationTypeOauth2) { _%>
+  let login: ReturnType<typeof useLoginModal>;
 <%_ } _%>
 
+<%_ if (authenticationTypeOauth2) { _%>
+  const loginService = { login: vitest.fn(), logout: vitest.fn() };
+<%_ } _%>
   beforeEach(() => {
     authenticated = ref(false);
     currentUsername = ref('');
     const wrapper = shallowMount(Home, {
       global: {
+<%_ if (!authenticationTypeOauth2) { _%>
+        plugins: [createTestingPinia()],
+<%_ } _%>
         stubs: {
           'router-link': true,
         },
         provide: {
+<%_ if (authenticationTypeOauth2) { _%>
           loginService,
+<%_ } _%>
           authenticated,
           currentUsername,
         },
       },
     });
     home = wrapper.vm;
+<%_ if (!authenticationTypeOauth2) { _%>
+    login = useLoginModal();
+<%_ } _%>
   });
 
   it('should not have user data set', () => {
@@ -49,12 +78,13 @@ describe('Home', () => {
   });
 
   it('should use login service', () => {
-    home.openLogin();
 
-<%_ if (!authenticationTypeOauth2) { _%>
-    expect(loginService.openLogin).toHaveBeenCalled();
-<%_ } else { %>
+<%_ if (authenticationTypeOauth2) { _%>
+    home.login();
     expect(loginService.login).toHaveBeenCalled();
+<%_ } else { %>
+    home.showLogin();
+    expect(login.showLogin).toHaveBeenCalled();
 <%_ } %>
   });
 });

--- a/generators/vue/templates/src/main/webapp/app/core/home/home.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/home/home.component.ts.ejs
@@ -3,28 +3,27 @@ import { type ComputedRef, defineComponent, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
 <%_ } _%>
 
+<%_ if (authenticationTypeOauth2) { _%>
 import type LoginService from '@/account/login.service';
+<%_ } else { _%>
+import { useLoginModal } from '@/account/login-modal';
+<%_ } _%>
 
 export default defineComponent({
   compatConfig: { MODE: 3 },
   setup() {
-    const loginService = inject<LoginService>('loginService');
-
+<%_ if (authenticationTypeOauth2) { _%>
+    const { login } = inject<LoginService>('loginService');
+<%_ } else { _%>
+    const { showLogin } = useLoginModal();
+<%_ } _%>
     const authenticated = inject<ComputedRef<boolean>>('authenticated');
     const username = inject<ComputedRef<string>>('currentUsername');
-
-    const openLogin = () => {
-<%_ if (!authenticationTypeOauth2) { _%>
-      loginService.openLogin();
-<%_ } else { %>
-      loginService.login();
-<%_ } _%>
-    };
 
     return {
       authenticated,
       username,
-      openLogin,
+      <% if (authenticationTypeOauth2) { %>login<% } else { %>showLogin<% } %>,
 <%_ if (enableTranslation) { _%>
       t$: useI18n().t,
 <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/core/home/home.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/home/home.vue.ejs
@@ -14,7 +14,7 @@
 
         <div class="alert alert-warning" v-if="!authenticated">
           <span v-text="t$('global.messages.info.authenticated.prefix')">If you want to </span>
-          <a class="alert-link" @click="openLogin()" v-text="t$('global.messages.info.authenticated.link')">sign in</a
+          <a class="alert-link" @click="<% if (authenticationTypeOauth2) { %>login<% } else { %>showLogin<% } %>()" v-text="t$('global.messages.info.authenticated.link')">sign in</a
           ><span v-html="t$('global.messages.info.authenticated.suffix')"
             >, you can try the default accounts:<br />- Administrator (login="admin" and password="admin") <br />- User (login="user" and
             password="user").</span

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -1,14 +1,36 @@
+<%#
+ Copyright 2013-2025 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import { vitest } from 'vitest';
 import { computed } from 'vue';
 import { shallowMount } from '@vue/test-utils';
-import JhiNavbar from './jhi-navbar.vue';
 import { type Router } from 'vue-router';
 import { createTestingPinia } from '@pinia/testing';
 
 import { useStore } from '@/store';
 import { createRouter } from '@/router';
-import <% if (authenticationTypeOauth2) { %>type <% } %>LoginService from '@/account/login.service';
-
+<%_ if (authenticationUsesCsrf) { _%>
+import type LoginService from '@/account/login.service';
+<%_ } _%>
+<%_ if (generateUserManagement) { _%>
+import { useLoginModal } from '@/account/login-modal';
+<%_ } _%>
+import JhiNavbar from './jhi-navbar.vue';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
 
 vitest.mock('@module-federation/enhanced/runtime', () => ({
@@ -23,7 +45,12 @@ const store = useStore();
 
 describe('JhiNavbar', () => {
   let jhiNavbar: JhiNavbarComponentType;
+<%_ if (authenticationUsesCsrf) { _%>
   let loginService: LoginService;
+<%_ } _%>
+<%_ if (generateUserManagement) { _%>
+  let login: ReturnType<typeof useLoginModal>;
+<%_ } _%>
   const accountService = { hasAnyAuthorityAndCheckAuth: vitest.fn().mockImplementation(() => Promise.resolve(true)) };
 <%_ if (enableTranslation) { _%>
   const changeLanguage = vitest.fn();
@@ -32,14 +59,7 @@ describe('JhiNavbar', () => {
 
   beforeEach(() => {
     router = createRouter();
-<%_ if (authenticationTypeJwt) { _%>
-    loginService = new LoginService({ emit: vitest.fn() });
-    vitest.spyOn(loginService, 'openLogin');
-<%_ } else if (authenticationTypeSession) { _%>
-    loginService = new LoginService({ emit: vitest.fn() });
-    vitest.spyOn(loginService, 'openLogin');
-    vitest.spyOn(loginService, 'logout');
-<%_ } else if (authenticationTypeOauth2) { _%>
+<%_ if (authenticationUsesCsrf) { _%>
     loginService = { login: vitest.fn(), logout: vitest.fn() };
 <%_ } _%>
     const wrapper = shallowMount(JhiNavbar, {
@@ -57,7 +77,9 @@ describe('JhiNavbar', () => {
           'b-navbar-brand': true,
         },
         provide: {
+<%_ if (authenticationUsesCsrf) { _%>
           loginService,
+<%_ } _%>
           currentLanguage: computed(() => 'foo'),
 <%_ if (enableTranslation) { _%>
           changeLanguage,
@@ -67,6 +89,9 @@ describe('JhiNavbar', () => {
       },
     });
     jhiNavbar = wrapper.vm;
+<%_ if (generateUserManagement) { _%>
+    login = useLoginModal();
+<%_ } _%>
   });
 
   it('should not have user data set', () => {
@@ -89,11 +114,12 @@ describe('JhiNavbar', () => {
   });
 
   it('should use login service', () => {
-    jhiNavbar.openLogin();
-<%_ if (!authenticationTypeOauth2) { _%>
-    expect(loginService.openLogin).toHaveBeenCalled();
-<%_ } else { _%>
+    jhiNavbar.<% if (authenticationTypeOauth2) { %>login<% } else { %>showLogin<% } %>();
+
+<%_ if (authenticationTypeOauth2) { _%>
     expect(loginService.login).toHaveBeenCalled();
+<%_ } else { _%>
+    expect(login.showLogin).toHaveBeenCalled();
 <%_ } _%>
   });
 
@@ -108,9 +134,10 @@ describe('JhiNavbar', () => {
 <%_ if (authenticationTypeOauth2) { _%>
     const logoutUrl = '/to-match';
     (loginService.logout as any).mockReturnValue(Promise.resolve({ data: { logoutUrl } }));
-<%_ } else if (!authenticationTypeJwt) { _%>
+<%_ } else if (authenticationUsesCsrf) { _%>
     (loginService.logout as any).mockReturnValue(Promise.resolve({}));
 <%_ } _%>
+
     await jhiNavbar.logout();
 
 <%_ if (!authenticationTypeJwt) { _%>

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -2,7 +2,12 @@ import { computed, <% if (applicationTypeGateway && microfrontend) { %>defineAsy
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n';
 <%_ } _%>
+<%_ if (authenticationUsesCsrf) { _%>
 import type LoginService from '@/account/login.service';
+<%_ } %>
+<%_ if (generateUserManagement) { %>
+import { useLoginModal } from '@/account/login-modal';
+<%_ } _%>
 import type AccountService from '@/account/account.service';
 <%_ if (enableTranslation) { _%>
 import languages from '@/shared/config/languages';
@@ -30,7 +35,15 @@ export default defineComponent({
 <%_ } _%>
   },
   setup() {
+<%_ if (authenticationUsesCsrf) { _%>
     const loginService = inject<LoginService>('loginService');
+  <%_ if (authenticationTypeOauth2) { _%>
+    const { login } = loginService;
+  <%_ } %>
+<%_ } %>
+<%_ if (generateUserManagement) { %>
+    const { showLogin } = useLoginModal();
+<%_ } _%>
     const accountService = inject<AccountService>('accountService');
     const currentLanguage = inject('currentLanguage', () => computed(() => navigator.language ?? '<%- nativeLanguage %>'), true);
 <%_ if (enableTranslation) { _%>
@@ -50,14 +63,6 @@ export default defineComponent({
     const openAPIEnabled = computed(() => store.activeProfiles.indexOf('api-docs') > -1);
     const inProduction = computed(() => store.activeProfiles.indexOf('prod') > -1);
     const authenticated = computed(() => store.authenticated);
-
-    const openLogin = () => {
-<%_ if (!authenticationTypeOauth2) { _%>
-      loginService.openLogin();
-<%_ } else { %>
-      loginService.login();
-<%_ } _%>
-    };
 
     const subIsActive = (input: string | string[]) => {
       const paths = Array.isArray(input) ? input : [input];
@@ -95,7 +100,7 @@ export default defineComponent({
       logout,
       subIsActive,
       accountService,
-      openLogin,
+      <% if (authenticationTypeOauth2) { %>login<% } else { %>showLogin<% } %>,
 <%_ if (enableTranslation) { _%>
       changeLanguage,
       languages: languages(),

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue.ejs
@@ -152,7 +152,7 @@
             <font-awesome-icon icon="sign-out-alt" />
             <span v-text="t$('global.menu.account.logout')">Sign out</span>
           </b-dropdown-item>
-          <b-dropdown-item data-cy="login" v-if="!authenticated" @click="openLogin()" id="login" active-class="active">
+          <b-dropdown-item data-cy="login" v-if="!authenticated" @click="showLogin()" id="login" active-class="active">
             <font-awesome-icon icon="sign-in-alt" />
             <span v-text="t$('global.menu.account.login')">Sign in</span>
           </b-dropdown-item>

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -11,12 +11,17 @@ import { setupAxiosInterceptors } from '@/shared/config/axios-interceptor';
 
 import App from './app.vue';
 import router<% if (applicationTypeGateway && microfrontend) { %>, { lazyRoutes }<% } %> from './router';
-import { initFortAwesome<% if (enableTranslation) { %>, initI18N<% } %> } from './shared/config/config';
-import { initBootstrapVue } from './shared/config/config-bootstrap-vue';
-import JhiItemCountComponent from './shared/jhi-item-count.vue';
-import JhiSortIndicatorComponent from './shared/sort/jhi-sort-indicator.vue';
-import LoginService from './account/login.service';
-import AccountService from './account/account.service';
+import { initFortAwesome<% if (enableTranslation) { %>, initI18N<% } %> } from '@/shared/config/config';
+import { initBootstrapVue } from '@/shared/config/config-bootstrap-vue';
+import JhiItemCountComponent from '@/shared/jhi-item-count.vue';
+import JhiSortIndicatorComponent from '@/shared/sort/jhi-sort-indicator.vue';
+<%_ if (authenticationUsesCsrf) { _%>
+import LoginService from '@/account/login.service';
+<%_ } _%>
+<%_ if (generateUserManagement) { _%>
+import { useLoginModal } from '@/account/login-modal';
+<%_ } _%>
+import AccountService from '@/account/account.service';
 
 import '../content/scss/global.scss';
 import '../content/scss/vendor.scss';
@@ -86,13 +91,12 @@ const app = createApp({
   compatConfig: { MODE: 3 },
   components: { App },
   template: '<App/>',
-<%_ if (!authenticationTypeOauth2) { _%>
-  setup(_props, { emit }) {
-    const loginService = new LoginService({ emit });
-    provide('loginService', loginService);
-<%_ } else { _%>
   setup() {
+<%_ if (authenticationUsesCsrf) { _%>
     provide('loginService', new LoginService());
+<%_ } _%>
+<%_ if (generateUserManagement) { _%>
+    const { hideLogin, showLogin } = useLoginModal();
 <%_ } _%>
     const store = useStore();
     const accountService = new AccountService(store);
@@ -143,7 +147,7 @@ const app = createApp({
     router.beforeResolve(async (to, from, next) => {
 <%_ if (!authenticationTypeOauth2) { _%>
       // Make sure login modal is closed
-      loginService.hideLogin();
+      hideLogin();
 
 <%_ } _%>
       if (!store.authenticated) {
@@ -173,7 +177,7 @@ const app = createApp({
 <%_ if (authenticationTypeOauth2) { _%>
             window.location.reload();
 <%_ } else { _%>
-            loginService.openLogin();
+            showLogin();
 <%_ } _%>
             return;
           }


### PR DESCRIPTION
…f global events

Related to https://github.com/jhipster/generator-jhipster/issues/23865.

BootstrapVueNext dropped modal handling using events.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
