### PR TITLE
Fix URL: spring-boot application properties

### DIFF
--- a/generators/heroku/__snapshots__/heroku.spec.ts.snap
+++ b/generators/heroku/__snapshots__/heroku.spec.ts.snap
@@ -125,7 +125,7 @@ exports[`generator - Heroku microservice application with JAR deployment should 
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:
@@ -341,7 +341,7 @@ exports[`generator - Heroku monolith application in the EU should match files sn
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:
@@ -555,7 +555,7 @@ exports[`generator - Heroku monolith application in the US should match files sn
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:
@@ -824,7 +824,7 @@ exports[`generator - Heroku monolith application with Git deployment should matc
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:
@@ -1040,7 +1040,7 @@ exports[`generator - Heroku monolith application with PostgreSQL should match fi
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:
@@ -1278,7 +1278,7 @@ exports[`generator - Heroku monolith application with an unavailable app name sh
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:
@@ -1505,7 +1505,7 @@ exports[`generator - Heroku monolith application with elasticsearch should match
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:
@@ -1710,7 +1710,7 @@ exports[`generator - Heroku monolith application with existing app should match 
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:

--- a/generators/heroku/templates/application-heroku.yml.ejs
+++ b/generators/heroku/templates/application-heroku.yml.ejs
@@ -25,7 +25,7 @@
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 eureka:

--- a/generators/spring-boot/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application-dev.yml.ejs
@@ -28,7 +28,7 @@
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 logging:

--- a/generators/spring-boot/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application-prod.yml.ejs
@@ -28,7 +28,7 @@
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 logging:

--- a/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
@@ -29,7 +29,7 @@
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 ---

--- a/generators/spring-boot/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/spring-boot/templates/src/test/resources/config/application.yml.ejs
@@ -28,7 +28,7 @@
 # ===================================================================
 # Standard Spring Boot properties.
 # Full reference is available at:
-# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# https://docs.spring.io/spring-boot/appendix/application-properties/index.html
 # ===================================================================
 
 <%_ if (databaseTypeNeo4j && !databaseMigrationLiquibase) { _%>


### PR DESCRIPTION
`http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html` does not exist

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
