### PR TITLE
internal: move stateful isJhipsterVersionLessThan to control

### DIFF
--- a/generators/angular/cleanup.ts
+++ b/generators/angular/cleanup.ts
@@ -25,19 +25,19 @@ import { CLIENT_WEBPACK_DIR } from '../generator-constants.js';
  * need to be removed.
  */
 
-export default asWritingTask(function cleanupOldFilesTask(this, { application }) {
-  if (this.isJhipsterVersionLessThan('3.2.0')) {
+export default asWritingTask(function cleanupOldFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('3.2.0')) {
     // removeFile and removeFolder methods should be called here for files and folders to cleanup
     this.removeFile(`${application.clientSrcDir}app/components/form/uib-pager.config.js`);
     this.removeFile(`${application.clientSrcDir}app/components/form/uib-pagination.config.js`);
   }
-  if (this.isJhipsterVersionLessThan('3.11.0')) {
+  if (control.isJhipsterVersionLessThan('3.11.0')) {
     this.removeFile(`${application.clientSrcDir}app/layouts/navbar/active-link.directive.js`);
   }
-  if (this.isJhipsterVersionLessThan('4.11.1')) {
+  if (control.isJhipsterVersionLessThan('4.11.1')) {
     this.removeFile(`${application.clientSrcDir}app/app.main-aot.ts`);
   }
-  if (this.isJhipsterVersionLessThan('5.0.0')) {
+  if (control.isJhipsterVersionLessThan('5.0.0')) {
     this.removeFile(`${application.clientSrcDir}app//app.route.ts`);
     this.removeFile(`${application.clientSrcDir}app/shared/auth/account.service.ts`);
     this.removeFile(`${application.clientSrcDir}app/shared/auth/auth-jwt.service.ts`);
@@ -63,16 +63,16 @@ export default asWritingTask(function cleanupOldFilesTask(this, { application })
     this.removeFile(`${application.clientTestDir}spec/entry.ts`);
     this.removeFile(`${application.clientTestDir}karma.conf.js`);
   }
-  if (this.isJhipsterVersionLessThan('5.8.0')) {
+  if (control.isJhipsterVersionLessThan('5.8.0')) {
     this.removeFile(`${application.clientSrcDir}app/admin/metrics/metrics-modal.component.html`);
     this.removeFile(`${application.clientSrcDir}app/admin/metrics/metrics-modal.component.ts`);
     this.removeFile(`${application.clientTestDir}spec/app/admin/metrics/metrics-modal.component.spec.ts`);
   }
-  if (this.isJhipsterVersionLessThan('6.0.0')) {
+  if (control.isJhipsterVersionLessThan('6.0.0')) {
     this.removeFolder(`${application.clientSrcDir}app/shared/layout/header/menus`);
     this.removeFolder(`${application.clientTestDir}spec/app/shared/layout/header/menus`);
   }
-  if (this.isJhipsterVersionLessThan('6.3.0')) {
+  if (control.isJhipsterVersionLessThan('6.3.0')) {
     this.removeFile(`${application.clientSrcDir}app/account/index.ts`);
     this.removeFile(`${application.clientSrcDir}app/admin/index.ts`);
     this.removeFile(`${application.clientSrcDir}app/core/index.ts`);
@@ -81,17 +81,17 @@ export default asWritingTask(function cleanupOldFilesTask(this, { application })
     this.removeFile(`${application.clientSrcDir}app/shared/index.ts`);
     this.removeFile(`${application.clientSrcDir}app/shared/shared-common.module.ts`);
   }
-  if (this.isJhipsterVersionLessThan('6.4.0')) {
+  if (control.isJhipsterVersionLessThan('6.4.0')) {
     this.removeFile(`${application.clientSrcDir}app/admin/admin.route.ts`);
     this.removeFile(`${application.clientSrcDir}app/admin/admin.module.ts`);
   }
-  if (this.isJhipsterVersionLessThan('6.6.1')) {
+  if (control.isJhipsterVersionLessThan('6.6.1')) {
     this.removeFile(`${application.clientSrcDir}app/core/language/language.helper.ts`);
   }
-  if (this.isJhipsterVersionLessThan('6.8.0')) {
+  if (control.isJhipsterVersionLessThan('6.8.0')) {
     this.removeFile(`${application.clientSrcDir}app/tsconfig-aot.json`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.0')) {
     this.removeFile(`${application.clientSrcDir}app/account/password/password-strength-bar.component.ts`);
     this.removeFile(`${application.clientSrcDir}app/account/password/password-strength-bar.scss`);
     this.removeFile(`${application.clientSrcDir}app/admin/docs/docs.scss`);
@@ -235,25 +235,25 @@ export default asWritingTask(function cleanupOldFilesTask(this, { application })
     this.removeFile(`${application.clientTestDir}spec/app/shared/sort/sort.directive.spec.ts`);
     this.removeFile(`${application.clientTestDir}jest.conf.js`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.1')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.1')) {
     this.removeFile(`${application.clientSrcDir}app/core/user/account.model.ts`);
     this.removeFile(`${application.clientSrcDir}app/core/user/user.model.ts`);
     this.removeFile(`${application.clientSrcDir}app/core/user/user.service.ts`);
     this.removeFile(`${application.clientSrcDir}app/core/user/user.service.spec.ts`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.2')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.2')) {
     this.removeFile(`${application.clientSrcDir}app/core/config/config.service.ts`);
     this.removeFile(`${application.clientSrcDir}app/core/config/config.service.spec.ts`);
     this.removeFile('.npmrc');
   }
-  if (this.isJhipsterVersionLessThan('7.1.1')) {
+  if (control.isJhipsterVersionLessThan('7.1.1')) {
     this.removeFile('.npmrc');
   }
 
-  if (this.isJhipsterVersionLessThan('7.6.1')) {
+  if (control.isJhipsterVersionLessThan('7.6.1')) {
     this.removeFile(`${application.clientSrcDir}content/scss/rtl.scss`);
   }
-  if (this.isJhipsterVersionLessThan('7.10.0')) {
+  if (control.isJhipsterVersionLessThan('7.10.0')) {
     this.removeFile('.browserslistrc');
     this.removeFile(`${application.clientSrcDir}polyfills.ts`);
     this.removeFile(`${application.clientSrcDir}app/admin/user-management/user-management.module.ts`);
@@ -280,14 +280,14 @@ export default asWritingTask(function cleanupOldFilesTask(this, { application })
     this.removeFile(`${application.clientSrcDir}app/admin/tracker/tracker.module.ts`);
     this.removeFile(`${application.clientSrcDir}app/account/account.module.ts`);
   }
-  if (this.isJhipsterVersionLessThan('8.0.1')) {
+  if (control.isJhipsterVersionLessThan('8.0.1')) {
     this.removeFile(`${application.clientSrcDir}app/layouts/main/main.module.ts`);
     this.removeFile(`${application.clientSrcDir}app/admin/admin-routing.module.ts`);
     this.removeFile(`${application.clientSrcDir}app/app.module.ts`);
     this.removeFile(`${application.clientSrcDir}app/app-routing.module.ts`);
     this.removeFile(`${application.clientSrcDir}app/entities/entity-routing.module.ts`);
   }
-  if (this.isJhipsterVersionLessThan('8.1.1')) {
+  if (control.isJhipsterVersionLessThan('8.1.1')) {
     this.removeFile(`${application.clientSrcDir}app/entities/user/user.service.ts`);
     this.removeFile(`${application.clientSrcDir}app/entities/user/user.service.spec.ts`);
   }

--- a/generators/angular/entity-files-angular.ts
+++ b/generators/angular/entity-files-angular.ts
@@ -136,18 +136,18 @@ export const postWriteEntitiesFiles = asPostWritingEntitiesTask(async function (
   source.addEntitiesToClient({ ...taskParam, entities });
 });
 
-export const cleanupEntitiesFiles = asWritingEntitiesTask(function ({ application, entities }) {
+export const cleanupEntitiesFiles = asWritingEntitiesTask(function ({ application, entities, control }) {
   for (const entity of (application.filterEntitiesForClient ?? filterEntitiesForClient)(entities).filter(entity => !entity.builtIn)) {
     const { entityFolderName, entityFileName, name: entityName } = entity;
-    if (this.isJhipsterVersionLessThan('5.0.0')) {
+    if (control.isJhipsterVersionLessThan('5.0.0')) {
       this.removeFile(`${application.clientSrcDir}app/entities/${entityName}/${entityName}.model.ts`);
     }
 
-    if (this.isJhipsterVersionLessThan('6.3.0')) {
+    if (control.isJhipsterVersionLessThan('6.3.0')) {
       this.removeFile(`${application.clientSrcDir}app/entities/${entityFolderName}/index.ts`);
     }
 
-    if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
+    if (control.isJhipsterVersionLessThan('7.0.0-beta.0')) {
       this.removeFile(`${application.clientSrcDir}/app/entities/${entityFolderName}/${entityFileName}.route.ts`);
       this.removeFile(`${application.clientSrcDir}/app/entities/${entityFolderName}/${entityFileName}.component.ts`);
       this.removeFile(`${application.clientSrcDir}/app/entities/${entityFolderName}/${entityFileName}.component.html`);
@@ -177,7 +177,7 @@ export const cleanupEntitiesFiles = asWritingEntitiesTask(function ({ applicatio
       this.removeFile(`${application.clientTestDir}/spec/app/entities/${entityFolderName}/${entityFileName}.service.spec.ts`);
     }
 
-    if (this.isJhipsterVersionLessThan('7.10.0')) {
+    if (control.isJhipsterVersionLessThan('7.10.0')) {
       this.removeFile(`${application.clientSrcDir}app/entities/${entityFolderName}/${entityFileName}.module.ts`);
       this.removeFile(`${application.clientSrcDir}app/entities/${entityFolderName}/route/${entityFileName}-routing.module.ts`);
     }

--- a/generators/app/cleanup.ts
+++ b/generators/app/cleanup.ts
@@ -23,8 +23,8 @@ import { asWritingTask } from '../base-application/support/index.js';
  * Removes files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default asWritingTask(function cleanupOldFilesTask() {
-  if (this.isJhipsterVersionLessThan('6.1.0')) {
+export default asWritingTask(function cleanupOldFilesTask({ control }) {
+  if (control.isJhipsterVersionLessThan('6.1.0')) {
     this.config.delete('blueprint');
     this.config.delete('blueprintVersion');
   }

--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -267,6 +267,10 @@ export default class CoreGenerator extends YeomanGenerator<JHipsterGeneratorOpti
             return control._enviromentHasDockerCompose;
           },
           customizeRemoveFiles,
+          isJhipsterVersionLessThan(version: string): boolean {
+            const jhipsterOldVersion = this.jhipsterOldVersion;
+            return jhipsterOldVersion ? semverLessThan(jhipsterOldVersion, version) : false;
+          },
         };
 
         const removeFiles = async (assertions: { oldVersion?: string; removedInVersion?: string } | string, ...files: string[]) => {
@@ -371,16 +375,6 @@ export default class CoreGenerator extends YeomanGenerator<JHipsterGeneratorOpti
       throw new Error(`${message}
 You can ignore this error by passing '--skip-checks' to jhipster command.`);
     }
-  }
-
-  /**
-   * Check if the JHipster version used to generate an existing project is less than the passed version argument
-   *
-   * @param {string} version - A valid semver version string
-   */
-  isJhipsterVersionLessThan(version: string): boolean {
-    const jhipsterOldVersion = this.control.jhipsterOldVersion;
-    return this.isVersionLessThan(jhipsterOldVersion, version);
   }
 
   /**

--- a/generators/base/types.d.ts
+++ b/generators/base/types.d.ts
@@ -7,7 +7,13 @@ export type Control = {
   reproducibleLiquibaseTimestamp?: Date;
   enviromentHasDockerCompose?: boolean;
   customizeRemoveFiles: ((file: string) => string | undefined)[];
-  removeFiles: (options: { removedInVersion: string } | string, ...files: string[]) => Promise<void>;
+  /**
+   * Check if the JHipster version used to generate an existing project is less than the passed version argument
+   *
+   * @param {string} version - A valid semver version string
+   */
+  isJhipsterVersionLessThan(version: string): boolean;
+  removeFiles: (options: { oldVersion?: string; removedInVersion: string } | string, ...files: string[]) => Promise<void>;
   /**
    * Cleanup files conditionally based on version and condition.
    * @example

--- a/generators/cucumber/cleanup.ts
+++ b/generators/cucumber/cleanup.ts
@@ -16,16 +16,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type Generator from './generator.js';
+import { asWritingTask } from '../base-application/support/task-type-inference.js';
 
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default function cleanupTask(this: Generator, { application }: any) {
-  if (this.isJhipsterVersionLessThan('7.4.2')) {
+export default asWritingTask(function cleanupTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('7.4.2')) {
     this.removeFile(`${application.javaPackageTestDir}cucumber.properties`);
     this.removeFile(`${application.srcTestJava}features/gitkeep`);
     this.removeFile(`${application.srcTestJava}features/user/user.feature`);
   }
-}
+});

--- a/generators/cypress/generator.ts
+++ b/generators/cypress/generator.ts
@@ -151,11 +151,11 @@ export default class CypressGenerator extends BaseApplicationGenerator {
   get writing() {
     return this.asWritingTaskGroup({
       async cleanup({ control, application: { authenticationTypeOauth2, generateUserManagement, cypressDir } }) {
-        if (this.isJhipsterVersionLessThan('7.0.0-beta.1')) {
+        if (control.isJhipsterVersionLessThan('7.0.0-beta.1')) {
           this.removeFile(`${cypressDir}support/keycloak-oauth2.ts`);
           this.removeFile(`${cypressDir}fixtures/users/user.json`);
         }
-        if (this.isJhipsterVersionLessThan('7.8.2')) {
+        if (control.isJhipsterVersionLessThan('7.8.2')) {
           this.removeFile('cypress.json');
           this.removeFile('cypress-audits.json');
 
@@ -192,9 +192,9 @@ export default class CypressGenerator extends BaseApplicationGenerator {
 
   get writingEntities() {
     return this.asWritingEntitiesTaskGroup({
-      cleanupCypressEntityFiles({ application: { cypressDir }, entities }) {
+      cleanupCypressEntityFiles({ application: { cypressDir }, control, entities }) {
         for (const entity of entities) {
-          if (this.isJhipsterVersionLessThan('7.8.2')) {
+          if (control.isJhipsterVersionLessThan('7.8.2')) {
             this.removeFile(`${cypressDir}integration/entity/${entity.entityFileName}.spec.ts`);
           }
         }

--- a/generators/docker-compose/files.ts
+++ b/generators/docker-compose/files.ts
@@ -25,8 +25,8 @@ const { OAUTH2 } = authenticationTypes;
 
 export function writeFiles() {
   return {
-    cleanup() {
-      if (this.isJhipsterVersionLessThan('7.10.0')) {
+    cleanup({ control }) {
+      if (control.isJhipsterVersionLessThan('7.10.0')) {
         this.removeFile('realm-config/jhipster-users-0.json');
       }
     },

--- a/generators/feign-client/cleanup.ts
+++ b/generators/feign-client/cleanup.ts
@@ -16,17 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type BaseGenerator from '../base-core/index.js';
+import { asWritingTask } from '../base-application/support/task-type-inference.js';
 
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default function cleanupTask(this: BaseGenerator, { application }: any) {
-  if (this.isJhipsterVersionLessThan('8.0.1')) {
+export default asWritingTask(function cleanupTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('8.0.1')) {
     if (application.authenticationTypeOauth2) {
       this.removeFile(`${application.javaPackageSrcDir}security/oauth2/AuthorizationHeaderUtil.java`);
       this.removeFile(`${application.javaPackageTestDir}security/oauth2/AuthorizationHeaderUtilTest.java`);
     }
   }
-}
+});

--- a/generators/gatling/cleanup.ts
+++ b/generators/gatling/cleanup.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-import type GatlingGenerator from './generator.js';
+import { asWritingTask } from '../base-application/support/task-type-inference.js';
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default function cleanupTask(this: GatlingGenerator, { application }) {
-  if (this.isJhipsterVersionLessThan('8.1.1')) {
+export default asWritingTask(function cleanupTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('8.1.1')) {
     if (application.buildToolGradle) {
       this.removeFile('gradle/gatling.gradle');
     }
   }
-}
+});

--- a/generators/generate-blueprint/generator.ts
+++ b/generators/generate-blueprint/generator.ts
@@ -275,9 +275,9 @@ export default class extends BaseGenerator {
 
   get postWriting() {
     return this.asPostWritingTaskGroup({
-      upgrade({ application }) {
+      upgrade({ application, control }) {
         if (!this.application[GENERATORS]) return;
-        if (!this.isJhipsterVersionLessThan('8.7.2')) return;
+        if (!control.isJhipsterVersionLessThan('8.7.2')) return;
         for (const generator of Object.keys(this.application[GENERATORS])) {
           const commandFile = `${this.application.blueprintsPath}${generator}/command.${application.blueprintMjsExtension}`;
           this.editFile(commandFile, { ignoreNonExisting: true }, content =>

--- a/generators/gradle/cleanup.ts
+++ b/generators/gradle/cleanup.ts
@@ -16,17 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type BaseGenerator from '../base-core/index.js';
+import { asWritingTask } from '../base-application/support/task-type-inference.js';
 
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default function cleanupOldServerFilesTask(this: BaseGenerator) {
-  if (this.isJhipsterVersionLessThan('5.0.0')) {
+export default asWritingTask(function cleanupOldServerFilesTask({ control }) {
+  if (control.isJhipsterVersionLessThan('5.0.0')) {
     this.removeFile('gradle/mapstruct.gradle');
   }
-  if (this.isJhipsterVersionLessThan('5.2.2')) {
+  if (control.isJhipsterVersionLessThan('5.2.2')) {
     this.removeFile('gradle/liquibase.gradle');
   }
-}
+});

--- a/generators/init/generator.ts
+++ b/generators/init/generator.ts
@@ -51,8 +51,8 @@ export default class InitGenerator extends BaseApplicationGenerator {
 
   get writing() {
     return this.asWritingTaskGroup({
-      cleanup() {
-        if (this.isJhipsterVersionLessThan('7.5.1')) {
+      cleanup({ control }) {
+        if (control.isJhipsterVersionLessThan('7.5.1')) {
           this.removeFile('.lintstagedrc.js');
         }
       },

--- a/generators/languages/generator.ts
+++ b/generators/languages/generator.ts
@@ -153,8 +153,8 @@ export default class LanguagesGenerator extends BaseApplicationGenerator {
   // Public API method used by the getter and also by Blueprints
   get configuring() {
     return this.asConfiguringTaskGroup({
-      migrateLanguages() {
-        if (this.isJhipsterVersionLessThan('7.10.0')) {
+      migrateLanguages({ control }) {
+        if (control.isJhipsterVersionLessThan('7.10.0')) {
           this.migrateLanguages({ in: 'id' });
         }
       },

--- a/generators/maven/cleanup.ts
+++ b/generators/maven/cleanup.ts
@@ -16,14 +16,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type CoreGenerator from '../base-core/index.js';
+import { asWritingTask } from '../base-application/support/task-type-inference.js';
 
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default function cleanupOldServerFilesTask(this: CoreGenerator) {
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+export default asWritingTask(function cleanupOldServerFilesTask({ control }) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     this.removeFile('.mvn/wrapper/MavenWrapperDownloader.java');
   }
-}
+});

--- a/generators/react/cleanup.ts
+++ b/generators/react/cleanup.ts
@@ -23,15 +23,15 @@ import { asWritingTask } from '../base-application/support/task-type-inference.j
  * Removes files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default asWritingTask(function cleanupOldFilesTask({ application }) {
-  if (this.isJhipsterVersionLessThan('6.3.0')) {
+export default asWritingTask(function cleanupOldFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('6.3.0')) {
     this.removeFile('tslint.json');
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.0')) {
     this.removeFile(`${application.clientSrcDir}app/modules/administration/audits/audits.tsx`);
     this.removeFile(`${application.clientTestDir}spec/enzyme-setup.ts`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.1')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.1')) {
     this.removeFile(`${application.clientTestDir}jest.conf.js`);
     this.removeFile(`${application.clientTestDir}spec/icons-mock.ts`);
     this.removeFile(`${application.clientTestDir}spec/storage-mock.ts`);
@@ -55,25 +55,25 @@ export default asWritingTask(function cleanupOldFilesTask({ application }) {
     this.removeFile(`${application.clientTestDir}spec/app/shared/reducers/locale.spec.ts`);
     this.removeFile(`${application.clientTestDir}spec/app/shared/reducers/user-management.spec.ts`);
   }
-  if (this.isJhipsterVersionLessThan('7.1.0')) {
+  if (control.isJhipsterVersionLessThan('7.1.0')) {
     this.removeFile(`${application.clientSrcDir}app/shared/reducers/action-type.util.ts`);
     this.removeFile(`${application.clientSrcDir}app/config/devtools.tsx`);
   }
 
-  if (this.isJhipsterVersionLessThan('7.4.0') && application.enableI18nRTL) {
+  if (control.isJhipsterVersionLessThan('7.4.0') && application.enableI18nRTL) {
     this.removeFile(`${application.clientSrcDir}content/scss/rtl.scss`);
   }
-  if (this.isJhipsterVersionLessThan('7.4.1')) {
+  if (control.isJhipsterVersionLessThan('7.4.1')) {
     this.removeFile('.npmrc');
   }
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     this.removeFile(`${application.clientSrcDir}app/entities/index.tsx`);
   }
-  if (this.isJhipsterVersionLessThan('7.8.2')) {
+  if (control.isJhipsterVersionLessThan('7.8.2')) {
     this.removeFile(`${application.clientSrcDir}app/shared/error/error-boundary-route.tsx`);
     this.removeFile(`${application.clientSrcDir}app/shared/error/error-boundary-route.spec.tsx`);
   }
-  if (this.isJhipsterVersionLessThan('7.9.3')) {
+  if (control.isJhipsterVersionLessThan('7.9.3')) {
     this.removeFile(`${application.clientSrcDir}app/config/translation-middleware.ts`);
   }
 });

--- a/generators/react/entity-files-react.ts
+++ b/generators/react/entity-files-react.ts
@@ -69,13 +69,13 @@ export const postWriteEntitiesFiles = asPostWritingEntitiesTask(async function (
   source.addEntitiesToClient({ application, entities: clientEntities });
 });
 
-export const cleanupEntitiesFiles = asWritingEntitiesTask(function cleanupEntitiesFiles({ application, entities }) {
+export const cleanupEntitiesFiles = asWritingEntitiesTask(function cleanupEntitiesFiles({ application, control, entities }) {
   for (const entity of (application.filterEntitiesForClient ?? filterEntitiesForClient)(entities).filter(
     entity => !entity.builtInUser && !entity.embedded,
   )) {
     const { entityFolderName, entityFileName } = entity;
 
-    if (this.isJhipsterVersionLessThan('7.0.0-beta.1')) {
+    if (control.isJhipsterVersionLessThan('7.0.0-beta.1')) {
       this.removeFile(`${application.clientTestDir}spec/app/entities/${entityFolderName}/${entityFileName}-reducer.spec.ts`);
     }
   }

--- a/generators/server/support/update-languages.ts
+++ b/generators/server/support/update-languages.ts
@@ -18,19 +18,15 @@
  */
 
 import { asPostWritingTask } from '../../base-application/support/task-type-inference.js';
-import type { Language } from '../../languages/support/languages.js';
 
 /**
  * Update Languages In MailServiceIT
  *
  * @param application
  */
-export const updateLanguagesInMailServiceITTask = asPostWritingTask<
-  any,
-  { javaPackageTestDir?: string; languagesDefinition?: readonly Language[] }
->(function updateLanguagesInMailServiceITTask({ application, control }) {
+export const updateLanguagesInMailServiceITTask = asPostWritingTask(function updateLanguagesInMailServiceITTask({ application, control }) {
   const { javaPackageTestDir, languagesDefinition } = application;
-  const { ignoreNeedlesError: ignoreNonExisting } = control;
+  const { ignoreNeedlesError: ignoreNonExisting } = control as any;
   let newContent = 'private static final String[] languages = {\n';
   languagesDefinition?.forEach((language, i) => {
     newContent += `        "${language.languageTag}"${i !== languagesDefinition.length - 1 ? ',' : ''}\n`;
@@ -42,8 +38,6 @@ export const updateLanguagesInMailServiceITTask = asPostWritingTask<
   );
 });
 
-export default asPostWritingTask<any, { javaPackageTestDir?: string; languagesDefinition?: readonly Language[] }>(
-  function updateLanguagesTask(this, taskParam) {
-    updateLanguagesInMailServiceITTask.call(this, taskParam);
-  },
-);
+export default asPostWritingTask(function updateLanguagesTask(this, taskParam) {
+  updateLanguagesInMailServiceITTask.call(this, taskParam);
+});

--- a/generators/spring-boot/cleanup-oauth2.ts
+++ b/generators/spring-boot/cleanup-oauth2.ts
@@ -22,12 +22,12 @@ import { asWritingTask } from '../base-application/support/index.js';
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default asWritingTask(function cleanupOldServerFilesTask(this, { application }) {
-  if (this.isJhipsterVersionLessThan('6.0.0')) {
+export default asWritingTask(function cleanupOldServerFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('6.0.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/OAuth2Configuration.java`);
     this.removeFile(`${application.javaPackageSrcDir}security/OAuth2AuthenticationSuccessHandler.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.6.1')) {
+  if (control.isJhipsterVersionLessThan('7.6.1')) {
     if (!application.databaseTypeNo) {
       this.removeFile(`${application.javaPackageSrcDir}web/rest/UserResource.java`);
     }

--- a/generators/spring-boot/cleanup.ts
+++ b/generators/spring-boot/cleanup.ts
@@ -31,21 +31,21 @@ export default asWritingTask(async function cleanupTask(this, taskParam) {
     cleanupOauth2.call(this, taskParam);
   }
 
-  if (this.isJhipsterVersionLessThan('3.5.0')) {
+  if (control.isJhipsterVersionLessThan('3.5.0')) {
     this.removeFile(`${application.javaPackageSrcDir}domain/util/JSR310DateTimeSerializer.java`);
     this.removeFile(`${application.javaPackageSrcDir}domain/util/JSR310LocalDateDeserializer.java`);
   }
-  if (this.isJhipsterVersionLessThan('3.6.0')) {
+  if (control.isJhipsterVersionLessThan('3.6.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/HerokuDatabaseConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('3.10.0')) {
+  if (control.isJhipsterVersionLessThan('3.10.0')) {
     this.removeFile(`${application.javaPackageSrcDir}security/CustomAccessDeniedHandler.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/filter/CsrfCookieGeneratorFilter.java`);
   }
-  if (this.isJhipsterVersionLessThan('4.0.0')) {
+  if (control.isJhipsterVersionLessThan('4.0.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/locale/AngularCookieLocaleResolver.java`);
   }
-  if (this.isJhipsterVersionLessThan('4.0.0')) {
+  if (control.isJhipsterVersionLessThan('4.0.0')) {
     this.removeFile(`${application.javaPackageSrcDir}async/ExceptionHandlingAsyncTaskExecutor.java`);
     this.removeFile(`${application.javaPackageSrcDir}async/package-info.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/jHipsterProperties.java`);
@@ -68,17 +68,17 @@ export default asWritingTask(async function cleanupTask(this, taskParam) {
     this.removeFile(`${application.javaPackageSrcDir}web/filter/CachingHttpHeadersFilter.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/filter/package-info.java`);
   }
-  if (this.isJhipsterVersionLessThan('4.3.0')) {
+  if (control.isJhipsterVersionLessThan('4.3.0')) {
     this.removeFile(`${application.javaPackageSrcDir}gateway/ratelimiting/RateLimitingRepository.java`);
   }
-  if (this.isJhipsterVersionLessThan('4.7.1')) {
+  if (control.isJhipsterVersionLessThan('4.7.1')) {
     this.removeFile(`${application.javaPackageSrcDir}web/rest/errors/ErrorVM.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/rest/errors/ParameterizedErrorVM.java`);
   }
-  if (this.isJhipsterVersionLessThan('4.13.1')) {
+  if (control.isJhipsterVersionLessThan('4.13.1')) {
     this.config.delete('hibernateCache');
   }
-  if (this.isJhipsterVersionLessThan('5.0.0')) {
+  if (control.isJhipsterVersionLessThan('5.0.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/ThymeleafConfiguration.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/rest/ProfileInfoResource.java`);
     this.removeFile(`${application.srcMainResources}mails/activationEmail.html`);
@@ -88,16 +88,16 @@ export default asWritingTask(async function cleanupTask(this, taskParam) {
     this.removeFile(`${application.srcTestResources}mail/testEmail.html`);
     this.removeFile(`${application.javaPackageSrcDir}web/rest/ProfileInfoResourceIT.java`);
   }
-  if (this.isJhipsterVersionLessThan('5.2.2')) {
+  if (control.isJhipsterVersionLessThan('5.2.2')) {
     if (application.authenticationTypeOauth2 && application.applicationTypeMicroservice) {
       this.removeFolder(`${JAVA_DOCKER_DIR}realm-config`);
       this.removeFile(`${JAVA_DOCKER_DIR}keycloak.yml`);
     }
   }
-  if (this.isJhipsterVersionLessThan('5.8.0')) {
+  if (control.isJhipsterVersionLessThan('5.8.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/MetricsConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('6.0.0')) {
+  if (control.isJhipsterVersionLessThan('6.0.0')) {
     this.removeFile(`${application.javaPackageSrcDir}web/rest/errors/CustomParameterizedException.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/rest/errors/InternalServerErrorException.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/rest/util/PaginationUtil.java`);
@@ -107,25 +107,25 @@ export default asWritingTask(async function cleanupTask(this, taskParam) {
     this.removeFile(`${application.javaPackageSrcDir}web/rest/LogsResource.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/rest/LogsResourceIT.java`);
   }
-  if (this.isJhipsterVersionLessThan('6.5.2')) {
+  if (control.isJhipsterVersionLessThan('6.5.2')) {
     this.removeFile(`${application.javaPackageSrcDir}service/mapper/UserMapperIT.java`);
     this.removeFile(`${application.javaPackageSrcDir}web/rest/ClientForwardControllerIT.java`);
   }
-  if (this.isJhipsterVersionLessThan('6.6.1')) {
+  if (control.isJhipsterVersionLessThan('6.6.1')) {
     this.removeFile(`${application.javaPackageSrcDir}web/rest/errors/EmailNotFoundException.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/DefaultProfileUtil.java`);
     this.removeFolder(`${application.javaPackageSrcDir}service/util`);
   }
-  if (this.isJhipsterVersionLessThan('6.8.0')) {
+  if (control.isJhipsterVersionLessThan('6.8.0')) {
     this.removeFile(`${application.javaPackageSrcDir}security/oauth2/JwtAuthorityExtractor.java`);
   }
-  if (this.isJhipsterVersionLessThan('6.8.1')) {
+  if (control.isJhipsterVersionLessThan('6.8.1')) {
     if (application.reactive) {
       this.removeFile(`${application.javaPackageSrcDir}config/ReactivePageableHandlerMethodArgumentResolver.java`);
       this.removeFile(`${application.javaPackageSrcDir}config/ReactiveSortHandlerMethodArgumentResolver.java`);
     }
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/apidoc/SwaggerConfiguration.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/metrics/package-info.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/metrics/JHipsterHealthIndicatorConfiguration.java`);
@@ -140,28 +140,28 @@ export default asWritingTask(async function cleanupTask(this, taskParam) {
     this.removeFile(`${application.javaPackageSrcDir}web/rest/AuditResourceIT.java`);
     this.removeFile(`${application.javaPackageSrcDir}repository/CustomAuditEventRepositoryIT.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.1')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.1')) {
     this.removeFile(`${application.javaPackageSrcDir}config/CloudDatabaseConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.4.2')) {
+  if (control.isJhipsterVersionLessThan('7.4.2')) {
     this.removeFile(`${application.javaPackageSrcDir}config/apidocs/GatewaySwaggerResourcesProvider.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/apidocs/GatewaySwaggerResourcesProviderTest.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.5.1')) {
+  if (control.isJhipsterVersionLessThan('7.5.1')) {
     if (application.reactive && application.databaseTypeSql) {
       this.removeFile(`${application.javaPackageSrcDir}service/ColumnConverter.java`);
       this.removeFile(`${application.javaPackageSrcDir}service/EntityManager.java`);
       this.removeFile(`${application.javaPackageSrcDir}ArchTest.java`);
     }
   }
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     this.removeFile(`${application.javaPackageSrcDir}TestContainersSpringContextCustomizerFactory.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.8.2')) {
+  if (control.isJhipsterVersionLessThan('7.8.2')) {
     this.removeFile(`${JAVA_DOCKER_DIR}realm-config/jhipster-users-0.json`);
     this.removeFile(`${application.javaPackageSrcDir}NoOpMailConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.10.0')) {
+  if (control.isJhipsterVersionLessThan('7.10.0')) {
     this.removeFile(`${application.srcTestResources}testcontainers.properties`);
     if (application.authenticationTypeJwt) {
       this.removeFile(`${application.javaPackageSrcDir}web/rest/UserJWTController.java`);
@@ -193,19 +193,19 @@ export default asWritingTask(async function cleanupTask(this, taskParam) {
     }
   }
 
-  if (this.isJhipsterVersionLessThan('8.0.1')) {
+  if (control.isJhipsterVersionLessThan('8.0.1')) {
     if (application.authenticationTypeOauth2) {
       this.removeFile(`${application.javaPackageSrcDir}security/oauth2/OAuthIdpTokenResponseDTO.java`);
     }
   }
 
-  if (this.isJhipsterVersionLessThan('8.1.1')) {
+  if (control.isJhipsterVersionLessThan('8.1.1')) {
     if (application.buildToolGradle) {
       this.removeFile('gradle/sonar.gradle');
     }
   }
 
-  if (this.isJhipsterVersionLessThan('8.4.0')) {
+  if (control.isJhipsterVersionLessThan('8.4.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/LocaleConfiguration.java`);
   }
 

--- a/generators/spring-boot/command.ts
+++ b/generators/spring-boot/command.ts
@@ -168,11 +168,7 @@ const command = {
         tokenType: 'BOOLEAN',
       },
       configure: gen => {
-        if (gen.jhipsterConfig.syncUserWithIdp === undefined && gen.jhipsterConfigWithDefaults.authenticationType === OAUTH2) {
-          if (gen.isJhipsterVersionLessThan('8.1.1')) {
-            gen.jhipsterConfig.syncUserWithIdp = true;
-          }
-        } else if (gen.jhipsterConfig.syncUserWithIdp && gen.jhipsterConfig.authenticationType !== OAUTH2) {
+        if (gen.jhipsterConfig.syncUserWithIdp && gen.jhipsterConfig.authenticationType !== OAUTH2) {
           throw new Error('syncUserWithIdp is only supported with authenticationType oauth2');
         }
       },

--- a/generators/spring-boot/entity-cleanup.ts
+++ b/generators/spring-boot/entity-cleanup.ts
@@ -16,9 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApplicationType } from '../../lib/types/application/application.js';
-import type { Entity } from '../../lib/types/application/entity.js';
-import type CoreGenerator from '../base-core/generator.js';
+import { asWritingEntitiesTask } from '../base-application/support/task-type-inference.js';
 
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
@@ -28,20 +26,20 @@ import type CoreGenerator from '../base-core/generator.js';
  * @param {Object} application
  * @param {Object} entity
  */
-export function cleanupOldFiles(
-  this: CoreGenerator,
-  {
-    application: { packageFolder, srcMainJava, srcTestJava, searchEngineElasticsearch },
-    entity: { entityClass, entityAbsoluteFolder },
-  }: { application: ApplicationType<Entity>; entity: Entity },
-) {
-  if (this.isJhipsterVersionLessThan('7.6.1')) {
+export const cleanupOldFiles = asWritingEntitiesTask(function cleanupOldFiles({
+  application: { packageFolder, srcMainJava, srcTestJava, searchEngineElasticsearch },
+  control,
+  entities,
+}) {
+  if (control.isJhipsterVersionLessThan('7.6.1')) {
     if (searchEngineElasticsearch) {
       this.removeFile(`${srcMainJava}${packageFolder}/repository/search/SortToFieldSortBuilderConverter.java`);
     }
   }
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     this.removeFile(`${srcMainJava}${packageFolder}/repository/search/SortToSortBuilderListConverter.java`);
-    this.removeFile(`${srcTestJava}${entityAbsoluteFolder}/repository/search/${entityClass}SearchRepositoryMockConfiguration.java`);
+    for (const { entityClass, entityAbsoluteFolder } of entities.filter(entity => !entity.skipServer)) {
+      this.removeFile(`${srcTestJava}${entityAbsoluteFolder}/repository/search/${entityClass}SearchRepositoryMockConfiguration.java`);
+    }
   }
-}
+});

--- a/generators/spring-boot/entity-files.ts
+++ b/generators/spring-boot/entity-files.ts
@@ -196,10 +196,8 @@ export const serverFiles = {
 
 export function writeFiles() {
   return {
-    cleanupOldServerFiles: asWritingEntitiesTask(function ({ application, entities }) {
-      for (const entity of entities.filter(entity => !entity.skipServer)) {
-        cleanupOldFiles.call(this, { application, entity });
-      }
+    cleanupOldServerFiles: asWritingEntitiesTask(function ({ application, control, entities }) {
+      cleanupOldFiles.call(this, { application, entities, control });
     }),
 
     writeServerFiles: asWritingEntitiesTask(async function ({ application, entities }) {

--- a/generators/spring-boot/generator.ts
+++ b/generators/spring-boot/generator.ts
@@ -103,7 +103,14 @@ export default class SpringBootGenerator extends BaseApplicationGenerator {
 
   get configuring() {
     return this.asConfiguringTaskGroup({
-      feignMigration() {
+      syncUserWithIdpMigration({ control }) {
+        if (this.jhipsterConfig.syncUserWithIdp === undefined && this.jhipsterConfigWithDefaults.authenticationType === 'oauth2') {
+          if (control.isJhipsterVersionLessThan('8.1.1')) {
+            this.jhipsterConfig.syncUserWithIdp = true;
+          }
+        }
+      },
+      feignMigration({ control }) {
         const { reactive, applicationType, feignClient } = this.jhipsterConfigWithDefaults;
         if (feignClient) {
           if (reactive) {
@@ -115,7 +122,7 @@ export default class SpringBootGenerator extends BaseApplicationGenerator {
         }
         if (
           feignClient === undefined &&
-          this.isJhipsterVersionLessThan('8.0.1') &&
+          control.isJhipsterVersionLessThan('8.0.1') &&
           !reactive &&
           applicationType === APPLICATION_TYPE_MICROSERVICE
         ) {

--- a/generators/spring-cache/cleanup.ts
+++ b/generators/spring-cache/cleanup.ts
@@ -24,18 +24,18 @@ import { asWritingTask } from '../base-application/support/task-type-inference.j
  */
 export default asWritingTask(async function cleanupTask(this, { application, control }) {
   if (application.cacheProviderHazelcast) {
-    if (this.isJhipsterVersionLessThan('3.12.0')) {
+    if (control.isJhipsterVersionLessThan('3.12.0')) {
       this.removeFile(`${application.javaPackageSrcDir}config/hazelcast/HazelcastCacheRegionFactory.java`);
       this.removeFile(`${application.javaPackageSrcDir}config/hazelcast/package-info.java`);
     }
   }
   if (application.cacheProviderRedis) {
-    if (this.isJhipsterVersionLessThan('7.8.2')) {
+    if (control.isJhipsterVersionLessThan('7.8.2')) {
       this.removeFile(`${application.javaPackageTestDir}RedisTestContainerExtension.java`);
     }
   }
   if (application.buildToolGradle) {
-    if (this.isJhipsterVersionLessThan('8.1.1')) {
+    if (control.isJhipsterVersionLessThan('8.1.1')) {
       this.removeFile('gradle/cache.gradle');
     }
   }

--- a/generators/spring-cloud-stream/generators/kafka/cleanup.ts
+++ b/generators/spring-cloud-stream/generators/kafka/cleanup.ts
@@ -16,17 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type KafkaGenerator from './generator.js';
+import { asWritingTask } from '../../../base-application/support/task-type-inference.js';
 
-export default function cleanupKafkaFilesTask(this: KafkaGenerator, { application }) {
-  if (this.isJhipsterVersionLessThan('6.5.2')) {
+export default asWritingTask(function cleanupKafkaFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('6.5.2')) {
     this.removeFile(`${application.javaPackageSrcDir}service/${application.upperFirstCamelCaseBaseName}KafkaConsumer.java`);
     this.removeFile(`${application.javaPackageSrcDir}service/${application.upperFirstCamelCaseBaseName}KafkaProducer.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     this.removeFile(`${application.javaPackageSrcDir}config/KafkaProperties.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.10.0')) {
+  if (control.isJhipsterVersionLessThan('7.10.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/KafkaSseConsumer.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/KafkaSseProducer.java`);
 
@@ -34,7 +34,7 @@ export default function cleanupKafkaFilesTask(this: KafkaGenerator, { applicatio
     this.removeFile(`${application.srcTestResources}META-INF/spring.factories`);
     this.removeFile(`${application.javaPackageTestDir}config/TestContainersSpringContextCustomizerFactory.java`);
   }
-  if (this.isJhipsterVersionLessThan('8.1.1')) {
+  if (control.isJhipsterVersionLessThan('8.1.1')) {
     if (application.messageBrokerPulsar) {
       this.removeFile('gradle/pulsar.gradle');
     }
@@ -42,4 +42,4 @@ export default function cleanupKafkaFilesTask(this: KafkaGenerator, { applicatio
       this.removeFile('gradle/kafka.gradle');
     }
   }
-}
+});

--- a/generators/spring-data-cassandra/cleanup.ts
+++ b/generators/spring-data-cassandra/cleanup.ts
@@ -18,23 +18,23 @@ import { asWritingTask } from '../base-application/support/task-type-inference.j
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export default asWritingTask(function cleanupCassandraFilesTask({ application }) {
-  if (this.isJhipsterVersionLessThan('4.3.0')) {
+export default asWritingTask(function cleanupCassandraFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('4.3.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/cassandra/CustomZonedDateTimeCodec.java`);
   }
-  if (this.isJhipsterVersionLessThan('5.8.0')) {
+  if (control.isJhipsterVersionLessThan('5.8.0')) {
     this.removeFile(`${application.srcTestResources}cassandra-random-port.yml`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/metrics/CassandraHealthIndicator.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/cassandra/package-info.java`);
     this.removeFile(`${application.javaPackageSrcDir}config/cassandra/CassandraConfiguration.java`);
     this.removeFile(`${application.javaPackageTestDir}config/CassandraConfigurationIT.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     this.removeFile(`${application.javaPackageTestDir}AbstractCassandraTest.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.10.0')) {
+  if (control.isJhipsterVersionLessThan('7.10.0')) {
     this.removeFile(`${application.javaPackageTestDir}config/TestContainersSpringContextCustomizerFactory.java`);
   }
 });

--- a/generators/spring-data-couchbase/entity-files.ts
+++ b/generators/spring-data-couchbase/entity-files.ts
@@ -64,9 +64,9 @@ export const entityFiles = {
   repositoryFiles,
 };
 
-export const cleanupCouchbaseEntityFilesTask = asWritingEntitiesTask(function ({ application, entities }) {
+export const cleanupCouchbaseEntityFilesTask = asWritingEntitiesTask(function ({ application, control, entities }) {
   for (const entity of entities.filter(entity => !entity.builtIn && !entity.skipServer)) {
-    if (this.isJhipsterVersionLessThan('7.6.1')) {
+    if (control.isJhipsterVersionLessThan('7.6.1')) {
       this.removeFile(
         `${application.srcMainResources}config/couchmove/changelog/V${entity.changelogDate}__${entity.entityInstance.toLowerCase()}.fts`,
       );

--- a/generators/spring-data-couchbase/files.ts
+++ b/generators/spring-data-couchbase/files.ts
@@ -72,8 +72,8 @@ export const couchbaseFiles = {
   ],
 };
 
-export const cleanupCouchbaseFilesTask = asWritingTask(function cleanupCouchbaseFilesTask({ application }) {
-  if (this.isJhipsterVersionLessThan('7.1.1')) {
+export const cleanupCouchbaseFilesTask = asWritingTask(function cleanupCouchbaseFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('7.1.1')) {
     this.removeFile(`${application.javaPackageSrcDir}repository/CustomReactiveCouchbaseRepository.java `);
     this.removeFile(`${application.javaPackageSrcDir}config/DatabaseConfigurationIT.java`);
     this.removeFile(`${application.javaPackageSrcDir}repository/N1qlCouchbaseRepository.java`);
@@ -84,7 +84,7 @@ export const cleanupCouchbaseFilesTask = asWritingTask(function cleanupCouchbase
     this.removeFile(`${application.javaPackageTestDir}repository/CustomCouchbaseRepositoryTest.java`);
   }
 
-  if (this.isJhipsterVersionLessThan('7.6.1')) {
+  if (control.isJhipsterVersionLessThan('7.6.1')) {
     this.removeFile(`${application.javaPackageTestDir}repository/JHipsterCouchbaseRepositoryTest.java`);
     this.removeFolder(`${application.javaPackageSrcDir}config/couchbase`);
     this.removeFile(`${application.srcMainResources}config/couchmove/changelog/V0__create_indexes.n1ql`);

--- a/generators/spring-data-elasticsearch/cleanup.ts
+++ b/generators/spring-data-elasticsearch/cleanup.ts
@@ -18,22 +18,22 @@ import { asWritingTask } from '../base-application/support/task-type-inference.j
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export default asWritingTask(function cleanupElasticsearchFilesTask({ application }) {
-  if (this.isJhipsterVersionLessThan('4.0.0')) {
+export default asWritingTask(function cleanupElasticsearchFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('4.0.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/ElasticSearchConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('5.2.2')) {
+  if (control.isJhipsterVersionLessThan('5.2.2')) {
     this.removeFile(`${application.javaPackageSrcDir}config/ElasticsearchConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.0')) {
     this.removeFile(`${application.javaPackageTestDir}config/ElasticsearchTestConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     if (application.generateUserManagement) {
       this.removeFile(`${application.javaPackageTestDir}repository/search/UserSearchRepositoryMockConfiguration.java`);
     }
   }
-  if (this.isJhipsterVersionLessThan('7.9.3')) {
+  if (control.isJhipsterVersionLessThan('7.9.3')) {
     if (application.reactive) {
       this.removeFile(`${application.javaPackageTestDir}config/ElasticsearchReactiveTestConfiguration.java`);
     }

--- a/generators/spring-data-mongodb/cleanup.ts
+++ b/generators/spring-data-mongodb/cleanup.ts
@@ -18,11 +18,11 @@ import { asWritingTask } from '../base-application/support/task-type-inference.j
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export default asWritingTask(function cleanupMongodbFilesTask({ application }) {
-  if (this.isJhipsterVersionLessThan('3.10.0')) {
+export default asWritingTask(function cleanupMongodbFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('3.10.0')) {
     this.removeFile(`${application.javaPackageSrcDir}config/CloudMongoDbConfiguration.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.7.1')) {
+  if (control.isJhipsterVersionLessThan('7.7.1')) {
     this.removeFile(`${application.javaPackageTestDir}MongoDbTestContainerExtension.java`);
   }
 });

--- a/generators/spring-data-neo4j/cleanup.ts
+++ b/generators/spring-data-neo4j/cleanup.ts
@@ -16,17 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type BaseGenerator from '../base-core/index.js';
+import { asWritingTask } from '../base-application/support/task-type-inference.js';
 
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default function cleanupTask(this: BaseGenerator, { application }: any) {
-  if (this.isJhipsterVersionLessThan('7.8.1')) {
+export default asWritingTask(function cleanupTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('7.8.1')) {
     this.removeFile(`${application.javaPackageSrcDir}AbstractNeo4jIT.java`);
   }
-  if (this.isJhipsterVersionLessThan('7.10.0')) {
+  if (control.isJhipsterVersionLessThan('7.10.0')) {
     this.removeFile(`${application.javaPackageTestDir}config/TestContainersSpringContextCustomizerFactory.java`);
   }
-}
+});

--- a/generators/spring-data-relational/cleanup.ts
+++ b/generators/spring-data-relational/cleanup.ts
@@ -16,14 +16,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type Generator from './generator.js';
+import { asWritingTask } from '../base-application/support/task-type-inference.js';
 
 /**
  * Removes server files that where generated in previous JHipster versions and therefore
  * need to be removed.
  */
-export default function cleanupOldServerFilesTask(this: Generator, { application }: any) {
-  if (this.isJhipsterVersionLessThan('4.0.0')) {
+export default asWritingTask(function cleanupOldServerFilesTask({ application, control }) {
+  if (control.isJhipsterVersionLessThan('4.0.0')) {
     if (application.devDatabaseTypeH2Any) {
       this.removeFile(`${application.javaPackageSrcDir}domain/util/FixedH2Dialect.java`);
     }
@@ -31,13 +31,13 @@ export default function cleanupOldServerFilesTask(this: Generator, { application
       this.removeFile(`${application.javaPackageSrcDir}domain/util/FixedPostgreSQL82Dialect`);
     }
   }
-  if (this.isJhipsterVersionLessThan('7.8.2')) {
+  if (control.isJhipsterVersionLessThan('7.8.2')) {
     this.removeFile(`${application.srcTestResources}config/application-testcontainers.yml`);
     if (application.reactive) {
       this.removeFile(`${application.javaPackageTestDir}ReactiveSqlTestContainerExtension.java`);
     }
   }
-  if (application.prodDatabaseTypeMysql && this.isJhipsterVersionLessThan('7.9.0')) {
+  if (application.prodDatabaseTypeMysql && control.isJhipsterVersionLessThan('7.9.0')) {
     this.removeFile(`${application.srcTestResources}testcontainers/mysql/my.cnf`);
   }
-}
+});

--- a/generators/vue/cleanup.ts
+++ b/generators/vue/cleanup.ts
@@ -24,22 +24,22 @@ import { asWritingTask } from '../base-application/support/task-type-inference.j
  * need to be removed.
  */
 export default asWritingTask(async function cleanupOldFilesTask({ application, control }) {
-  if (this.isJhipsterVersionLessThan('7.0.0-beta.0')) {
+  if (control.isJhipsterVersionLessThan('7.0.0-beta.0')) {
     this.removeFile(`${application.clientSrcDir}app/admin/audits/audits.component.ts`);
     this.removeFile(`${application.clientSrcDir}app/admin/audits/audits.service.ts`);
     this.removeFile(`${application.clientSrcDir}app/admin/audits/audits.vue`);
     this.removeFile(`${application.clientTestDir}spec/app/admin/audits/audits.component.spec.ts`);
   }
-  if (this.isJhipsterVersionLessThan('7.0.2')) {
+  if (control.isJhipsterVersionLessThan('7.0.2')) {
     this.removeFile('config/index.js');
     this.removeFile('config/dev.env.js');
     this.removeFile('config/prod.env.js');
   }
-  if (this.isJhipsterVersionLessThan('7.0.1')) {
+  if (control.isJhipsterVersionLessThan('7.0.1')) {
     this.removeFile('.npmrc');
   }
 
-  if (this.isJhipsterVersionLessThan('7.3.1')) {
+  if (control.isJhipsterVersionLessThan('7.3.1')) {
     this.removeFile('webpack/env.js');
     this.removeFile('webpack/dev.env.js');
     this.removeFile('webpack/prod.env.js');
@@ -47,10 +47,10 @@ export default asWritingTask(async function cleanupOldFilesTask({ application, c
     this.removeFile('webpack/loader.conf.js');
   }
 
-  if (this.isJhipsterVersionLessThan('7.4.2')) {
+  if (control.isJhipsterVersionLessThan('7.4.2')) {
     this.removeFile(`${application.clientSrcDir}app/entities/user/user.oauth2.service.ts`);
   }
-  if (this.isJhipsterVersionLessThan('7.10.1')) {
+  if (control.isJhipsterVersionLessThan('7.10.1')) {
     this.removeFile('tsconfig.spec.json');
     this.removeFile(`${application.clientSrcDir}app/shared/config/formatter.ts`);
     this.removeFile(`${application.clientTestDir}spec/app/shared/config/formatter.spec.ts`);
@@ -58,7 +58,7 @@ export default asWritingTask(async function cleanupOldFilesTask({ application, c
     this.removeFile(`${application.clientTestDir}jest.conf.js`);
     this.removeFile(`${application.clientTestDir}spec/setup.js`);
   }
-  if (this.isJhipsterVersionLessThan('8.0.0-beta.3')) {
+  if (control.isJhipsterVersionLessThan('8.0.0-beta.3')) {
     this.removeFile(`${application.clientTestDir}spec/setup.ts`);
     this.removeFile(`${application.clientTestDir}spec/tsconfig.json`);
     this.removeFile(`${application.clientTestDir}spec/app/account/account.service.spec.ts`);
@@ -95,7 +95,7 @@ export default asWritingTask(async function cleanupOldFilesTask({ application, c
     this.removeFile(`${application.clientTestDir}spec/app/admin/gateway/gateway.component.spec.ts`);
     this.removeFile(`${application.clientTestDir}spec/app/entities/entities-menu.spec.ts`);
   }
-  if (this.isJhipsterVersionLessThan('8.0.0-beta.4') && !application.microfrontend) {
+  if (control.isJhipsterVersionLessThan('8.0.0-beta.4') && !application.microfrontend) {
     this.removeFile('.eslintrc.js');
     this.removeFile('tsconfig.test.json');
     this.removeFile('webpack/config.js');
@@ -104,7 +104,7 @@ export default asWritingTask(async function cleanupOldFilesTask({ application, c
     this.removeFile('webpack/webpack.dev.js');
     this.removeFile('webpack/webpack.prod.js');
   }
-  if (this.isJhipsterVersionLessThan('8.1.1')) {
+  if (control.isJhipsterVersionLessThan('8.1.1')) {
     this.removeFile('vite.config.ts');
     this.removeFile('vitest.config.ts');
   }

--- a/generators/vue/entity-files-vue.ts
+++ b/generators/vue/entity-files-vue.ts
@@ -71,12 +71,12 @@ export const postWriteEntityFiles = asPostWritingEntitiesTask(async function pos
   });
 });
 
-export const cleanupEntitiesFiles = asWritingEntitiesTask(function cleanupEntitiesFiles({ application, entities }) {
+export const cleanupEntitiesFiles = asWritingEntitiesTask(function cleanupEntitiesFiles({ application, control, entities }) {
   for (const entity of (application.filterEntitiesForClient ?? (entities => entities))(entities).filter(
     entity => !entity.builtInUser && !entity.embedded,
   )) {
     const { entityFolderName, entityFileName } = entity;
-    if (this.isJhipsterVersionLessThan('8.0.0-beta.3')) {
+    if (control.isJhipsterVersionLessThan('8.0.0-beta.3')) {
       this.removeFile(`${application.clientTestDir}/spec/app/entities/${entityFolderName}/${entityFileName}.component.spec.ts`);
       this.removeFile(`${application.clientTestDir}/spec/app/entities/${entityFolderName}/${entityFileName}-detail.component.spec.ts`);
       this.removeFile(`${application.clientTestDir}/spec/app/entities/${entityFolderName}/${entityFileName}-update.component.spec.ts`);

--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -53,9 +53,9 @@ export default class VueGenerator extends BaseApplicationGenerator {
 
   get configuring() {
     return this.asConfiguringTaskGroup({
-      configureDevServerPort() {
+      configureDevServerPort({ control }) {
         if (this.jhipsterConfig.devServerPort === undefined) return;
-        if (this.isJhipsterVersionLessThan('8.7.4')) {
+        if (control.isJhipsterVersionLessThan('8.7.4')) {
           // Migrate old devServerPort with new one
           const { applicationIndex = 0 } = this.jhipsterConfigWithDefaults;
           this.jhipsterConfig.devServerPort = 9000 + applicationIndex;


### PR DESCRIPTION
`isJhipsterVersionLessThan` depends on `jhipsterOldVersion` from control.
Move it to control.

Related to https://github.com/jhipster/generator-jhipster/issues/28235
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
