### PR TITLE
Fix URLs in generated readme.md

### DIFF
--- a/generators/angular/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/angular/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`generator - angular:bootstrap bootstrapping default config should prepa
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "dtoSuffix": "DTO",
   "dynamic": undefined,
   "embeddableLaunchScript": undefined,

--- a/generators/app/__snapshots__/generator.spec.ts.snap
+++ b/generators/app/__snapshots__/generator.spec.ts.snap
@@ -451,7 +451,7 @@ exports[`generator - app with default config should match snapshot 1`] = `
     "postgresql",
   ],
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "domains": [
     "com.mycompany.myapp",
   ],
@@ -1135,7 +1135,7 @@ exports[`generator - app with gateway should match snapshot 1`] = `
     "postgresql",
   ],
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "domains": [
     "com.mycompany.myapp",
   ],
@@ -1804,7 +1804,7 @@ exports[`generator - app with microservice should match snapshot 1`] = `
     "postgresql",
   ],
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "domains": [
     "com.mycompany.myapp",
   ],

--- a/generators/base-simple-application/__snapshots__/application.spec.ts.snap
+++ b/generators/base-simple-application/__snapshots__/application.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`application mutation test expects mutateApplication to match snapshot 1`] = `
 {
   "customizeTemplatePaths": [],
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vjhipsterVersion",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "hipsterBugTrackerLink": "https://github.com/jhipster/generator-jhipster/issues?state=open",
   "hipsterBugTrackerProductName": "JHipster",
   "hipsterChatLink": "https://gitter.im/jhipster/generator-jhipster",

--- a/generators/base-simple-application/application.ts
+++ b/generators/base-simple-application/application.ts
@@ -76,8 +76,7 @@ export const mutateApplication = {
   hipsterChatLink: 'https://gitter.im/jhipster/generator-jhipster',
 
   projectDescription: ({ projectDescription, humanizedBaseName }) => projectDescription ?? `Description for ${humanizedBaseName}`,
-  documentationArchiveUrl: ({ jhipsterVersion, hipsterDocumentationLink }) =>
-    `${hipsterDocumentationLink}documentation-archive/v${jhipsterVersion}`,
+  documentationArchiveUrl: ({ hipsterDocumentationLink }) => `${hipsterDocumentationLink}`,
 
   jhipsterPackageJson: packageJson,
 } as const satisfies MutateDataPropertiesWithRequiredProperties<

--- a/generators/ci-cd/__snapshots__/generator.spec.ts.snap
+++ b/generators/ci-cd/__snapshots__/generator.spec.ts.snap
@@ -139,7 +139,7 @@ exports[`generator - ci-cd cli with multiples values should match context snapsh
   "dockerContainers": Any<Object>,
   "dockerImage": undefined,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "domains": [
     "com.mycompany.myapp",
   ],

--- a/generators/client/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/client/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`generator - client:bootstrap bootstrapping default config should prepar
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "dtoSuffix": "DTO",
   "dynamic": undefined,
   "embeddableLaunchScript": undefined,

--- a/generators/common/__snapshots__/generator.spec.ts.snap
+++ b/generators/common/__snapshots__/generator.spec.ts.snap
@@ -123,7 +123,7 @@ plugins:
   "README.md": {
     "contents": "# jhipster
 
-This application was generated using JHipster JHIPSTER_VERSION, you can find documentation and help at [https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION](https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION).
+This application was generated using JHipster JHIPSTER_VERSION, you can find documentation and help at [https://www.jhipster.tech/releases/](https://www.jhipster.tech/releases/).
 
 
 ## Project Structure
@@ -141,13 +141,13 @@ This application was generated using JHipster JHIPSTER_VERSION, you can find doc
 
 
 [JHipster Homepage and latest documentation]: https://www.jhipster.tech/
-[JHipster JHIPSTER_VERSION archive]: https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION
-[Using JHipster in development]: https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION/development/
-[Using Docker and Docker-Compose]: https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION/docker-compose
-[Using JHipster in production]: https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION/production/
-[Running tests page]: https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION/running-tests/
-[Code quality page]: https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION/code-quality/
-[Setting up Continuous Integration]: https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION/setting-up-ci/
+[JHipster releases]: https://www.jhipster.tech/releases/
+[Using JHipster in development]: https://www.jhipster.tech/development/
+[Using Docker and Docker-Compose]: https://www.jhipster.tech/docker-compose
+[Using JHipster in production]: https://www.jhipster.tech/production/
+[Running tests page]: https://www.jhipster.tech/running-tests/
+[Code quality page]: https://www.jhipster.tech/code-quality/
+[Setting up Continuous Integration]: https://www.jhipster.tech/setting-up-ci/
 
 [Node.js]: https://nodejs.org/
 [NPM]: https://www.npmjs.com/

--- a/generators/common/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/common/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -109,7 +109,7 @@ exports[`generator - common:bootstrap bootstrapping default config should prepar
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "dtoSuffix": "DTO",
   "dynamic": undefined,
   "embeddableLaunchScript": undefined,

