### PR TITLE
Remove link to Pivotal (End of Availability)

### DIFF
--- a/rfcs/2-jhipster-rfc-jhipster-control-center.md
+++ b/rfcs/2-jhipster-rfc-jhipster-control-center.md
@@ -121,7 +121,6 @@ Some existing similar or related solutions :
 - [JHipster Registry](https://www.jhipster.tech/jhipster-registry/)
 - [Spring Boot Admin](https://docs.spring-boot-admin.com/)
 - [Trampoline](https://ernestort.github.io/Trampoline/)
-- [Pivotal Cloud Foundry Apps Manager](https://docs.run.pivotal.io/console/manage-apps.html)
 - [Azure Spring Cloud](https://azure.microsoft.com/en-in/services/spring-cloud/): currently focused only on running Spring Boot workloads but we can expect management features coming to it in the future.
 
 ## Unresolved questions


### PR DESCRIPTION
Link doesn't exist

https://www.cloudamqp.com/blog/pws-end-of-life-move-to-us-directly.html