### PR TITLE
Sonar: Text does not meet the minimal contrast requirement with its background

### DIFF
--- a/generators/spring-boot/templates/src/main/resources/templates/error.html.ejs
+++ b/generators/spring-boot/templates/src/main/resources/templates/error.html.ejs
@@ -25,7 +25,6 @@
         padding: 30px 10px;
         font-size: 20px;
         line-height: 1.4;
-        color: #737373;
         background: #3e8acc;
         -webkit-text-size-adjust: 100%;
         -ms-text-size-adjust: 100%;
@@ -47,6 +46,7 @@
           0 1px 10px #a7a7a7,
           inset 0 1px 0 #fff;
         background: #fcfcfc;
+        color: #3D3D3D;
       }
 
       h1 {
@@ -56,7 +56,7 @@
       }
 
       h1 span {
-        color: #bbb;
+        color: #575757;
       }
 
       h3 {


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=jhipster-sample-application&open=AZoraGLP_nwc1dLy-plp&tab=code

**Before**
<img width="1240" height="502" alt="image" src="https://github.com/user-attachments/assets/c48741e8-2aff-477f-9816-77a201ff31f6" />

**After**
<img width="1288" height="511" alt="image" src="https://github.com/user-attachments/assets/aad1ec7f-9068-400c-8b18-3d25fd1064df" />
