### PR TITLE
[Angular] Fix SASS warnings on vendor.scss

### DIFF
--- a/generators/angular/templates/src/main/webapp/content/scss/vendor.scss.ejs
+++ b/generators/angular/templates/src/main/webapp/content/scss/vendor.scss.ejs
@@ -26,9 +26,9 @@ eg $input-color: red;
 @import 'bootswatch/dist/<%= clientTheme %>/variables';
 <%_ } _%>
 // Override Bootstrap variables
-@import 'bootstrap-variables';
+@use 'bootstrap-variables';
 // Import Bootstrap source files from node_modules
-@import 'bootstrap/scss/bootstrap';
+@use 'bootstrap/scss/bootstrap';
 <%_ if (!clientThemeNone) { _%>
 @import 'bootswatch/dist/<%= clientTheme %>/bootswatch';
 <%_ } _%>


### PR DESCRIPTION
Related to #28808 

Fix:
<img width="573" height="507" alt="image" src="https://github.com/user-attachments/assets/6d844d25-d9c8-4656-ad62-4c8ebef9d5f4" />
