### PR TITLE
cypress: fix bug in collection relationships

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/e2e/entity/_entity_.cy.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/e2e/entity/_entity_.cy.ts.ejs
@@ -193,7 +193,7 @@ describe('<%- entityNameCapitalized %> e2e test', () => {
           body: {
             ...<%= entityInstance %>Sample,
     <%_ for (relationship of requiredRelationships) { _%>
-            <%= relationship.relationshipName %>: <%= relationship.otherEntity.entityInstance %>,
+            <%= relationship.propertyName %>: <%= relationship.collection ? '[' : '' %><%= relationship.otherEntity.entityInstance %><%= relationship.collection ? ']' : '' %>,
     <%_ } _%>
           },
   <%_ } else { _%>


### PR DESCRIPTION
In Spring Boot v4, tests fails due to unknown property. Happens in required collection relationships due to wrong property name.

Changes only -default samples.

Related to https://github.com/jhipster/generator-jhipster/issues/31529, https://github.com/jhipster/generator-jhipster/issues/31475

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