--- a/generators/common/templates/README.md.jhi.ejs
+++ b/generators/common/templates/README.md.jhi.ejs
@@ -34,7 +34,7 @@
 _&>
 # <%= baseName %>
 
-This application was generated using JHipster <%= jhipsterVersion %>, you can find documentation and help at [<%= documentationArchiveUrl %>](<%= documentationArchiveUrl %>).
+This application was generated using JHipster <%= jhipsterVersion %>, you can find documentation and help at [<%= documentationArchiveUrl %>releases/](<%= documentationArchiveUrl %>releases/).
 
 <&- fragments.introSection() &>
 ## Project Structure
@@ -57,22 +57,22 @@ This application was generated using JHipster <%= jhipsterVersion %>, you can fi
 <&- fragments.othersSection() &>
 <& } &>
 [JHipster Homepage and latest documentation]: <%= hipsterDocumentationLink %>
-[JHipster <%= jhipsterVersion %> archive]: <%= documentationArchiveUrl %>
+[JHipster releases]: <%= documentationArchiveUrl %>releases/
 <%_ if (applicationTypeGateway || applicationTypeMicroservice) { _%>
-[Doing microservices with JHipster]: <%= documentationArchiveUrl %>/microservices-architecture/
+[Doing microservices with JHipster]: <%= documentationArchiveUrl %>microservices-architecture/
 <%_ } _%>
-[Using JHipster in development]: <%= documentationArchiveUrl %>/development/
+[Using JHipster in development]: <%= documentationArchiveUrl %>development/
 <%_ if (serviceDiscoveryEureka) { _%>
-[Service Discovery and Configuration with the JHipster-Registry]: <%= documentationArchiveUrl %>/microservices-architecture/#jhipster-registry
+[Service Discovery and Configuration with the JHipster-Registry]: <%= documentationArchiveUrl %>microservices-architecture/#jhipster-registry
 <%_ } _%>
 <%_ if (serviceDiscoveryConsul) { _%>
-[Service Discovery and Configuration with Consul]: <%= documentationArchiveUrl %>/microservices-architecture/#consul
+[Service Discovery and Configuration with Consul]: <%= documentationArchiveUrl %>microservices-architecture/#consul
 <%_ } _%>
-[Using Docker and Docker-Compose]: <%= documentationArchiveUrl %>/docker-compose
-[Using JHipster in production]: <%= documentationArchiveUrl %>/production/
-[Running tests page]: <%= documentationArchiveUrl %>/running-tests/
-[Code quality page]: <%= documentationArchiveUrl %>/code-quality/
-[Setting up Continuous Integration]: <%= documentationArchiveUrl %>/setting-up-ci/
+[Using Docker and Docker-Compose]: <%= documentationArchiveUrl %>docker-compose
+[Using JHipster in production]: <%= documentationArchiveUrl %>production/
+[Running tests page]: <%= documentationArchiveUrl %>running-tests/
+[Code quality page]: <%= documentationArchiveUrl %>code-quality/
+[Setting up Continuous Integration]: <%= documentationArchiveUrl %>setting-up-ci/
 
 [Node.js]: https://nodejs.org/
 [NPM]: https://www.npmjs.com/

