### PR TITLE
update prepare entity with base-application type

### DIFF
--- a/generators/base-application/support/prepare-entity.spec.ts
+++ b/generators/base-application/support/prepare-entity.spec.ts
@@ -21,8 +21,8 @@ import { beforeEach, describe, it } from 'esmocha';
 
 import { expect } from 'chai';
 
-import type { EntityAll } from '../../../lib/types/application-all.d.ts';
 import { formatDateForChangelog } from '../../base/support/index.ts';
+import type { Entity } from '../types.d.ts';
 
 import { entityDefaultConfig, prepareEntityPrimaryKeyForTemplates } from './prepare-entity.ts';
 
@@ -71,7 +71,7 @@ describe('generator - base-application - support - prepareEntity', () => {
             { fieldName: 'id', fieldType: 'CustomType', path: ['id'] },
             { fieldName: 'uuid', fieldType: 'UUID', id: true, path: ['uuid'] },
           ],
-        } as unknown as EntityAll;
+        } as unknown as Entity;
         beforeEach(() => {
           entity = prepareEntityPrimaryKeyForTemplates({ entity });
         });

--- a/generators/base-application/support/prepare-entity.ts
+++ b/generators/base-application/support/prepare-entity.ts
@@ -23,7 +23,6 @@ import { APPLICATION_TYPE_GATEWAY, APPLICATION_TYPE_MICROSERVICE } from '../../.
 import { binaryOptions } from '../../../lib/jdl/core/built-in-options/index.ts';
 import type { FieldType } from '../../../lib/jhipster/field-types.ts';
 import { databaseTypes, fieldTypes, searchEngineTypes } from '../../../lib/jhipster/index.ts';
-import type { EntityAll, FieldAll } from '../../../lib/types/application-all.d.ts';
 import { getMicroserviceAppName, mutateData, normalizePathEnd, stringHashCode, upperFirstCamelCase } from '../../../lib/utils/index.ts';
 import { parseChangelog } from '../../base/support/timestamp.ts';
 import type CoreGenerator from '../../base-core/generator.js';
@@ -36,7 +35,7 @@ import { getDatabaseTypeData, hibernateSnakeCase } from '../../server/support/in
 import type { Entity as ServerEntity } from '../../server/types.ts';
 import type { Config as SpringBootConfig } from '../../spring-boot/types.ts';
 import type { Config as SpringDataRelationalConfig } from '../../spring-data-relational/types.ts';
-import type { PrimaryKey } from '../types.js';
+import type { Entity, Field, PrimaryKey, Relationship } from '../types.ts';
 
 import { createFaker } from './faker.ts';
 import { fieldIsEnum } from './field-utils.ts';
@@ -278,7 +277,7 @@ export function prepareEntityPrimaryKeyForTemplates(
     entity: entityWithConfig,
     enableCompositeId = true,
     application,
-  }: { entity: EntityAll; enableCompositeId?: boolean; application?: any },
+  }: { entity: Entity<Field, Relationship>; enableCompositeId?: boolean; application?: any },
 ) {
   const idFields = entityWithConfig.fields.filter(field => field.id);
   const idRelationships = entityWithConfig.relationships.filter(relationship => relationship.id);
@@ -301,7 +300,7 @@ export function prepareEntityPrimaryKeyForTemplates(
         fieldNameHumanized: 'ID',
         fieldTranslationKey: 'global.field.id',
         autoGenerate: true,
-      } as FieldAll;
+      } as Field;
       entityWithConfig.fields.unshift(idField);
     }
     idFields.push(idField);
@@ -440,7 +439,7 @@ export function prepareEntityPrimaryKeyForTemplates(
   return entityWithConfig;
 }
 
