### PR TITLE
Empty fallbacks in spreads are unnecessary

### DIFF
--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -947,7 +947,7 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
           }
 
           const renderOptions = {
-            ...(options?.renderOptions ?? {}),
+            ...options?.renderOptions,
             // Set root for ejs to lookup for partials.
             root: templatesRoots,
             // ejs caching cause problem https://github.com/jhipster/generator-jhipster/pull/20757

--- a/generators/spring-data/generators/relational/support/database-url.ts
+++ b/generators/spring-data/generators/relational/support/database-url.ts
@@ -48,7 +48,7 @@ export default function getDatabaseUrl(databaseType: string, protocol: 'r2dbc' |
   if (databaseDataForType.getData) {
     databaseDataForType = {
       ...databaseDataForType,
-      ...(databaseDataForType.getData(options) || {}),
+      ...databaseDataForType.getData(options),
     };
   }
   const { port = '', protocolSuffix = '', extraOptions = '', localDirectory = options.localDirectory } = databaseDataForType;


### PR DESCRIPTION
https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-useless-fallback-in-spread.html