### PR TITLE
cli: remove jhipster 8 warning

### DIFF
--- a/cli/cli.mjs
+++ b/cli/cli.mjs
@@ -16,19 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { dirname, join, relative } from 'path';
-import { fileURLToPath } from 'url';
-import { existsSync } from 'fs';
 import semver from 'semver';
-import chalk from 'chalk';
 
 import { packageJson } from '../lib/index.js';
 import { runJHipster } from './program.mjs';
 import { done, logger } from './utils.mjs';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 const currentNodeVersion = process.versions.node;
 const minimumNodeVersion = packageJson.engines.node;
@@ -37,16 +29,6 @@ if (!process.argv.includes('--skip-checks') && !semver.satisfies(currentNodeVers
   logger.fatal(
     `You are running Node version ${currentNodeVersion}.\nJHipster requires Node version ${minimumNodeVersion}.\nPlease update your version of Node.`,
   );
-}
-
-const appFolderOrWorkspaceRoot = existsSync('../node_modules') ? join(process.cwd(), '..') : process.cwd();
-// If this file is not inside app npm repository and the executable exists inside the repository show warning.
-if (
-  relative(appFolderOrWorkspaceRoot, __dirname).startsWith('..') &&
-  existsSync(join(appFolderOrWorkspaceRoot, 'node_modules/.bin/jhipster'))
-) {
-  logger.warn(`Since JHipster v8, the jhipster command will not use the locally installed generator-jhipster.
-    If you want to execute the locally installed generator-jhipster, run: ${chalk.yellow('npx jhipster')}`);
 }
 
 export default runJHipster().catch(done);


### PR DESCRIPTION
We have the warning in place for long enough.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
