### PR TITLE
Feat/additional field type mapping for elasticsearch

### DIFF
--- a/generators/spring-data/generators/elasticsearch/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.elastic_search.ejs
+++ b/generators/spring-data/generators/elasticsearch/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.elastic_search.ejs
@@ -29,30 +29,32 @@
     <%_ if (field.id && field.fieldName != 'id') { _%>
     @org.springframework.data.annotation.Id
     <%_ } _%>
-    <%_ if (!field.id) { _%>
-      <%_ if (field.fieldIsEnum) { _%>
-      @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Keyword)
-      <%_ } else if (field.blobContentTypeText || field.fieldTypeString) { _%>
-      @org.springframework.data.elasticsearch.annotations.MultiField(
-          mainField = @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Text),
-          otherFields = { 
-              @org.springframework.data.elasticsearch.annotations.InnerField(suffix = "keyword", type = org.springframework.data.elasticsearch.annotations.FieldType.Keyword, ignoreAbove = 256)
-          }
-      )
-      <%_ } else if (field.fieldTypeBoolean) { _%>
-      @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Boolean)
-      <%_ } else if (field.fieldTypeInteger) { _%>
-      @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Integer)
-      <%_ } else if (field.fieldTypeLocalTime) { _%>
-      @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Date, format = org.springframework.data.elasticsearch.annotations.DateFormat.hour_minute_second_millis)
-      <%_ } _%>
+    <%_ if (field.fieldIsEnum) { _%>
+    @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Keyword)
+    <%_ } else if (field.blobContentTypeText || field.fieldTypeString) { _%>
+    @org.springframework.data.elasticsearch.annotations.MultiField(
+        mainField = @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Text),
+        otherFields = { 
+            @org.springframework.data.elasticsearch.annotations.InnerField(suffix = "keyword", type = org.springframework.data.elasticsearch.annotations.FieldType.Keyword, ignoreAbove = 256)
+        }
+    )
+    <%_ } else if (field.fieldTypeBoolean) { _%>
+    @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Boolean)
+    <%_ } else if (field.fieldTypeInteger) { _%>
+    @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Integer)
+    <%_ } else if (field.fieldTypeLong) { _%>
+    @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Long)
+    <%_ } else if (field.fieldTypeLocalTime) { _%>
+    @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Date, format = org.springframework.data.elasticsearch.annotations.DateFormat.hour_minute_second_millis)
+    <%_ } else if (field.fieldTypeInstant) { _%>
+    @org.springframework.data.elasticsearch.annotations.Field(type = org.springframework.data.elasticsearch.annotations.FieldType.Date, format = org.springframework.data.elasticsearch.annotations.DateFormat.date_time)
     <%_ } _%>
   <&_ } -&>
 <%_ } -%>
 
 <%_ for (const relationship of relationships) { -%>
   <&_ if (fragment.relationship<%- relationship.relationshipNameCapitalized %>AnnotationSection) { -&>
-    <% /* just break the cycle in the reactive area, we already have the annotation in place */
+    <% // just break the cycle; in the reactive area, we already have the annotation in place
       if (!relationship.ownerSide && !reactive) { %>
         @org.springframework.data.annotation.Transient
     <% } %>


### PR DESCRIPTION
<!--
PR description.
-->
I noticed the field mapping for certain fields is missing, so Elasticsearch falls back to dynamic field mapping. Especially in the sub-documents case, this leads to the situation that certain features like sorting on keywords may not work properly - or if you have special (custom, non-default) field mapping defined on a sub entity.

Also in some cases it is necessary to disable the dynamic field mapping all-together on an Entity. I have that in some scenario where I have String fields where there is sometimes a date formatted value inside (and sometimes not) and I do not want it to then auto-detect it as a date field - because once it was detected as date fields indexing would reject non-date values...
In those cases, I even define 

```
    @org.springframework.data.elasticsearch.annotations.Mapping(dateDetection = org.springframework.data.elasticsearch.annotations.Mapping.Detection.FALSE, numericDetection = org.springframework.data.elasticsearch.annotations.Mapping.Detection.FALSE)
```
on top of the Entity class. Don't know if it is worth having it as part of jhipster - I have that currently as part of my local blueprint, configurable via annotaton. So I have left it away for now. But what I added was an explicit `@Field(type = ...)` for Long and Instant fields as this was still missing.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
