### PR TITLE
Fix: bump prettier-plugin-packagejson from 2.5.10 to 2.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "pluralize": "8.0.0",
         "prettier": "3.5.3",
         "prettier-plugin-java": "2.6.7",
-        "prettier-plugin-packagejson": "2.5.10",
+        "prettier-plugin-packagejson": "2.5.11",
         "prettier-plugin-properties": "0.3.0",
         "randexp": "0.5.3",
         "semver": "7.7.1",
@@ -3202,7 +3202,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
       "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -6975,6 +6974,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
       "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7012,9 +7012,9 @@
       }
     },
     "node_modules/git-hooks-list": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.2.0.tgz",
-      "integrity": "sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.1.1.tgz",
+      "integrity": "sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
@@ -10559,13 +10559,13 @@
       }
     },
     "node_modules/prettier-plugin-packagejson": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.10.tgz",
-      "integrity": "sha512-LUxATI5YsImIVSaaLJlJ3aE6wTD+nvots18U3GuQMJpUyClChaZlQrqx3dBnbhF20OnKWZyx8EgyZypQtBDtgQ==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.11.tgz",
+      "integrity": "sha512-BJpXSrQhrewmeRxe1e/BYrWyrBG4yc+RaearWGdNwcUnHZQUffFVqPsXyB7tQA7WFeBRgh3wadXb9p2BPuLKvw==",
       "license": "MIT",
       "dependencies": {
-        "sort-package-json": "2.15.1",
-        "synckit": "0.9.2"
+        "sort-package-json": "3.2.0",
+        "synckit": "0.11.4"
       },
       "peerDependencies": {
         "prettier": ">= 1.16.0"
@@ -10574,34 +10574,6 @@
         "prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/prettier-plugin-packagejson/node_modules/@pkgr/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
-      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/prettier-plugin-packagejson/node_modules/synckit": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
-      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/prettier-plugin-properties": {
@@ -11594,19 +11566,18 @@
       "license": "MIT"
     },
     "node_modules/sort-package-json": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.15.1.tgz",
-      "integrity": "sha512-9x9+o8krTT2saA9liI4BljNjwAbvUnWf11Wq+i/iZt8nl2UGYnf3TH5uBydE7VALmP7AGwlfszuEeL8BDyb0YA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.2.0.tgz",
+      "integrity": "sha512-jadbj4vvIlevL578X5+1qVX/Nn9Jk7/U+cLVjR1IqfDFo3ISY0eoyksd3ylyTwGunlEMUgbTRYowLr0CkSxcQw==",
       "license": "MIT",
       "dependencies": {
         "detect-indent": "^7.0.1",
-        "detect-newline": "^4.0.0",
-        "get-stdin": "^9.0.0",
-        "git-hooks-list": "^3.0.0",
+        "detect-newline": "^4.0.1",
+        "git-hooks-list": "^4.0.0",
         "is-plain-obj": "^4.1.0",
-        "semver": "^7.6.0",
+        "semver": "^7.7.1",
         "sort-object-keys": "^1.1.3",
-        "tinyglobby": "^0.2.9"
+        "tinyglobby": "^0.2.12"
       },
       "bin": {
         "sort-package-json": "cli.js"
@@ -11948,7 +11919,6 @@
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
       "integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@pkgr/core": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
     "update-snapshot": "esmocha --no-insight --no-parallel --update-snapshot --",
     "update-snapshots": "esmocha lib/jdl generators cli .blueprint --update-snapshot --no-insight --forbid-only"
   },
+  "overrides": {
+    "ejs-lint": {
+      "ejs": "$ejs"
+    }
+  },
   "dependencies": {
     "@eslint/js": "9.26.0",
     "@faker-js/faker": "9.7.0",
@@ -160,7 +165,7 @@
     "pluralize": "8.0.0",
     "prettier": "3.5.3",
     "prettier-plugin-java": "2.6.7",
-    "prettier-plugin-packagejson": "2.5.10",
+    "prettier-plugin-packagejson": "2.5.11",
     "prettier-plugin-properties": "0.3.0",
     "randexp": "0.5.3",
     "semver": "7.7.1",
@@ -214,10 +219,5 @@
     "type": "opencollective",
     "url": "https://opencollective.com/generator-jhipster",
     "logo": "https://opencollective.com/opencollective/logo.txt"
-  },
-  "overrides": {
-    "ejs-lint": {
-      "ejs": "$ejs"
-    }
   }
 }


### PR DESCRIPTION
Fix #29387 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