--- a/generators/java/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/java/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -112,7 +112,7 @@ exports[`generator - java:bootstrap bootstrapping default config should prepare 
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "domains": Any<Array>,
   "dtoSuffix": "DTO",
   "dynamic": undefined,

--- a/generators/javascript-simple-application/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/javascript-simple-application/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`generator - javascript-simple-application:bootstrap bootstrapping defau
   "creationTimestamp": 1577836800000,
   "customizeTemplatePaths": Any<Array>,
   "dasherizedBaseName": "jhipster",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "eslintConfigFile": "eslint.config.mjs",
   "hipster": "jhipster_family_member_3",
   "hipsterBugTrackerLink": "https://github.com/jhipster/generator-jhipster/issues?state=open",

--- a/generators/react/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/react/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`generator - react:bootstrap bootstrapping default config should prepare
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "dtoSuffix": "DTO",
   "dynamic": undefined,
   "embeddableLaunchScript": undefined,

--- a/generators/server/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/server/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -112,7 +112,7 @@ exports[`generator - server:bootstrap bootstrapping default config should prepar
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "dtoSuffix": "DTO",
   "dynamic": undefined,
   "embeddableLaunchScript": undefined,

--- a/generators/spring-boot/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-boot/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -112,7 +112,7 @@ exports[`generator - spring-boot:bootstrap bootstrapping default config should p
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "domains": Any<Array>,
   "dtoSuffix": "DTO",
   "dynamic": undefined,

--- a/generators/vue/generators/bootstrap/__snapshots__/generator.spec.ts.snap
+++ b/generators/vue/generators/bootstrap/__snapshots__/generator.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`generator - vue:bootstrap bootstrapping default config should prepare a
   "devServerPortProxy": 9000,
   "dockerContainers": Any<Object>,
   "dockerServicesDir": "src/main/docker/",
-  "documentationArchiveUrl": "https://www.jhipster.tech/documentation-archive/vJHIPSTER_VERSION",
+  "documentationArchiveUrl": "https://www.jhipster.tech/",
   "dtoSuffix": "DTO",
   "dynamic": undefined,
   "embeddableLaunchScript": undefined,


### PR DESCRIPTION
URLs in readme.md are KO

Examples:
- https://www.jhipster.tech/documentation-archive/v8.11.0
- https://www.jhipster.tech/documentation-archive/v8.11.0/code-quality/
- https://www.jhipster.tech/documentation-archive/v8.11.0/running-tests/
- ...

URLs with releases have date now (ex: https://www.jhipster.tech/2025/05/06/jhipster-release-8.11.0.html)

My proposition is:
Before
```
This application was generated using JHipster 8.11.0, you can find documentation and help at [https://www.jhipster.tech/documentation-archive/v8.11.0](https://www.jhipster.tech/documentation-archive/v8.11.0).
```
After
```
This application was generated using JHipster 8.11.0, you can find documentation and help at [https://www.jhipster.tech/releases/](https://www.jhipster.tech/releases/).
```

Before
```
[JHipster 8.11.0 archive]: https://www.jhipster.tech/documentation-archive/v8.11.0
[Using JHipster in development]: https://www.jhipster.tech/documentation-archive/v8.11.0/development/
[Using Docker and Docker-Compose]: https://www.jhipster.tech/documentation-archive/v8.11.0/docker-compose
[Using JHipster in production]: https://www.jhipster.tech/documentation-archive/v8.11.0/production/
[Running tests page]: https://www.jhipster.tech/documentation-archive/v8.11.0/running-tests/
[Code quality page]: https://www.jhipster.tech/documentation-archive/v8.11.0/code-quality/
[Setting up Continuous Integration]: https://www.jhipster.tech/documentation-archive/v8.11.0/setting-up-ci/
```
After
```
[JHipster releases]: https://www.jhipster.tech/releases/
[Using JHipster in development]: https://www.jhipster.tech/development/
[Using Docker and Docker-Compose]: https://www.jhipster.tech/docker-compose
[Using JHipster in production]: https://www.jhipster.tech/production/
[Running tests page]: https://www.jhipster.tech/running-tests/
[Code quality page]: https://www.jhipster.tech/code-quality/
[Setting up Continuous Integration]: https://www.jhipster.tech/setting-up-ci/
```

<img width="1497" height="153" alt="image" src="https://github.com/user-attachments/assets/996b7368-d227-4e71-840b-794c4516eb5f" />

<img width="1621" height="230" alt="image" src="https://github.com/user-attachments/assets/a0df1ae5-8bbe-437c-9f22-0f108a0107e4" />

@DanielFran @mshima WDYT?