### PR TITLE
java: revert supported java version to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following Java and Node combinations are tested and verified by GitHub Actio
 
 | Java     | Node     | Status |
 | -------- | -------- | ------ |
-| 17/21/23 | 18/20/22 | ✅     |
+| 17/21/24 | 18/20/22 | ✅     |
 
 ## Sponsors
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -26,7 +26,7 @@ export const JHIPSTER_DEPENDENCIES_VERSION = '8.10.0';
 // Version of Java
 export const JAVA_VERSION = '17';
 // Supported Java versions, https://www.oracle.com/java/technologies/java-se-support-roadmap.html
-export const JAVA_COMPATIBLE_VERSIONS = ['17', '21', '23'];
+export const JAVA_COMPATIBLE_VERSIONS = ['17', '21', '24'];
 // Force spring milestone repository. Spring Boot milestones are detected.
 export const ADD_SPRING_MILESTONE_REPOSITORY = false;
 


### PR DESCRIPTION
Switch to latest java to 24.

Depends on https://github.com/jhipster/generator-jhipster/pull/29325.

Reverts jhipster/generator-jhipster#29123