### PR TITLE
Mount devcontainer workspace in same path from host

### DIFF
--- a/generators/spring-boot/templates/.devcontainer/devcontainer.json.ejs
+++ b/generators/spring-boot/templates/.devcontainer/devcontainer.json.ejs
@@ -62,6 +62,11 @@
 
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
+
+  // Mount the workspace folder to the same path inside the container, so docker-in-docker containers work correctly. See https://github.com/jhipster/generator-jhipster/issues/31239
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+  "workspaceFolder": "${localWorkspaceFolder}",
+
   "features": {
     "docker-in-docker": "latest",
     "docker-from-docker": "latest"


### PR DESCRIPTION
Docker in docker uses mounts from host.
When a devcontainer tries to start another container the relative path is according to devcontainer's workspace path.
Mounting the devcontainer in same path from host fixes the container's volumes started from devcontainer.

Fixes https://github.com/jhipster/generator-jhipster/issues/31239.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
