### PR TITLE
fix: ensure login e2e tests target visible fields

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/login-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/login-page.cy.ts.ejs
@@ -49,7 +49,7 @@ describe('login page', () => {
 <%_ } _%>
 
   it('requires username', () => {
-    cy.get(passwordLoginSelector).type('a-password');
+    cy.get(passwordLoginSelector).should('be.visible').type('a-password');
     cy.get(submitLoginSelector).click();
 <%_ if (!clientFrameworkReact) { _%>
     cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(<% if (authenticationTypeSession) { %>401<% } else { %>400<% } %>));
@@ -59,7 +59,7 @@ describe('login page', () => {
   });
 
   it('requires password', () => {
-    cy.get(usernameLoginSelector).type('a-login');
+    cy.get(usernameLoginSelector).should('be.visible').type('a-login');
     cy.get(submitLoginSelector).click();
 <%_ if (!clientFrameworkReact) { _%>
     cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(<% if (authenticationTypeSession) { %>401<% } else { %>400<% } %>));
@@ -71,16 +71,16 @@ describe('login page', () => {
   });
 
   it('errors when password is incorrect', () => {
-    cy.get(usernameLoginSelector).type(username);
-    cy.get(passwordLoginSelector).type('bad-password');
+    cy.get(usernameLoginSelector).should('be.visible').type(username);
+    cy.get(passwordLoginSelector).should('be.visible').type('bad-password');
     cy.get(submitLoginSelector).click();
     cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(401));
     cy.get(errorLoginSelector).should('be.visible');
   });
 
   it('go to home page when successfully logs in', () => {
-    cy.get(usernameLoginSelector).type(username);
-    cy.get(passwordLoginSelector).type(password);
+    cy.get(usernameLoginSelector).should('be.visible').type(username);
+    cy.get(passwordLoginSelector).should('be.visible').type(password);
     cy.get(submitLoginSelector).click();
     cy.wait('@authenticate').then(({ response }) => expect(response?.statusCode).to.equal(200));
     cy.hash().should('eq', '');

--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/account/reset-password-page.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/account/reset-password-page.cy.ts.ejs
@@ -31,7 +31,7 @@ describe('forgot your password', () => {
   beforeEach(() => {
     cy.visit('');
     cy.clickOnLoginItem();
-    cy.get(usernameLoginSelector).type(username);
+    cy.get(usernameLoginSelector).should('be.visible').type(username);
     cy.get(forgetYourPasswordSelector).click();
   });
 


### PR DESCRIPTION
<!--
PR description.
-->
Made the login e2e tests more stable.
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
