### PR TITLE
spring-cache: drop jhipster.spring-cache-conventions.gradle

### DIFF
--- a/generators/generator-constants.ts
+++ b/generators/generator-constants.ts
@@ -49,7 +49,7 @@ export const MAIN_DIR = 'src/main/';
 export const TEST_DIR = 'src/test/';
 
 export const GRADLE_BUILD_SRC_DIR = 'buildSrc/';
-export const GRADLE_BUILD_SRC_MAIN_DIR = `${GRADLE_BUILD_SRC_DIR}/src/main/groovy/`;
+export const GRADLE_BUILD_SRC_MAIN_DIR = `${GRADLE_BUILD_SRC_DIR}src/main/groovy/`;
 
 // Note: this will be prepended with 'target/classes' for Maven, or with 'build/resources/main' for Gradle.
 export const CLIENT_DIST_DIR = 'static/';

--- a/generators/spring-cache/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-cache/__snapshots__/generator.spec.ts.snap
@@ -5,9 +5,6 @@ exports[`generator - spring-cache caffeine-gradle should match files snapshot 1`
   ".yo-rc.json": {
     "stateCleared": "modified",
   },
-  "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle": {
-    "stateCleared": "modified",
-  },
   "src/main/java/com/mycompany/myapp/config/CacheConfiguration.java": {
     "stateCleared": "modified",
   },
@@ -34,16 +31,8 @@ exports[`generator - spring-cache caffeine-gradle should match source calls 1`] 
       "version": "'TYPESAFE-VERSION'",
     },
   ],
