### PR TITLE
[Angular] Remove unnecessary imports (SharedModule)

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/activate/activate.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/activate/activate.ts.ejs
@@ -20,12 +20,11 @@ import { Component, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { mergeMap } from 'rxjs/operators';
 
-import SharedModule from 'app/shared/shared.module';
 import { ActivateService } from './activate.service';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-activate',
-  imports: [SharedModule, RouterLink],
+  imports: [RouterLink],
   templateUrl: './activate.html',
 })
 export default class Activate implements OnInit {

--- a/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.ts.ejs
@@ -18,11 +18,8 @@
 -%>
 import { Component, ElementRef, Renderer2, effect, inject, input } from '@angular/core';
 
-import SharedModule from 'app/shared/shared.module';
-
 @Component({
   selector: '<%= jhiPrefixDashed %>-password-strength-bar',
-  imports: [SharedModule],
   templateUrl: './password-strength-bar.html',
   styleUrl: './password-strength-bar.scss',
 })

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-cache/metrics-cache.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-cache/metrics-cache.ts.ejs
@@ -19,7 +19,6 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { KeyValuePipe, DecimalPipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
 import { CacheMetrics } from 'app/admin/metrics/metrics.model';
 import { filterNaN } from 'app/core/util/operators';
 
@@ -27,7 +26,7 @@ import { filterNaN } from 'app/core/util/operators';
   selector: '<%= jhiPrefixDashed %>-metrics-cache',
   templateUrl: './metrics-cache.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [SharedModule, KeyValuePipe, DecimalPipe],
+  imports: [KeyValuePipe, DecimalPipe],
 })
 export class MetricsCache {
   /**

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-datasource/metrics-datasource.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-datasource/metrics-datasource.ts.ejs
@@ -19,7 +19,6 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
 import { Databases } from 'app/admin/metrics/metrics.model';
 import { filterNaN } from 'app/core/util/operators';
 
@@ -27,7 +26,7 @@ import { filterNaN } from 'app/core/util/operators';
   selector: '<%= jhiPrefixDashed %>-metrics-datasource',
   templateUrl: './metrics-datasource.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [SharedModule, DecimalPipe],
+  imports: [DecimalPipe],
 })
 export class MetricsDatasource {
   /**

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-endpoints-requests/metrics-endpoints-requests.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-endpoints-requests/metrics-endpoints-requests.ts.ejs
@@ -19,13 +19,12 @@
 import { Component, input } from '@angular/core';
 import { KeyValuePipe, DecimalPipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
 import { Services } from 'app/admin/metrics/metrics.model';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-metrics-endpoints-requests',
   templateUrl: './metrics-endpoints-requests.html',
-  imports: [SharedModule, KeyValuePipe, DecimalPipe],
+  imports: [KeyValuePipe, DecimalPipe],
 })
 export class MetricsEndpointsRequests {
   /**

--- a/generators/angular/templates/src/main/webapp/app/layouts/error/error.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/error/error.ts.ejs
@@ -22,12 +22,10 @@ import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
-import SharedModule from 'app/shared/shared.module';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-error',
   templateUrl: './error.html',
-  imports: [SharedModule],
 })
 export default class Error implements OnInit<% if (enableTranslation) { %>, OnDestroy<% } %> {
   errorMessage = signal<string | undefined>(undefined);


### PR DESCRIPTION
Target: remove `shared.module.ts`, use only standalone components