### PR TITLE
Fix static resource loading on deep client-side routes

### DIFF
--- a/generators/client/templates/src/main/webapp/404.html.ejs
+++ b/generators/client/templates/src/main/webapp/404.html.ejs
@@ -22,7 +22,7 @@
     <meta charset="utf-8" />
     <title>Page Not Found</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <style>
       * {
         line-height: 1.2;

--- a/generators/client/templates/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/src/main/webapp/index.html.ejs
@@ -31,9 +31,9 @@
 <%_ if (clientFrameworkAngular) { _%>
     <base href="/" />
 <%_ } _%>
-    <link rel="icon" href="favicon.ico" />
-    <link rel="manifest" href="manifest.webapp" />
-    <link rel="stylesheet" href="content/css/loading.css" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.webapp" />
+    <link rel="stylesheet" href="/content/css/loading.css" />
     <!-- jhipster-needle-add-resources-to-root - JHipster will add new resources here -->
   </head>
   <body>


### PR DESCRIPTION
## Problem

On a route like `/blog/1`, the relative `href`s in `index.html` resolve against the current URL, so the browser requests `/blog/content/css/loading.css` instead of `/content/css/loading.css` (404 on dev server, 401 in prod since `SpaWebFilter` doesn't forward paths with a file extension).

<img width="2032" height="1167" alt="Screenshot 2026-08-14 at 10 55 50 AM" src="https://github.com/user-attachments/assets/f39bb6fb-55e3-41d3-84ba-888cfd083de9" />

## Root cause

The webpack builds do set `base: '/'` on `HtmlWebpackPlugin`, but the plugin appends the `<base>` tag at the end of `<head>`, after the `<link>` tags, and `<base>` only affects URLs that come after it:

```html
<link rel="stylesheet" href="content/css/loading.css" />
<!-- jhipster-needle-add-resources-to-root -->
<base href="/"></head>
```

Angular is unaffected (its `<base>` is hardcoded before the links); React and Vue are broken.

## Fix

Use absolute paths so resolution doesn't depend on `<base>` ordering.