### PR TITLE
Don’t restore npm cache in build-cache action

### DIFF
--- a/.github/actions/cache-java-dependencies/action.yml
+++ b/.github/actions/cache-java-dependencies/action.yml
@@ -32,6 +32,7 @@ runs:
     - uses: jhipster/actions/setup-runner@v0
       with:
         binary-dir: ${{ github.workspace }}/generator-jhipster/bin
+        npm-cache: false
     - name: 'mvn: install JHipster'
       run: |
         echo "::group::jhipster-bom"


### PR DESCRIPTION
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
