### PR TITLE
update Okta instructions in generated READMEs

### DIFF
--- a/generators/spring-boot/templates/README.md.jhi.spring-boot.ejs
+++ b/generators/spring-boot/templates/README.md.jhi.spring-boot.ejs
@@ -104,19 +104,7 @@ When using Kubernetes, importing should be done using init-containers (with a vo
 
 ### Okta
 
-If you'd like to use Okta instead of Keycloak, it's pretty quick using the [Okta CLI](https://cli.okta.com/). After you've installed it, run:
-
-```shell
-okta register
-```
-
-Then, in your JHipster app's directory, run `okta apps create` and select **JHipster**. This will set up an Okta app for you, create `ROLE_ADMIN` and `ROLE_USER` groups, create a `.okta.env` file with your Okta settings, and configure a `groups` claim in your ID token.
-
-Run `source .okta.env` and start your app with Maven or Gradle. You should be able to sign in with the credentials you registered with.
-
-If you're on Windows, you should install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) so the `source` command will work.
-
-If you'd like to configure things manually through the Okta developer console, see the instructions below.
+If you'd like to use Okta instead of Keycloak, it's pretty quick. 
 
 First, you'll need to create a free developer account at <https://developer.okta.com/signup/>. After doing so, you'll get your own Okta domain, that has a name like `https://dev-123456.okta.com`.
 


### PR DESCRIPTION
Upcoming changes to Okta's free plan offerings will cause the old instructions to not work. This PR removes the part of the instructions which is impacted while not touching the alternative instructions that will continue to work as before. 

More information on free plan changes at https://developer.okta.com/blog/2025/05/13/okta-developer-edition-changes

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary -- n/a
- [ ] The JDL part is updated if necessary -- n/a?
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary -- n/a
- [ ] Documentation is added/updated where necessary -- this updates docs
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