-  "addGradlePlugin": [
-    {
-      "id": "jhipster.spring-cache-conventions",
-    },
-  ],
   "addJavaDefinitions": [
     [
-      {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
       {
         "dependencies": [
           {
@@ -113,9 +102,6 @@ exports[`generator - spring-cache caffeine-maven should match source calls 1`] =
   "addJavaDefinitions": [
     [
       {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
-      {
         "dependencies": [
           {
             "artifactId": "spring-boot-starter-cache",
@@ -167,9 +153,6 @@ exports[`generator - spring-cache ehcache-gradle should match files snapshot 1`]
   ".yo-rc.json": {
     "stateCleared": "modified",
   },
-  "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle": {
-    "stateCleared": "modified",
-  },
   "src/main/java/com/mycompany/myapp/config/CacheConfiguration.java": {
     "stateCleared": "modified",
   },
@@ -184,16 +167,8 @@ exports[`generator - spring-cache ehcache-gradle should match source calls 1`] =
       "relationships": [],
     },
   ],
-  "addGradlePlugin": [
-    {
-      "id": "jhipster.spring-cache-conventions",
-    },
-  ],
   "addJavaDefinitions": [
     [
-      {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
       {
         "dependencies": [
           {
@@ -255,9 +230,6 @@ exports[`generator - spring-cache ehcache-maven should match source calls 1`] = 
   "addJavaDefinitions": [
     [
       {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
-      {
         "dependencies": [
           {
             "artifactId": "spring-boot-starter-cache",
@@ -301,9 +273,6 @@ exports[`generator - spring-cache hazelcast-gradle should match files snapshot 1
   ".yo-rc.json": {
     "stateCleared": "modified",
   },
-  "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle": {
-    "stateCleared": "modified",
-  },
   "src/main/java/com/mycompany/myapp/config/CacheConfiguration.java": {
     "stateCleared": "modified",
   },
@@ -338,16 +307,8 @@ exports[`generator - spring-cache hazelcast-gradle should match source calls 1`]
       "version": "'HAZELCAST-HIBERNATE-53-VERSION'",
     },
   ],
-  "addGradlePlugin": [
-    {
-      "id": "jhipster.spring-cache-conventions",
-    },
-  ],
   "addJavaDefinitions": [
     [
-      {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
       {
         "dependencies": [
           {
@@ -410,9 +371,6 @@ exports[`generator - spring-cache hazelcast-maven should match source calls 1`] 
   "addJavaDefinitions": [
     [
       {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
-      {
         "dependencies": [
           {
             "artifactId": "spring-boot-starter-cache",
@@ -457,9 +415,6 @@ exports[`generator - spring-cache infinispan-gradle should match files snapshot 
   ".yo-rc.json": {
     "stateCleared": "modified",
   },
-  "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle": {
-    "stateCleared": "modified",
-  },
   "src/main/java/com/mycompany/myapp/config/CacheConfiguration.java": {
     "stateCleared": "modified",
   },
@@ -474,16 +429,8 @@ exports[`generator - spring-cache infinispan-gradle should match source calls 1`
       "relationships": [],
     },
   ],
-  "addGradlePlugin": [
-    {
-      "id": "jhipster.spring-cache-conventions",
-    },
-  ],
   "addJavaDefinitions": [
     [
-      {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
       {
         "dependencies": [
           {
@@ -559,9 +506,6 @@ exports[`generator - spring-cache infinispan-maven should match source calls 1`]
   "addJavaDefinitions": [
     [
       {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
-      {
         "dependencies": [
           {
             "artifactId": "spring-boot-starter-cache",
@@ -619,9 +563,6 @@ exports[`generator - spring-cache memcached-gradle should match files snapshot 1
   ".yo-rc.json": {
     "stateCleared": "modified",
   },
-  "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle": {
-    "stateCleared": "modified",
-  },
   "src/main/java/com/mycompany/myapp/config/CacheConfiguration.java": {
     "stateCleared": "modified",
   },
@@ -636,16 +577,8 @@ exports[`generator - spring-cache memcached-gradle should match source calls 1`]
       "relationships": [],
     },
   ],
-  "addGradlePlugin": [
-    {
-      "id": "jhipster.spring-cache-conventions",
-    },
-  ],
   "addJavaDefinitions": [
     [
-      {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
       {
         "dependencies": [
           {
@@ -717,9 +650,6 @@ exports[`generator - spring-cache memcached-maven should match source calls 1`] 
   "addJavaDefinitions": [
     [
       {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
-      {
         "dependencies": [
           {
             "artifactId": "spring-boot-starter-cache",
@@ -773,9 +703,6 @@ exports[`generator - spring-cache redis-gradle should match files snapshot 1`] =
   ".yo-rc.json": {
     "stateCleared": "modified",
   },
-  "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle": {
-    "stateCleared": "modified",
-  },
   "src/main/java/com/mycompany/myapp/config/CacheConfiguration.java": {
     "stateCleared": "modified",
   },
@@ -799,16 +726,8 @@ exports[`generator - spring-cache redis-gradle should match source calls 1`] = `
       "relationships": [],
     },
   ],
-  "addGradlePlugin": [
-    {
-      "id": "jhipster.spring-cache-conventions",
-    },
-  ],
   "addJavaDefinitions": [
     [
-      {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
       {
         "dependencies": [
           {
@@ -890,9 +809,6 @@ exports[`generator - spring-cache redis-maven should match source calls 1`] = `
   ],
   "addJavaDefinitions": [
     [
-      {
-        "gradleFile": "buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle",
-      },
       {
         "dependencies": [
           {

--- a/generators/spring-cache/files.ts
+++ b/generators/spring-cache/files.ts
@@ -17,15 +17,11 @@
  * limitations under the License.
  */
 import { asWriteFilesSection, asWritingTask } from '../base-application/support/task-type-inference.ts';
-import { GRADLE_BUILD_SRC_MAIN_DIR, SERVER_MAIN_SRC_DIR, SERVER_TEST_SRC_DIR } from '../generator-constants.ts';
+import { SERVER_MAIN_SRC_DIR, SERVER_TEST_SRC_DIR } from '../generator-constants.ts';
 import { moveToJavaPackageSrcDir, moveToJavaPackageTestDir } from '../java/support/index.ts';
 
 const files = asWriteFilesSection({
   cacheFiles: [
-    {
-      condition: data => data.buildToolGradle,
-      templates: [`${GRADLE_BUILD_SRC_MAIN_DIR}/jhipster.spring-cache-conventions.gradle`],
-    },
     {
       path: `${SERVER_MAIN_SRC_DIR}_package_/`,
       renameTo: moveToJavaPackageSrcDir,

--- a/generators/spring-cache/generator.ts
+++ b/generators/spring-cache/generator.ts
@@ -19,6 +19,7 @@
 import BaseApplicationGenerator from '../base-application/index.ts';
 import { createNeedleCallback } from '../base-core/support/needles.ts';
 import type { Source as CommonSource } from '../common/types.ts';
+import { GRADLE_BUILD_SRC_MAIN_DIR } from '../generator-constants.ts';
 
 import cleanupTask from './cleanup.ts';
 import writeTask from './files.ts';
@@ -115,6 +116,11 @@ export default class SpringCacheGenerator extends BaseApplicationGenerator<
 
   get writing() {
     return this.asWritingTaskGroup({
+      async cleanup({ control }) {
+        await control.cleanupFiles({
+          '9.0.0-alpha.0': [`${GRADLE_BUILD_SRC_MAIN_DIR}/jhipster.spring-cache-conventions.gradle`],
+        });
+      },
       cleanupTask,
       writeTask,
     });
@@ -161,7 +167,6 @@ export default class SpringCacheGenerator extends BaseApplicationGenerator<
               });
             }
           }
-          source.addGradlePlugin?.({ id: 'jhipster.spring-cache-conventions' });
         }
       },
       addDependencies({ application, source }) {
@@ -172,7 +177,6 @@ export default class SpringCacheGenerator extends BaseApplicationGenerator<
 
         const definition = getCacheProviderMavenDefinition(cacheProvider!, javaDependencies);
         source.addJavaDefinitions?.(
-          { gradleFile: 'buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle' },
           {
             ...definition.base,
             dependencies: [

--- a/generators/spring-cache/templates/buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle.ejs
+++ b/generators/spring-cache/templates/buildSrc/src/main/groovy/jhipster.spring-cache-conventions.gradle.ejs
@@ -1,3 +1,0 @@
-dependencies {
-    // jhipster-needle-gradle-dependency - JHipster will add additional dependencies here
-}


### PR DESCRIPTION
It's only used for dependencies. Spring Boot v4 should have less dependencies.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