-function fieldToId(field: FieldAll): any {
+function fieldToId(field: Field): any {
   return {
     field,
     get name() {
@@ -542,10 +541,10 @@ export function preparePostEntityCommonDerivedProperties(entity: CommonEntity) {
     entity.anyFieldHasTextContentType = blobFieldsContentType.includes(TEXT);
   }
 
-  preparePostEntityCommonDerivedPropertiesNotTyped(entity as EntityAll);
+  preparePostEntityCommonDerivedPropertiesNotTyped(entity as Entity);
 }
 
-function preparePostEntityCommonDerivedPropertiesNotTyped(entity: EntityAll) {
+function preparePostEntityCommonDerivedPropertiesNotTyped(entity: Entity) {
   const { relationships, fields } = entity;
   const oneToOneRelationships = relationships.filter(({ relationshipType }) => relationshipType === 'one-to-one');
   entity.fieldsContainNoOwnerOneToOne = oneToOneRelationships.some(({ ownerSide }) => !ownerSide);

--- a/generators/base-application/support/prepare-field.ts
+++ b/generators/base-application/support/prepare-field.ts
@@ -24,8 +24,8 @@ import { applyDerivedPropertyOnly, mutateData } from '../../../lib/utils/index.t
 import type CoreGenerator from '../../base-core/generator.js';
 import { getTypescriptType } from '../../client/support/index.ts';
 import type { Entity as CommonEntity, Field as CommonField } from '../../common/types.d.ts';
-import type { DatabaseProperty } from '../../liquibase/types.js';
 import { isFieldEnumType } from '../internal/types/field-types.ts';
+import type { Field } from '../types.js';
 
 import type { FakerWithRandexp } from './faker.js';
 import { prepareProperty } from './prepare-property.ts';
@@ -195,7 +195,7 @@ function generateFakeDataForField(
   } else if (field.fieldTypeBinary && field.fieldTypeBlobContent === TEXT) {
     data = '../fake-data/blob/hipster.txt';
   } else if (field.fieldType === STRING) {
-    data = field.id ? faker.string.uuid() : faker.helpers.fake(fakeStringTemplateForFieldName((field as DatabaseProperty).columnName!));
+    data = field.id ? faker.string.uuid() : faker.helpers.fake(fakeStringTemplateForFieldName((field as Field).columnName!));
   } else if (field.fieldType === UUID) {
     data = faker.string.uuid();
   } else if (field.fieldType === BOOLEAN) {

--- a/generators/base-application/types.d.ts
+++ b/generators/base-application/types.d.ts
@@ -31,6 +31,7 @@ type Property = {
 
   skipClient?: boolean;
   skipServer?: boolean;
+  columnName?: string;
 };
 
 export type Field = Property &
@@ -85,6 +86,8 @@ export type Field = Property &
 
     fieldTypeBytes?: boolean;
     // Derived properties
+    dynamic?: boolean;
+    derivedPath?: string[];
     fieldTypeBinary?: boolean;
     fieldTypeDuration?: boolean;
     fieldTypeLocalDate?: boolean;
@@ -109,6 +112,7 @@ export type Field = Property &
 
     enumInstance?: string;
     builtIn?: boolean;
+    requiresPersistableImplementation?: boolean;
   };
 
 export type DerivedField<E extends Entity = Entity, F extends Field = Entity['fields'][number]> = F & {
@@ -125,6 +129,13 @@ export interface Relationship
   extends Property,
     BaseRelationship,
     DerivedPropertiesOnlyOf<'relationship', 'LeftSide' | 'RightSide' | 'ManyToOne' | 'OneToMany' | 'OneToOne' | 'ManyToMany'> {
+  derivedPrimaryKey?: {
+    derivedFields: (Field & {
+      originalField: Field;
+      derived: boolean;
+    })[];
+  };
+
   relationshipNameCapitalized: string;
   otherRelationship: this;
   collection: boolean;
@@ -149,6 +160,7 @@ export interface Relationship
 
   relationshipValidate?: boolean;
   relationshipValidateRules?: string[];
+  bagRelationship?: boolean;
 }
 
 /**
@@ -205,6 +217,7 @@ export interface Entity<F extends Field = Field, R extends Relationship = Relati
   extends Omit<Required<BaseEntity<F>>, 'relationships'> {
   relationships: RelationshipWithEntity<R, this>[];
   otherRelationships: R[];
+  entityClass: string;
 
   primaryKey?: PrimaryKey<F>;
 
@@ -277,6 +290,26 @@ export interface Entity<F extends Field = Field, R extends Relationship = Relati
   applicationType?: string;
   microfrontend?: boolean;
   skipUiGrouping?: boolean;
+  fieldsContainNoOwnerOneToOne?: boolean;
+  anyPropertyHasValidation?: boolean;
+  relationshipsByOtherEntity?: Record<string, RelationshipWithEntity<R, this>[]>;
+  differentRelationships?: Record<string, RelationshipWithEntity<R, this>[]>;
+  otherEntities?: this[];
+  persistableRelationships?: RelationshipWithEntity<R, this>[];
+  otherEntitiesWithPersistableRelationship?: this[];
+  updatableEntity?: boolean;
+  entityContainsCollectionField?: boolean;
+  requiresPersistableImplementation?: boolean;
+  otherEntityPrimaryKeyTypes?: string[];
+  otherEntityPrimaryKeyTypesIncludesUUID?: boolean;
+  eagerLoad?: boolean;
+  relationshipsContainEagerLoad?: boolean;
+  containsBagRelationships?: boolean;
+  implementsEagerLoadApis?: boolean;
+  eagerRelations?: RelationshipWithEntity<R, this>[];
+  regularEagerRelations?: RelationshipWithEntity<R, this>[];
+  reactiveEagerRelations: RelationshipWithEntity<R, this>[];
+  reactiveRegularEagerRelations?: RelationshipWithEntity<R, this>[];
 }
 
 /* ApplicationType Start */

--- a/generators/java/types.d.ts
+++ b/generators/java/types.d.ts
@@ -75,7 +75,6 @@ export interface Entity<F extends Field = Field, R extends Relationship = Relati
   entityJavadoc?: string;
   entityApiDescription?: string;
 
-  entityClass: string;
   entityClassPlural: string;
   entityAbsoluteClass: string;
   /** Entity folder relative to project root */

--- a/generators/liquibase/types.d.ts
+++ b/generators/liquibase/types.d.ts
@@ -35,7 +35,6 @@ export type LiquibaseSourceType = BaseEntityChangesSource & {
 export type Source = LiquibaseSourceType & JavaSource;
 
 export type DatabaseProperty = {
-  columnName?: string;
   columnRequired?: boolean;
   nullable?: boolean;
 };

--- a/generators/spring-boot/types.d.ts
+++ b/generators/spring-boot/types.d.ts
@@ -1,6 +1,6 @@
 import type { HandleCommandTypes } from '../../lib/command/types.js';
 import type { OptionWithDerivedProperties } from '../base-application/internal/types/application-options.js';
-import type { Entity as BaseApplicationEntity, RelationshipWithEntity } from '../base-application/types.js';
+import type { Entity as BaseApplicationEntity } from '../base-application/types.js';
 import type { Config as CommonConfig } from '../common/types.d.ts';
 import type { Application as GradleApplication } from '../gradle/types.js';
 import type { JavaAnnotation } from '../java/support/add-java-annotation.ts';
@@ -54,7 +54,6 @@ export type Field = ServerField &
     autoGenerateByRepository?: boolean;
     mapstructExpression?: boolean;
 
-    requiresPersistableImplementation?: boolean;
     fieldNameAsDatabaseColumn?: string;
   };
 
@@ -67,7 +66,6 @@ export interface Entity<F extends Field = Field, R extends Relationship = Relati
 
   isUsingMapsId?: boolean;
   mapsIdAssoc?: R;
-  reactiveEagerRelations: RelationshipWithEntity<R, this>[];
 
   reactiveOtherEntities: Set<this>;
   reactiveUniqueEntityTypes: Set<string>;

--- a/lib/types/application-all.d.ts
+++ b/lib/types/application-all.d.ts
@@ -17,11 +17,7 @@
  * limitations under the License.
  */
 import type { Entity as AngularEntity } from '../../generators/angular/types.d.ts';
-import type {
-  Application as BaseApplication,
-  Entity as BaseApplicationEntity,
-  RelationshipWithEntity,
-} from '../../generators/base-application/types.d.ts';
+import type { Application as BaseApplication, Entity as BaseApplicationEntity } from '../../generators/base-application/types.d.ts';
 import type { Application as ClientApplication, Field as ClientField } from '../../generators/client/types.d.ts';
 import type { Application as DockerApplication } from '../../generators/docker/types.d.ts';
 import type { Application as GitApplication } from '../../generators/git/types.d.ts';
@@ -45,54 +41,16 @@ import type {
   Relationship as SpringDataRelationalRelationship,
 } from '../../generators/spring-data-relational/types.d.ts';
 
-export type FieldAll = SpringDataRelationalField &
-  LiquibaseField &
-  ClientField & {
-    derivedPath?: string[];
-    dynamic?: boolean;
-  };
+export type FieldAll = SpringDataRelationalField & LiquibaseField & ClientField & {};
 
-export interface RelationshipAll extends SpringDataRelationalRelationship, ServerRelationship, LiquibaseRelationship {
-  bagRelationship?: boolean;
-  derivedPrimaryKey?: {
-    derivedFields: (FieldAll & {
-      originalField: FieldAll;
-      derived: boolean;
-    })[];
-  };
-}
+export interface RelationshipAll extends SpringDataRelationalRelationship, ServerRelationship, LiquibaseRelationship {}
 
 export interface EntityAll<F extends FieldAll = FieldAll, R extends RelationshipAll = RelationshipAll>
   extends BaseApplicationEntity<F, R>,
     AngularEntity<F, R>,
     LiquibaseEntity<F, R>,
     SpringDataRelationalEntity<F, R>,
-    SpringBootEntity<F, R> {
-  updatableEntity?: boolean;
-  eagerLoad?: boolean;
-  implementsEagerLoadApis?: boolean;
-  requiresPersistableImplementation?: boolean;
-
-  fieldsContainNoOwnerOneToOne?: boolean;
-  anyPropertyHasValidation?: boolean;
-  entityContainsCollectionField?: boolean;
-  relationshipsContainEagerLoad?: boolean;
-  containsBagRelationships?: boolean;
-
-  otherEntityPrimaryKeyTypes?: string[];
-  otherEntityPrimaryKeyTypesIncludesUUID?: boolean;
-
-  otherEntities?: this[];
-  otherEntitiesWithPersistableRelationship?: this[];
-
-  regularEagerRelations?: RelationshipWithEntity<R, this>[];
-  eagerRelations?: RelationshipWithEntity<R, this>[];
-  reactiveRegularEagerRelations?: RelationshipWithEntity<R, this>[];
-  persistableRelationships?: RelationshipWithEntity<R, this>[];
-
-  relationshipsByOtherEntity?: Record<string, RelationshipWithEntity<R, this>[]>;
-  differentRelationships?: Record<string, RelationshipWithEntity<R, this>[]>;
-}
+    SpringBootEntity<F, R> {}
 
 export interface UserEntity extends EntityAll {
   hasImageField?: boolean;


### PR DESCRIPTION
Contributes to https://github.com/jhipster/generator-jhipster/issues/28235
**NOT MEANT TO BE MERGED** - Just to identify the amount of fields to move to their respective generators

I know that we should do the reverse (lowering the fields where they are used but this PR is a starter to do so: knowing the fields to move downstream by not using <type>-all is a prereq IMHO

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
