### PR TITLE
Correct non-working EntityClass*Humanized annotations

### DIFF
--- a/generators/base-application/support/prepare-entity.ts
+++ b/generators/base-application/support/prepare-entity.ts
@@ -146,6 +146,7 @@ export default function prepareEntity(entityWithConfig: BaseApplicationEntity, g
   });
 
   mutateData(entityWithConfig, {
+    __override__: false,
     entityClassHumanized: ({ entityNameCapitalized }) => startCase(entityNameCapitalized),
     entityClassPluralHumanized: ({ entityNamePlural }) => startCase(entityNamePlural),
   });


### PR DESCRIPTION
<!--
PR description.
-->
In #28730 there were a few additional changes, especially concerning the handling of `entityClassHumanized` and `entityClassPluralHumanized`. The mutateData call was changed there from a string value (return value of the function) to passing a function. 

According to the docs of the mutateData function (and the actual behaviour), it would now always override the values with the values produced from the functions:

https://github.com/jhipster/generator-jhipster/blob/88050b594ce34b2b639a01d8b9b7134eed933446/lib/utils/object.ts#L73-L75

This leaves the two (non-internal!) annotations broken, i.e. the value set there in jdl does not have any effect anymore.

https://github.com/jhipster/generator-jhipster/blob/88050b594ce34b2b639a01d8b9b7134eed933446/generators/app/README.md?plain=1#L47-L55


---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
