### PR TITLE
Fix: bump cassandra from 5.0.2 to 5.0.5

### DIFF
--- a/generators/docker-compose/__snapshots__/docker-compose.spec.ts.snap
+++ b/generators/docker-compose/__snapshots__/docker-compose.spec.ts.snap
@@ -354,6 +354,9 @@ jhipster:
   mscassandra-cassandra:
     image: cassandra-placeholder
     container_name: mscassandra-cassandra
+    environment:
+      - MAX_HEAP_SIZE=2G
+      - HEAP_NEWSIZE=512M
     healthcheck:
       test:
         - CMD

--- a/generators/docker/templates/docker/cassandra.yml.ejs
+++ b/generators/docker/templates/docker/cassandra.yml.ejs
@@ -22,6 +22,9 @@ services:
   cassandra:
     image: <%- dockerContainers.cassandra %>
     container_name: <%= baseName.toLowerCase() %>-cassandra
+    environment:
+      - MAX_HEAP_SIZE=2G
+      - HEAP_NEWSIZE=512M
     # volumes:
     #   - ~/volumes/jhipster/<%= baseName %>/cassandra/:/var/lib/cassandra/data
     # If you want to expose these ports outside your dev PC,

--- a/generators/server/resources/Dockerfile
+++ b/generators/server/resources/Dockerfile
@@ -26,7 +26,7 @@ LABEL ALIAS=mongodb
 FROM couchbase/server:7.6.7
 LABEL ALIAS=couchbase
 
-FROM cassandra:5.0.2
+FROM cassandra:5.0.5
 
 FROM mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04
 LABEL ALIAS=mssql


### PR DESCRIPTION
Fix #30285 