### PR TITLE
[Angular] Replace SharedModule import with only FontAwesomeModule import

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.ts.ejs
@@ -20,7 +20,7 @@ import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KeyValuePipe, JsonPipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { SortDirective, SortByDirective, sortStateSignal, SortService } from 'app/shared/sort';
 import { ConfigurationService } from './configuration.service';
 import { Bean, PropertySource } from './configuration.model';
@@ -28,7 +28,7 @@ import { Bean, PropertySource } from './configuration.model';
 @Component({
   selector: '<%= jhiPrefixDashed %>-configuration',
   templateUrl: './configuration.html',
-  imports: [SharedModule, FormsModule, SortDirective, SortByDirective, KeyValuePipe, JsonPipe],
+  imports: [FontAwesomeModule, FormsModule, SortDirective, SortByDirective, KeyValuePipe, JsonPipe],
 })
 export default class Configuration implements OnInit {
   allBeans = signal<Bean[] | undefined>(undefined);

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.ts.ejs
@@ -19,14 +19,14 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
-import SharedModule from 'app/shared/shared.module';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { Thread, ThreadState } from 'app/admin/metrics/metrics.model';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-thread-modal',
   templateUrl: './metrics-modal-threads.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [SharedModule],
+  imports: [FontAwesomeModule],
 })
 export class MetricsModalThreads implements OnInit {
   ThreadState = ThreadState;

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.ts.ejs
@@ -19,7 +19,7 @@
 import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, inject, signal } from '@angular/core';
 import { combineLatest } from 'rxjs';
 
-import SharedModule from 'app/shared/shared.module';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { MetricsService } from './metrics.service';
 import { MetricsModel, Thread } from './metrics.model';
 import { JvmMemory } from './blocks/jvm-memory/jvm-memory';
@@ -36,7 +36,7 @@ import { MetricsSystem } from './blocks/metrics-system/metrics-system';
   templateUrl: './metrics.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    SharedModule,
+    FontAwesomeModule,
     JvmMemory,
     JvmThreads,
     MetricsCache,

--- a/generators/angular/templates/src/main/webapp/app/admin/user-management/detail/user-management-detail.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/user-management/detail/user-management-detail.ts.ejs
@@ -19,14 +19,14 @@
 import { Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DatePipe } from '@angular/common';
-import SharedModule from 'app/shared/shared.module';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { User } from '../user-management.model';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-user-mgmt-detail',
   templateUrl: './user-management-detail.html',
-  imports: [RouterLink, SharedModule, DatePipe],
+  imports: [RouterLink, FontAwesomeModule, DatePipe],
 })
 export default class UserManagementDetail {
   user = input<User | null>(null);


### PR DESCRIPTION
Target: remove `shared.module.ts`, use only standalone components