### PR TITLE
Suppress warning in SqlTestContainersSpringContextCustomizerFactory

### DIFF
--- a/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
+++ b/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
@@ -66,7 +66,7 @@ public class SqlTestContainersSpringContextCustomizerFactory implements ContextC
                             Class<? extends SqlTestContainer> containerClass = (Class<? extends SqlTestContainer>) Class.forName(this.getClass().getPackageName() + ".<% if (prodDatabaseTypeMysql) { %>Mysql<% } else if (prodDatabaseTypeMariadb) { %>Mariadb<% } else if (prodDatabaseTypeMssql) { %>MsSql<% } else if (prodDatabaseTypePostgresql) { %>PostgreSql<% } %>TestContainer");
                             prodTestContainer = beanFactory.createBean(containerClass);
                             beanFactory.registerSingleton(containerClass.getName(), prodTestContainer);
-                            /**
+                            /*
                              * ((DefaultListableBeanFactory)beanFactory).registerDisposableBean(containerClass.getName(), prodTestContainer);
                              */
                         } catch (ClassNotFoundException e) {

--- a/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
+++ b/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
@@ -62,16 +62,12 @@ public class SqlTestContainersSpringContextCustomizerFactory implements ContextC
                     log.debug("detected the EmbeddedSQL annotation on class {}", testClass.getName());
                     log.info("Warming up the sql database");
                     if (null == prodTestContainer) {
-                        try {
-                            Class<?> containerClass = Class.forName(this.getClass().getPackageName() + ".<% if (prodDatabaseTypeMysql) { %>Mysql<% } else if (prodDatabaseTypeMariadb) { %>Mariadb<% } else if (prodDatabaseTypeMssql) { %>MsSql<% } else if (prodDatabaseTypePostgresql) { %>PostgreSql<% } %>TestContainer");
-                            prodTestContainer = (SqlTestContainer) beanFactory.createBean(containerClass);
-                            beanFactory.registerSingleton(containerClass.getName(), prodTestContainer);
-                            /*
-                             * ((DefaultListableBeanFactory)beanFactory).registerDisposableBean(containerClass.getName(), prodTestContainer);
-                             */
-                        } catch (ClassNotFoundException e) {
-                            throw new RuntimeException(e);
-                        }
+                        Class<? extends SqlTestContainer> containerClass = <% if (prodDatabaseTypeMysql) { %>Mysql<% } else if (prodDatabaseTypeMariadb) { %>Mariadb<% } else if (prodDatabaseTypeMssql) { %>MsSql<% } else if (prodDatabaseTypePostgresql) { %>PostgreSql<% } %>TestContainer.class;
+                        prodTestContainer = beanFactory.createBean(containerClass);
+                        beanFactory.registerSingleton(containerClass.getName(), prodTestContainer);
+                        /*
+                         * ((DefaultListableBeanFactory)beanFactory).registerDisposableBean(containerClass.getName(), prodTestContainer);
+                         */
                     }
     <%_ if (reactive) { _%>
                     testValues = testValues.and("spring.r2dbc.url=" + prodTestContainer.getTestContainer().getJdbcUrl().replace("jdbc", "r2dbc")<% if (prodDatabaseTypeMariadb) { %>.replace("mariadb", "mysql")<% } else if (prodDatabaseTypeMssql) { %>.replace(";encrypt=false", "")<% } %> + "<%- prodDatabaseExtraOptions %>");

--- a/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
+++ b/generators/spring-data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
@@ -63,8 +63,8 @@ public class SqlTestContainersSpringContextCustomizerFactory implements ContextC
                     log.info("Warming up the sql database");
                     if (null == prodTestContainer) {
                         try {
-                            Class<? extends SqlTestContainer> containerClass = (Class<? extends SqlTestContainer>) Class.forName(this.getClass().getPackageName() + ".<% if (prodDatabaseTypeMysql) { %>Mysql<% } else if (prodDatabaseTypeMariadb) { %>Mariadb<% } else if (prodDatabaseTypeMssql) { %>MsSql<% } else if (prodDatabaseTypePostgresql) { %>PostgreSql<% } %>TestContainer");
-                            prodTestContainer = beanFactory.createBean(containerClass);
+                            Class<?> containerClass = Class.forName(this.getClass().getPackageName() + ".<% if (prodDatabaseTypeMysql) { %>Mysql<% } else if (prodDatabaseTypeMariadb) { %>Mariadb<% } else if (prodDatabaseTypeMssql) { %>MsSql<% } else if (prodDatabaseTypePostgresql) { %>PostgreSql<% } %>TestContainer");
+                            prodTestContainer = (SqlTestContainer) beanFactory.createBean(containerClass);
                             beanFactory.registerSingleton(containerClass.getName(), prodTestContainer);
                             /*
                              * ((DefaultListableBeanFactory)beanFactory).registerDisposableBean(containerClass.getName(), prodTestContainer);


### PR DESCRIPTION
I think we can use the direct type here to remove the warning. But if not, we can use the commit just before to remove it as well.

**Note:** Why is the registerDisposableBean commented out? It should be there or not.
