### PR TITLE
try to use command for docker compose

### DIFF
--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -16,14 +16,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import assert from 'assert';
 import fs, { existsSync, readFileSync, statSync } from 'fs';
 import path, { join, relative } from 'path';
 import { rm } from 'fs/promises';
+import { union } from 'lodash-es';
 import chalk from 'chalk';
 import semver, { lt as semverLessThan } from 'semver';
 
-import { union } from 'lodash-es';
 import { execaCommandSync } from 'execa';
 import type { PackageJson } from 'type-fest';
 import { packageJson } from '../../lib/index.js';
@@ -51,9 +52,7 @@ import type {
   CleanupArgumentType,
   Control,
 } from './types.js';
-
 const { WRITING } = PRIORITY_NAMES;
-
 /**
  * Base class that contains blueprints support.
  * Provides built-in state support with control object.

--- a/generators/bootstrap-workspaces/command.ts
+++ b/generators/bootstrap-workspaces/command.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs';
 import type { JHipsterCommandDefinition } from '../../lib/command/index.js';
 
 const command = {
@@ -9,6 +10,53 @@ const command = {
       },
       description: 'Use custom configuration',
       scope: 'generator',
+    },
+    directoryPath: {
+      cli: {
+        type: String,
+        description: 'Root directory where your applications are located',
+      },
+      prompt: gen => ({
+        message: 'Enter the root directory where your applications are located',
+        type: 'input',
+        when: !gen.customWorkspacesConfig && !(gen.sharedWorkspaces.existingWorkspaces && !gen.options.askAnswered),
+        validate: async input => {
+          const path = gen.destinationPath(input);
+          if (existsSync(path)) {
+            const applications = await gen.findApplicationFolders(path);
+            return applications.length === 0 ? `No application found in ${path}` : true;
+          }
+          return `${path} is not a directory or doesn't exist`;
+        },
+        default: () => '../',
+      }),
+      scope: 'storage',
+    },
+    appsFolders: {
+      cli: {
+        name: 'workspacesFolders',
+        type: Array,
+        default: [],
+        description: 'Folders to use as monorepository workspace',
+      },
+      prompt: gen => ({
+        message: 'Which applications do you want to include in your configuration?',
+        type: 'checkbox',
+        when: !gen.customWorkspacesConfig && !(gen.sharedWorkspaces.existingWorkspaces && !gen.options.askAnswered),
+        validate: async input => {
+          const path = gen.destinationPath(input);
+          if (existsSync(path)) {
+            const applications = await gen.findApplicationFolders(path);
+            return applications.length === 0 ? `No application found in ${path}` : true;
+          }
+          return `${path} is not a directory or doesn't exist`;
+        },
+        choices: async () =>
+          (await gen.findApplicationFolders(gen.directoryPath)).filter(app => app !== 'jhipster-registry' && app !== 'registry'),
+        default: async () =>
+          (await gen.findApplicationFolders(gen.directoryPath)).filter(app => app !== 'jhipster-registry' && app !== 'registry'),
+      }),
+      scope: 'storage',
     },
   },
 } as const satisfies JHipsterCommandDefinition;

--- a/generators/bootstrap-workspaces/generator.ts
+++ b/generators/bootstrap-workspaces/generator.ts
@@ -30,20 +30,6 @@ export default class BootstrapWorkspacesGenerator extends BaseWorkspacesGenerato
     }
   }
 
-  get prompting() {
-    return this.asPromptingTaskGroup({
-      async askForOptions() {
-        if (this.customWorkspacesConfig || (this.sharedWorkspaces.existingWorkspaces && !this.options.askAnswered)) return;
-
-        await this.askForWorkspacesConfig();
-      },
-    });
-  }
-
-  get [BaseWorkspacesGenerator.PROMPTING]() {
-    return this.delegateTasksToBlueprint(() => this.prompting);
-  }
-
   get configuring() {
     return this.asConfiguringTaskGroup({
       configureWorkspaces() {

--- a/generators/bootstrap/support/multi-step-transform/template-file.ts
+++ b/generators/bootstrap/support/multi-step-transform/template-file.ts
@@ -16,7 +16,6 @@ export default class TemplateFile {
   private _filename: any;
   private _extension: any;
   private _compiled: ejs.TemplateFunction;
-  // eslint-disable-next-line no-use-before-define
   private _fragments: TemplateFile[];
   private _fragmentName: string;
   private _debug: { enabled: boolean } & ((msg: string) => void);

--- a/generators/docker-compose/command.ts
+++ b/generators/docker-compose/command.ts
@@ -1,4 +1,8 @@
+import chalk from 'chalk';
 import type { JHipsterCommandDefinition } from '../../lib/command/index.js';
+import { monitoringTypes, serviceDiscoveryTypes } from '../../lib/jhipster/index.js';
+const { CONSUL, EUREKA, NO: NO_SERVICE_DISCOVERY } = serviceDiscoveryTypes;
+const { PROMETHEUS, NO: NO_MONITORING } = monitoringTypes;
 
 const command = {
   arguments: {
@@ -8,6 +12,102 @@ const command = {
     },
   },
   configs: {
+    monitoring: {
+      prompt: gen => ({
+        type: 'list',
+        name: 'monitoring',
+        message: 'Do you want to setup monitoring for your applications ?',
+        when: !(gen.workspaces.existingWorkspaces && !gen.options.askAnswered),
+        choices: [
+          {
+            value: NO_MONITORING,
+            name: 'No',
+          },
+          {
+            value: PROMETHEUS,
+            name: 'Yes, for metrics only with Prometheus',
+          },
+        ],
+        default: NO_MONITORING,
+      }),
+      scope: 'storage',
+    },
+    clusteredDbApps: {
+      prompt: gen => ({
+        type: 'checkbox',
+        name: 'clusteredDbApps',
+        message: 'Which applications should use a clustered database?',
+        choices: gen.applications.filter(app => app.databaseTypeMongodb || app.databaseTypeCouchbase).map(app => app.appFolder),
+        when: () =>
+          !(gen.workspaces.existingWorkspaces && !gen.options.askAnswered) &&
+          gen.applications.filter(app => app.databaseTypeMongodb || app.databaseTypeCouchbase) !== 0,
+      }),
+      scope: 'storage',
+    },
+    serviceDiscoveryType: {
+      prompt: gen => ({
+        name: 'serviceDiscoveryType',
+        message: 'Which Service Discovery registry and Configuration server would you like to use ?',
+        type: 'list',
+        default: () => {
+          const serviceDiscoveryEnabledApps = gen.applications.filter(app => app.serviceDiscoveryAny ?? false);
+          if (serviceDiscoveryEnabledApps.length === 0) {
+            return NO_SERVICE_DISCOVERY;
+          }
+          if (serviceDiscoveryEnabledApps.every(app => app.serviceDiscoveryConsul)) {
+            gen.log.log(chalk.green('Consul detected as the service discovery and configuration provider used by your apps'));
+            return CONSUL;
+          } else if (serviceDiscoveryEnabledApps.every(app => app.serviceDiscoveryEureka)) {
+            gen.log.log(chalk.green('JHipster registry detected as the service discovery and configuration provider used by your apps'));
+            return EUREKA;
+          }
+          gen.log.warn(
+            chalk.yellow('Unable to determine the service discovery and configuration provider to use from your apps configuration.'),
+          );
+          gen.log.verboseInfo('Your service discovery enabled apps:');
+          serviceDiscoveryEnabledApps.forEach(app => {
+            gen.log.verboseInfo(` -${app.baseName} (${app.serviceDiscoveryType})`);
+          });
+          return CONSUL;
+        },
+        when: () => {
+          if (!(gen.workspaces.existingWorkspaces && !gen.options.askAnswered)) {
+            return false;
+          }
+          const serviceDiscoveryEnabledApps = gen.applications.filter(app => app.serviceDiscoveryAny);
+          if (serviceDiscoveryEnabledApps.length === 0) {
+            gen.jhipsterConfig.serviceDiscoveryType = NO_SERVICE_DISCOVERY;
+          }
+          return serviceDiscoveryEnabledApps.length !== 0;
+        },
+        choices: [
+          {
+            value: CONSUL,
+            name: 'Consul',
+          },
+          {
+            value: EUREKA,
+            name: 'JHipster Registry',
+          },
+          {
+            value: NO_SERVICE_DISCOVERY,
+            name: 'No Service Discovery and Configuration',
+          },
+        ],
+      }),
+      scope: 'storage',
+    },
+    adminPassword: {
+      prompt: gen => ({
+        type: 'input',
+        when: () => !gen.workspaces.existingWorkspaces && gen.options.askAnswered && gen.serviceDiscoveryType === EUREKA,
+        name: 'adminPassword',
+        message: 'Enter the admin password used to secure the JHipster Registry',
+        default: 'admin',
+        validate: input => (input.length < 5 ? 'The password must have at least 5 characters' : true),
+      }),
+      scope: 'storage',
+    },
     jwtSecretKey: {
       cli: {
         type: String,

--- a/generators/spring-boot/templates/README.md.jhi.spring-boot.ejs
+++ b/generators/spring-boot/templates/README.md.jhi.spring-boot.ejs
@@ -104,7 +104,7 @@ When using Kubernetes, importing should be done using init-containers (with a vo
 
 ### Okta
 
-If you'd like to use Okta instead of Keycloak, it's pretty quick. 
+If you'd like to use Okta instead of Keycloak, it's pretty quick.
 
 First, you'll need to create a free developer account at <https://developer.okta.com/signup/>. After doing so, you'll get your own Okta domain, that has a name like `https://dev-123456.okta.com`.
 

--- a/lib/testing/helpers.ts
+++ b/lib/testing/helpers.ts
@@ -70,7 +70,6 @@ type JHipsterRunResult<GeneratorType extends CoreGenerator = CoreGenerator> = Om
    */
   composedMockedGenerators: string[];
 
-  // eslint-disable-next-line no-use-before-define
   createJHipster: (ns: string, options?: WithJHipsterGenerators) => JHipsterRunContext;
 
   application?: ApplicationType;


### PR DESCRIPTION
Hi,

I'll need a bit of help: I tried to move docker-compose properties to commands, but unfortunately the config is also used in server generator.
I don't know by which magic this configuration worked before, but it looks like it was hacky way.

Can you please help when you'll have time @mshima?

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
