### PR TITLE
[Angular] Sonar: arrow function is equivalent to Boolean. Use Boolean directly

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.ts.ejs
@@ -64,7 +64,7 @@ export default class PasswordStrengthBar {
     const symbols = regex.test(p);
 
     const flags = [lowerLetters, upperLetters, numbers, symbols];
-    const passedMatches = flags.filter((isMatchedFlag: boolean) => isMatchedFlag).length;
+    const passedMatches = flags.filter(Boolean).length;
 
     force += 2 * p.length + (p.length >= 10 ? 1 : 0);
     force += passedMatches * 10;


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=jhipster-sample-application&open=AZl2F9-gX95Gr0TMtVBC