### PR TITLE
[React] Ignore console error on tests

### DIFF
--- a/generators/react/templates/src/main/webapp/app/config/notification-middleware.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/config/notification-middleware.spec.ts.ejs
@@ -186,6 +186,8 @@ describe('Notification Middleware', () => {
     store = makeStore();
     sinon.spy(toastify.toast, 'error');
     sinon.spy(toastify.toast, 'success');
+    // ignore console errors
+    jest.spyOn(window.console, 'error').mockImplementation();
   });
 
   afterEach(() => {


### PR DESCRIPTION
Fix
<img width="1085" height="603" alt="image" src="https://github.com/user-attachments/assets/9c71bc52-ac15-4ec0-b1ec-df172bdca313" />
Same as https://github.com/jhipster/generator-jhipster/blob/57b5e442f20ef71e0c8afa4b315dcb6ad0955665/generators/react/templates/src/main/webapp/app/shared/error/error-boundary.spec.tsx.ejs#L12