### PR TITLE
internal: change features defaults

### DIFF
--- a/.blueprint/code-workspace/generator.mts
+++ b/.blueprint/code-workspace/generator.mts
@@ -7,10 +7,6 @@ import { defaultSamplesFolder, promptSamplesFolder, samplesFolderConfig } from '
 export default class extends BaseGenerator {
   samplePath;
 
-  constructor(args, options, features) {
-    super(args, options, { queueCommandTasks: true, ...features });
-  }
-
   get [BaseGenerator.PROMPTING]() {
     return this.asAnyTaskGroup({
       promptSamplesFolder,

--- a/.blueprint/from-issue/generator.mts
+++ b/.blueprint/from-issue/generator.mts
@@ -55,10 +55,6 @@ export default class extends BaseGenerator {
   summaryFooter = '';
   summaryDiffs = '';
 
-  constructor(args, options, features) {
-    super(args, options, { queueCommandTasks: true, ...features });
-  }
-
   get [BaseGenerator.PROMPTING]() {
     return this.asAnyTaskGroup({
       async promptOptions() {

--- a/.blueprint/generate-generator/generator.mts
+++ b/.blueprint/generate-generator/generator.mts
@@ -4,10 +4,6 @@ import BaseGenerator from '../../generators/base-core/index.js';
 export default class extends BaseGenerator {
   generatorNamespace;
 
-  constructor(args, options, features) {
-    super(args, options, { queueCommandTasks: true, ...features });
-  }
-
   get [BaseGenerator.WRITING]() {
     return this.asAnyTaskGroup({
       async writing() {

--- a/.blueprint/generate-sample/generator.mts
+++ b/.blueprint/generate-sample/generator.mts
@@ -16,10 +16,6 @@ export default class extends BaseGenerator<Config & { entities: string[] }> {
   entitiesSample;
   sampleYorcFolder;
 
-  constructor(args, options, features) {
-    super(args, options, { queueCommandTasks: true, ...features });
-  }
-
   get [BaseGenerator.INITIALIZING]() {
     return this.asAnyTaskGroup({
       projectVersion() {

--- a/.blueprint/github-build-matrix/generator.ts
+++ b/.blueprint/github-build-matrix/generator.ts
@@ -33,7 +33,7 @@ export default class extends BaseGenerator {
   matrix!: string;
 
   constructor(args, opts, features) {
-    super(args, opts, { queueCommandTasks: true, ...features, jhipsterBootstrap: false });
+    super(args, opts, { ...features, jhipsterBootstrap: false });
   }
 
   get [BaseGenerator.WRITING]() {

--- a/.blueprint/update-vscode/generator.mts
+++ b/.blueprint/update-vscode/generator.mts
@@ -4,10 +4,6 @@ import { getPackageRoot } from '../../lib/index.js';
 import { getWorkflowSamples } from '../generate-sample/support/get-workflow-samples.js';
 
 export default class extends BaseGenerator {
-  constructor(args, options, features) {
-    super(args, options, { queueCommandTasks: true, ...features });
-  }
-
   get [BaseGenerator.WRITING]() {
     return this.asAnyTaskGroup({
       async generateVscodeLaunch() {

--- a/generators/app/generator.ts
+++ b/generators/app/generator.ts
@@ -23,7 +23,6 @@ import { camelCase } from 'lodash-es';
 import BaseApplicationGenerator from '../base-application/index.js';
 import { GENERATOR_CLIENT, GENERATOR_COMMON, GENERATOR_SERVER } from '../generator-list.js';
 import { getDefaultAppName } from '../project-name/support/index.js';
-import { packageJson } from '../../lib/index.js';
 
 import { applicationTypes } from '../../lib/jhipster/index.js';
 import cleanupOldFilesTask from './cleanup.js';
@@ -72,10 +71,6 @@ export default class JHipsterAppGenerator extends BaseApplicationGenerator {
   get configuring() {
     return this.asConfiguringTaskGroup({
       setup() {
-        if (!this.options.reproducibleTests) {
-          this.jhipsterConfig.jhipsterVersion = packageJson.version;
-        }
-
         if (this.jhipsterConfig.applicationType === MICROSERVICE) {
           this.jhipsterConfig.skipUserManagement = true;
         }

--- a/generators/base-application/generator.ts
+++ b/generators/base-application/generator.ts
@@ -137,7 +137,7 @@ export default class BaseApplicationGenerator<
   static POST_WRITING_ENTITIES = asPriority(POST_WRITING_ENTITIES);
 
   constructor(args: string | string[], options: JHipsterGeneratorOptions, features: JHipsterGeneratorFeatures) {
-    super(args, options, features);
+    super(args, options, { storeJHipsterVersion: true, storeBlueprintVersion: true, ...features });
 
     if (this.options.help) {
       return;

--- a/generators/base-core/generator-core.spec.ts
+++ b/generators/base-core/generator-core.spec.ts
@@ -23,7 +23,7 @@ describe('generator - base-core', () => {
 
     it('no argument', async () => {
       const base = new Dummy([], { env: await helpers.createTestEnv() });
-      base.parseJHipsterArguments({
+      base._parseJHipsterArguments({
         jdlFiles: {
           type: String,
         },
@@ -32,7 +32,7 @@ describe('generator - base-core', () => {
     });
     it('undefined positional arguments', async () => {
       const base = new Dummy({ positionalArguments: [], env: await helpers.createTestEnv() });
-      base.parseJHipsterArguments({
+      base._parseJHipsterArguments({
         jdlFiles: {
           type: String,
         },
@@ -41,7 +41,7 @@ describe('generator - base-core', () => {
     });
     it('undefined argument', async () => {
       const base = new Dummy([undefined], { env: await helpers.createTestEnv() });
-      base.parseJHipsterArguments({
+      base._parseJHipsterArguments({
         jdlFiles: {
           type: String,
         },
@@ -50,7 +50,7 @@ describe('generator - base-core', () => {
     });
     it('undefined positional arguments', async () => {
       const base = new Dummy({ positionalArguments: [undefined], env: await helpers.createTestEnv() });
-      base.parseJHipsterArguments({
+      base._parseJHipsterArguments({
         jdlFiles: {
           type: String,
         },
@@ -59,7 +59,7 @@ describe('generator - base-core', () => {
     });
     it('string arguments', async () => {
       const base = new Dummy(['foo'], { env: await helpers.createTestEnv() });
-      base.parseJHipsterArguments({
+      base._parseJHipsterArguments({
         jdlFiles: {
           type: String,
         },
@@ -68,7 +68,7 @@ describe('generator - base-core', () => {
     });
     it('vararg arguments', async () => {
       const base = new Dummy(['bar', 'foo'], { env: await helpers.createTestEnv() });
-      base.parseJHipsterArguments({
+      base._parseJHipsterArguments({
         first: {
           type: String,
         },
@@ -82,7 +82,7 @@ describe('generator - base-core', () => {
     });
     it('vararg arguments using positionalArguments', async () => {
       const base = new Dummy({ positionalArguments: ['bar', ['foo']], env: await helpers.createTestEnv() });
-      base.parseJHipsterArguments({
+      base._parseJHipsterArguments({
         first: {
           type: String,
         },

--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -198,17 +198,6 @@ export default class CoreGenerator<ConfigType extends Config = Config, Options =
 
       /* Options parsing must be executed after forcing jhipster storage namespace and after sharedData have been populated */
       this.parseJHipsterOptions(baseCommand.options);
-
-      // Don't write jhipsterVersion to .yo-rc.json when reproducible
-      if (
-        this.options.namespace.startsWith('jhipster:') &&
-        !this.options.namespace.startsWith('jhipster:bootstrap') &&
-        this.getFeatures().storeJHipsterVersion !== false &&
-        !this.options.reproducibleTests &&
-        !this.jhipsterConfig.jhipsterVersion
-      ) {
-        this.storeCurrentJHipsterVersion();
-      }
     }
 
     this.logger = this.log as any;
@@ -230,7 +219,7 @@ export default class CoreGenerator<ConfigType extends Config = Config, Options =
     // Add base template folder.
     this.jhipsterTemplatesFolders = [this.templatePath()];
 
-    if (this.features.queueCommandTasks === true) {
+    if (this.features.queueCommandTasks !== false) {
       this.on('before:queueOwnTasks', () => {
         this.queueCurrentJHipsterCommandTasks();
       });
@@ -242,10 +231,6 @@ export default class CoreGenerator<ConfigType extends Config = Config, Options =
    */
   usage(): string {
     return super.usage().replace('yo jhipster:', 'jhipster ');
-  }
-
-  storeCurrentJHipsterVersion(): void {
-    this.jhipsterConfig.jhipsterVersion = packageJson.version;
   }
 
   get control(): Control {

--- a/generators/base-workspaces/generator.ts
+++ b/generators/base-workspaces/generator.ts
@@ -30,7 +30,6 @@ import type { Entity } from '../../lib/types/application/entity.js';
 import type { ApplicationType } from '../../lib/types/application/application.js';
 import { CONTEXT_DATA_APPLICATION_KEY } from '../base-application/support/constants.js';
 import { CUSTOM_PRIORITIES, PRIORITY_NAMES } from './priorities.js';
-import command from './command.js';
 import { CONTEXT_DATA_DEPLOYMENT_KEY, CONTEXT_DATA_WORKSPACES_APPLICATIONS_KEY, CONTEXT_DATA_WORKSPACES_KEY } from './support/index.js';
 
 const {
@@ -86,11 +85,11 @@ export default abstract class BaseWorkspacesGenerator<Config = unknown> extends 
   constructor(args, options, features) {
     super(args, options, features);
 
-    if (!this.options.help) {
-      this.registerPriorities(CUSTOM_PRIORITIES);
-
-      this.parseJHipsterOptions(command.options);
+    if (this.options.help) {
+      return;
     }
+
+    this.registerPriorities(CUSTOM_PRIORITIES);
   }
 
   get #deployment() {

--- a/generators/base/api.d.ts
+++ b/generators/base/api.d.ts
@@ -87,11 +87,18 @@ export type JHipsterGeneratorFeatures = BaseFeatures & {
    *  - prettier and eslint.
    */
   jhipsterBootstrap?: boolean;
+
   /**
    * Store current version at .yo-rc.json.
    * Defaults to true.
    */
   storeJHipsterVersion?: boolean;
+
+  /**
+   * Store current version at .yo-rc.json.
+   * Defaults to true.
+   */
+  storeBlueprintVersion?: boolean;
 
   /**
    * Create transforms for commit.

--- a/generators/base/api.d.ts
+++ b/generators/base/api.d.ts
@@ -70,6 +70,7 @@ export type JHipsterGeneratorFeatures = BaseFeatures & {
    * Wraps write context and shows removed fields and replacements if exists.
    */
   jhipster7Migration?: boolean | 'verbose' | 'silent';
+  blueprintSupport?: boolean;
   sbsBlueprint?: boolean;
   checkBlueprint?: boolean;
   /**

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -91,7 +91,7 @@ export default class JHipsterBaseBlueprintGenerator<
     this.on('before:queueOwnTasks', () => {
       const { storeBlueprintVersion, storeJHipsterVersion, queueCommandTasks = true } = this.getFeatures();
       if (this.fromBlueprint) {
-        if (storeBlueprintVersion && !this.options.reproducibleTests && !this.blueprintConfig!.blueprintVersion) {
+        if (storeBlueprintVersion && !this.options.reproducibleTests) {
           try {
             const blueprintPackageJson = JSON.parse(readFileSync(this._meta!.packagePath!, 'utf8'));
             this.blueprintConfig!.blueprintVersion = blueprintPackageJson.version;
@@ -101,7 +101,7 @@ export default class JHipsterBaseBlueprintGenerator<
         }
       }
       if (!this.fromBlueprint && !this.delegateToBlueprint) {
-        if (storeJHipsterVersion && !this.options.reproducibleTests && !this.jhipsterConfig.jhipsterVersion) {
+        if (storeJHipsterVersion && !this.options.reproducibleTests) {
           this.jhipsterConfig.jhipsterVersion = packageJson.version;
         }
       }

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -50,9 +50,7 @@ export default class JHipsterBaseBlueprintGenerator<
 
   constructor(args: string | string[], options: JHipsterGeneratorOptions, features: JHipsterGeneratorFeatures) {
     const { jhipsterContext, ...opts } = options ?? {};
-    // Handle locally due to blueprint support.
-    const { queueCommandTasks } = features ?? {};
-    super(args, opts, { queueCommandTasks: false, ...features });
+    super(args, opts, { blueprintSupport: true, ...features });
 
     if (this.options.help) {
       return;
@@ -91,7 +89,7 @@ export default class JHipsterBaseBlueprintGenerator<
     }
 
     this.on('before:queueOwnTasks', () => {
-      const { storeBlueprintVersion, storeJHipsterVersion } = this.getFeatures();
+      const { storeBlueprintVersion, storeJHipsterVersion, queueCommandTasks = true } = this.getFeatures();
       if (this.fromBlueprint) {
         if (storeBlueprintVersion && !this.options.reproducibleTests && !this.blueprintConfig!.blueprintVersion) {
           try {
@@ -108,8 +106,8 @@ export default class JHipsterBaseBlueprintGenerator<
         }
       }
       if (this.fromBlueprint || !this.delegateToBlueprint) {
-        if (queueCommandTasks !== false) {
-          this.queueCurrentJHipsterCommandTasks();
+        if (queueCommandTasks) {
+          this._queueCurrentJHipsterCommandTasks();
         }
       }
     });

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import fs from 'fs';
+import fs, { readFileSync } from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import semver from 'semver';
@@ -50,7 +50,9 @@ export default class JHipsterBaseBlueprintGenerator<
 
   constructor(args: string | string[], options: JHipsterGeneratorOptions, features: JHipsterGeneratorFeatures) {
     const { jhipsterContext, ...opts } = options ?? {};
-    super(args, opts, features);
+    // Handle locally due to blueprint support.
+    const { queueCommandTasks } = features ?? {};
+    super(args, opts, { queueCommandTasks: false, ...features });
 
     if (this.options.help) {
       return;
@@ -86,13 +88,31 @@ export default class JHipsterBaseBlueprintGenerator<
         this.log.warn('Error adding current blueprint templates as alternative for JHipster templates.');
         this.log.log(error);
       }
-    } else if (this.features.queueCommandTasks === undefined) {
-      this.on('before:queueOwnTasks', () => {
-        if (!this.delegateToBlueprint) {
+    }
+
+    this.on('before:queueOwnTasks', () => {
+      const { storeBlueprintVersion, storeJHipsterVersion } = this.getFeatures();
+      if (this.fromBlueprint) {
+        if (storeBlueprintVersion && !this.options.reproducibleTests && !this.blueprintConfig!.blueprintVersion) {
+          try {
+            const blueprintPackageJson = JSON.parse(readFileSync(this._meta!.packagePath!, 'utf8'));
+            this.blueprintConfig!.blueprintVersion = blueprintPackageJson.version;
+          } catch {
+            this.log(`Could not retrieve version of blueprint '${this.options.namespace}'`);
+          }
+        }
+      }
+      if (!this.fromBlueprint && !this.delegateToBlueprint) {
+        if (storeJHipsterVersion && !this.options.reproducibleTests && !this.jhipsterConfig.jhipsterVersion) {
+          this.jhipsterConfig.jhipsterVersion = packageJson.version;
+        }
+      }
+      if (this.fromBlueprint || !this.delegateToBlueprint) {
+        if (queueCommandTasks !== false) {
           this.queueCurrentJHipsterCommandTasks();
         }
-      });
-    }
+      }
+    });
   }
 
   /**

--- a/generators/entities/generator.ts
+++ b/generators/entities/generator.ts
@@ -19,7 +19,6 @@
  */
 import BaseApplicationGenerator from '../base-application/index.js';
 import { GENERATOR_APP } from '../generator-list.js';
-import command from './command.js';
 
 export default class EntitiesGenerator extends BaseApplicationGenerator {
   entities;
@@ -35,7 +34,6 @@ export default class EntitiesGenerator extends BaseApplicationGenerator {
       loadArguments() {
         this.jhipsterConfig.entities = this.jhipsterConfig.entities || [];
 
-        this.parseJHipsterArguments(command.arguments);
         if (!this.entities || this.entities.length === 0) {
           this.entities = this.getExistingEntityNames();
         } else {

--- a/generators/generate-blueprint/generator.ts
+++ b/generators/generate-blueprint/generator.ts
@@ -59,6 +59,10 @@ export default class extends BaseGenerator {
   ignoreExistingGenerators!: boolean;
   gitDependency!: string;
 
+  constructor(args, options, features) {
+    super(args, options, { storeJHipsterVersion: true, ...features });
+  }
+
   async _beforeQueue() {
     if (!this.fromBlueprint) {
       await this.composeWithBlueprints();
@@ -147,9 +151,6 @@ export default class extends BaseGenerator {
 
   get composing() {
     return this.asComposingTaskGroup({
-      storeCurrentVersion() {
-        this.storeCurrentJHipsterVersion();
-      },
       async compose() {
         if (this.jhipsterConfig[LOCAL_BLUEPRINT_OPTION]) return;
         const initGenerator = await this.composeWithJHipster(GENERATOR_INIT, { generatorOptions: { packageJsonType: 'module' } });

--- a/generators/generate-blueprint/templates/.blueprint/generate-sample/generator.mjs.ejs
+++ b/generators/generate-blueprint/templates/.blueprint/generate-sample/generator.mjs.ejs
@@ -21,7 +21,7 @@ export default class extends BaseGenerator {
   generatorOptions;
 
   constructor(args, opts, features) {
-    super(args, opts, { ...features, queueCommandTasks: true, jhipsterBootstrap: false });
+    super(args, opts, { ...features,  jhipsterBootstrap: false });
   }
 
   get [BaseGenerator.WRITING]() {

--- a/generators/generate-blueprint/templates/.blueprint/github-build-matrix/generator.mjs.ejs
+++ b/generators/generate-blueprint/templates/.blueprint/github-build-matrix/generator.mjs.ejs
@@ -11,7 +11,7 @@ export default class extends BaseGenerator {
   matrix;
 
   constructor(args, opts, features) {
-    super(args, opts, { ...features, queueCommandTasks: true, jhipsterBootstrap: false });
+    super(args, opts, { ...features,  jhipsterBootstrap: false });
   }
 
   get [BaseGenerator.WRITING]() {

--- a/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
+++ b/generators/generate-blueprint/templates/generators/generator/generator.mjs.jhi.ejs
@@ -52,7 +52,7 @@ export default class extends <%= generatorClass %>Generator {
   constructor(args, opts, features) {
     super(args, opts, {
       ...features,
-      queueCommandTasks: true,
+      
 <%_ if (sbs) { _%>
       sbsBlueprint: true,
 <%_ } else if (!customGenerator) { _%>

--- a/generators/javascript/generators/husky/generator.ts
+++ b/generators/javascript/generators/husky/generator.ts
@@ -19,10 +19,6 @@
 import BaseApplicationGenerator from '../../../base-application/index.js';
 
 export default class HuskyGenerator extends BaseApplicationGenerator {
-  constructor(args, options, features) {
-    super(args, options, { queueCommandTasks: true, ...features });
-  }
-
   async beforeQueue() {
     if (!this.fromBlueprint) {
       await this.composeWithBlueprints();

--- a/generators/javascript/generators/prettier/generator.ts
+++ b/generators/javascript/generators/prettier/generator.ts
@@ -24,10 +24,6 @@ export default class PrettierGenerator extends BaseApplicationGenerator {
   prettierConfigFile!: string;
   monorepositoryRoot?: boolean;
 
-  constructor(args, opts, features) {
-    super(args, opts, { queueCommandTasks: true, ...features });
-  }
-
   async beforeQueue() {
     if (!this.fromBlueprint) {
       await this.composeWithBlueprints();

--- a/lib/command/generator-command.spec.ts
+++ b/lib/command/generator-command.spec.ts
@@ -23,7 +23,7 @@ class CommandGenerator extends BaseApplicationGenerator {
   context = {};
 
   constructor(args, opts, features) {
-    super(args, opts, { ...features, queueCommandTasks: true, jhipsterBootstrap: false });
+    super(args, opts, { ...features, jhipsterBootstrap: false });
     this.customLifecycle = true;
   }
 }


### PR DESCRIPTION
- `queueCommandTasks` will always true by default.
- move `storeJHipsterVersion` handling to base and set default as true for base-application. 
- add `storeBlueprintVersion ` handling to base and set default as true for base-application. 
- convert features handling methods to private.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
