### PR TITLE
prevent addition of @JsonIgnoreProperties for entity with DTO mapping and database-type as sql

### DIFF
--- a/generators/java/generators/domain/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
+++ b/generators/java/generators/domain/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.ejs
@@ -148,31 +148,37 @@ for (relationship of relationships) {
 <&- fragments.relationship<%- relationship.relationshipNameCapitalized %>AnnotationSection() -&>
   <%_ if (relationship.relationshipOneToMany) { _%>
     <%_ if (relationship.ignoreOtherSideProperty) { _%>
+      <%_ if (!dtoMapstruct || !databaseTypeSql ) { _%>
     @JsonIgnoreProperties(value = {
         <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
         "<%= otherRelationship.propertyName %>",
         <%_ }); _%>
     }, allowSetters = true)
+      <%_ } _%>
     <%_ } _%>
     private Set<<%= relationship.otherEntity.persistClass %>> <%= relationship.relationshipFieldNamePlural %> = new HashSet<>();
 
   <%_ } else if (relationship.relationshipManyToOne) { _%>
     <%_ if (relationship.ignoreOtherSideProperty) { _%>
+      <%_ if (!dtoMapstruct || !databaseTypeSql ) { _%>
     @JsonIgnoreProperties(value = {
       <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
         "<%= otherRelationship.propertyName %>",
       <%_ }); _%>
     }, allowSetters = true)
+      <%_ } _%>
     <%_ } _%>
     private <%= relationship.otherEntity.persistClass %> <%= relationship.relationshipFieldName %>;
 
   <%_ } else if (relationship.relationshipManyToMany) { _%>
     <%_ if (relationship.ignoreOtherSideProperty) { _%>
+      <%_ if (!dtoMapstruct || !databaseTypeSql ) { _%>
     @JsonIgnoreProperties(value = {
       <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
         "<%= otherRelationship.propertyName %>",
       <%_ }); _%>
     }, allowSetters = true)
+      <%_ } _%>
     <%_ } _%>
     private Set<<%= relationship.otherEntity.persistClass %>> <%= relationship.relationshipFieldNamePlural %> = new HashSet<>();
 

--- a/generators/spring-data-relational/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.jakarta_persistence.ejs
+++ b/generators/spring-data-relational/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.jakarta_persistence.ejs
@@ -102,7 +102,7 @@ import org.hibernate.type.SqlTypes;
                <%= relationship.otherEntity.primaryKey.fields.length > 1 ? '}' : '' %>
       <%_ } _%>
   <%_ } else { -%>
-      <%_ if (relationship.ignoreOtherSideProperty) { -%>
+      <%_ if (relationship.ignoreOtherSideProperty && (!dtoMapstruct || !databaseTypeSql )) { -%>
     @JsonIgnoreProperties(value = {
         <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
         "<%= otherRelationship.propertyName %>",


### PR DESCRIPTION
**Fix #29835**

**ISSUE :** 
Entities generated with DTO mappings have included @JsonIgnoreProperties for SQL databases, 
and it can lead to unexpected serialization behavior.

SOLUTION :
This change ensures that _@JsonIgnoreProperties_ is only added to entities when:
- Not using DTO mapping
- Using NoSQL databases (like MongoDB or Cassandra)

- Entities using DTOs rely on MapStruct for transformation, so _@JsonIgnoreProperties_ is unnecessary
- For SQL databases, this prevents unnecessary annotations and results in cleaner entity generation