### PR TITLE
bump node-version to 24 in CI

### DIFF
--- a/.github/actions/build-matrix/action.yml
+++ b/.github/actions/build-matrix/action.yml
@@ -93,7 +93,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
     - name: 'Check changes'
       id: build-changes
       run: |

--- a/.github/workflows/docker-compose-integration.yml
+++ b/.github/workflows/docker-compose-integration.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 24
       - run: npm ci --ignore-scripts
       - id: build
         run: bin/jhipster.cjs github-build-matrix docker-compose-integration --event-name ${{ github.event_name }}

--- a/.github/workflows/generator-graalvm.yml
+++ b/.github/workflows/generator-graalvm.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 24
       - run: npm ci --ignore-scripts
       - id: build
         run: bin/jhipster.cjs github-build-matrix graalvm --event-name ${{ github.event_name }}

--- a/generators/generate-blueprint/templates/.github/workflows/build-cache.yml.ejs
+++ b/generators/generate-blueprint/templates/.github/workflows/build-cache.yml.ejs
@@ -15,7 +15,7 @@ jobs:
           path: generator-jhipster-<%= baseName %>
       - uses: jhipster/actions/setup-runner@v0
         with:
-          node-version: 20
+          node-version: 24
           binary-dir: ${{ github.workspace }}/generator-jhipster-<%= baseName %>/cli/
       - uses: jhipster/actions/cache-npm-dependencies@v0
         with:


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/30467
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
