### PR TITLE
k8s: generate trustStore password instead of hardcoding (fixes #27051)

### DIFF
--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -218,7 +218,7 @@ spec:
       <%_ if (ingressTypeGke) { _%>
         # Custom trustStore required when using Let's Encrypt staging
         - name: JAVA_OPTS
-          value: "-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts -Djavax.net.ssl.trustStorePassword=123456 -Xmx256m -Xms256m"
+          value: "-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts -Djavax.net.ssl.trustStorePassword=<%= baseName %> -Xmx256m -Xms256m"
         - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI
           value: https://keycloak.<%= kubernetesNamespace %>.<%= ingressDomain %>/realms/jhipster
       <%_ } else { _%>

--- a/generators/kubernetes/templates/registry/jhipster-registry.yml.ejs
+++ b/generators/kubernetes/templates/registry/jhipster-registry.yml.ejs
@@ -131,7 +131,7 @@ spec:
           value: https://keycloak.<%= kubernetesNamespace %>.<%= ingressDomain %>/realms/jhipster
         # Custom trustStore required when using Let's Encrypt staging
         - name: JAVA_OPTS
-          value: "-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts -Djavax.net.ssl.trustStorePassword=123456"
+          value: "-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts -Djavax.net.ssl.trustStorePassword=<%= baseName %>"
         <%_ } else { _%>
         - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI
           value: http://keycloak.<%= kubernetesNamespace %>.<%= ingressDomain %>/realms/jhipster
@@ -157,7 +157,7 @@ spec:
           name: application-config
   <%_ if (useKeycloak) { _%>
       <%_ if (ingressTypeGke) { _%>
-      # When using Let's Encrypt staging certificates, for a successful start, add CAs to java truststore 
+      # When using Let's Encrypt staging certificates, for a successful start, add CAs to java truststore
       - name: java-truststore
         secret:
           secretName: letsencrypt-ca-secret


### PR DESCRIPTION
- Replace hardcoded -Djavax.net.ssl.trustStorePassword=<digits> with -Djavax.net.ssl.trustStorePassword=<%= baseName %>.
- Affects: generators/kubernetes/templates/jhipster-registry.yml.ejs, generators/kubernetes/templates/deployment.yml.ejs
- Motivation: fix Sonar/security finding; avoid hard-coded secrets.
- No breaking changes; only template values updated.
Fixes #27051.
