### PR TITLE
Spring Boot: fix test _entityClass_ResourceIT.java.ejs for composed types with OneToOne and @MapsId (eg when extending User)

### DIFF
--- a/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
@@ -24,10 +24,12 @@ import static <%= packageName %>.web.rest.TestUtil.createUpdateProxyForBean;
 var filterTestableRelationships = (reactive ? reactiveEagerRelations : relationships).filter(rel => rel.persistableRelationship && !rel.otherEntity.hasCyclicRequiredRelationship);
 const fieldsToTest = fields.filter(field => !field.id && !field.autoGenerate && !field.transient);
 let mapsIdEntity;
+let mapsIdProperty;
 let mapsIdEntityInstance;
 let mapsIdRepoInstance;
 if (isUsingMapsId) {
   mapsIdEntity = mapsIdAssoc.otherEntityNameCapitalized;
+  mapsIdProperty = mapsIdAssoc.propertyNameCapitalized;
   mapsIdEntityInstance =  mapsIdEntity.charAt(0).toLowerCase() + mapsIdEntity.slice(1);
   mapsIdRepoInstance = `${mapsIdEntityInstance}Repository`;
 }
@@ -834,8 +836,8 @@ _%>
         em.detach(updated<%= persistClass %>);
     <%_ } _%>
 
-        // Update the <%= mapsIdEntity %> with new association value
-        updated<%= persistClass %>.set<%= mapsIdEntity %>(<%= alreadyGeneratedEntities.pop() %>);
+        // Update the updated<%= persistClass %> with new association value
+        updated<%= persistClass %>.set<%= mapsIdProperty %>(<%= alreadyGeneratedEntities.pop() %>);
     <%_ if (dtoMapstruct) { _%>
         <%= dtoClass %> updated<%= dtoClass %> = <%= entityInstance %>Mapper.toDto(updated<%= persistClass %>);
         assertThat(updated<%= dtoClass %>).isNotNull();
@@ -865,7 +867,7 @@ _%>
          * Validate the id for MapsId, the ids must be same
          * Uncomment the following line for assertion. However, please note that there is a known issue and uncommenting will fail the test.
          * Please look at https://github.com/jhipster/generator-jhipster/issues/9100. You can modify this test as necessary.
-         * assertThat(test<%= entityClass %>.get<%= primaryKey.nameCapitalized %>()).isEqualTo(test<%= entityClass %>.get<%= mapsIdEntity %>().get<%= primaryKey.nameCapitalized %>());
+         * assertThat(updated<%= persistClass %>.get<%= primaryKey.nameCapitalized %>()).isEqualTo(updated<%= persistClass %>.get<%= mapsIdProperty %>().get<%= primaryKey.nameCapitalized %>());
          */
     <%_ if (searchEngineElasticsearch) { _%>
         int searchDatabaseSizeAfter = IterableUtil.sizeOf(<%= entityInstance %>SearchRepository.findAll()<%= callListBlock %>);


### PR DESCRIPTION
See Issue #29901

##### **Suggested changes**
In the file `test _entityClass_ResourceIT.java.ejs`, I noticed that it's generating the name of the setter with:
```
mapsIdAssoc.otherEntityNameCapitalized
```
It's using the class name from the other entity (in this case `User`) when generating the name for the setter method. Which only works if the field/setter has the same name as the class. However, in my case (and in the case shown in the documentation for extending a user https://www.jhipster.tech/user-entity/ ): The field is called `internalUser` and the class is called `User`.

I tried to find something containing `InternalUser` (case-sensitive) and found the following possibilities:
* `mapsIdAssoc.relationshipNameCapitalized`
* `mapsIdAssoc.propertyNameCapitalized`
* `mapsIdAssoc.propertyJavaBeanName`
All of these 3 options contained `InternalUser`. I'm not sure about the exact meanings of each. 

My proposed fix is to use:
```
mapsIdAssoc.propertyNameCapitalized
```

##### **Testing**

I tested my changes from this commit locally (by using `npm ci` and setting an alias) and am now receiving Spring Boot (Java) code which compiles successfully. I started the application and verified that the entities are visible via the GUI. However, I haven't yet thoroughly tested my new composed types. I'm assuming that it works because it's something that's mentioned in the documentation. But I will be trying to use it (run-time) anyway in the near future because I want to use it.

I haven't written any automated test for it. I might look into that if it's required. However I'm not sure if I'm able to figure out where to put such a test or which kind of test to write.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [X] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
