### PR TITLE
cypress: adjusts to logout test

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/logout.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/logout.cy.ts.ejs
@@ -26,13 +26,21 @@ describe('logout', () => {
   const username = Cypress.env('E2E_USERNAME') ?? '<%- generateInMemoryUserCredentials ? 'admin' : 'user' %>';
   const password = Cypress.env('E2E_PASSWORD') ?? '<%- generateInMemoryUserCredentials ? 'admin' : 'user' %>';
 
+<%_ if (authenticationUsesCsrf) { _%>
+  beforeEach(() => {
+    cy.intercept('POST', '/api/logout').as('logout');
+  });
+
+<%_ } _%>
   it<%- clientFrameworkReact ? '.skip' : '' %>('go to home page when successfully logs out', () => {
     cy.login(username, password);
     cy.visit('');
+
     cy.clickOnLogoutItem();
-    // Wait logout
-    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
-    cy.visit('');
+
+<%_ if (authenticationUsesCsrf) { _%>
+    cy.wait('@logout');
+<%_ } _%>
     cy.get(navbarSelector).get(accountMenuSelector).click();
     cy.get(navbarSelector).get(accountMenuSelector).get(loginItemSelector).should('be.visible');
   });


### PR DESCRIPTION
Remove `cy.wait()`
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
