### PR TITLE
[Angular] Replace SharedModule import with only NgbModule import

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/jvm-memory/jvm-memory.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/jvm-memory/jvm-memory.ts.ejs
@@ -19,13 +19,13 @@
 import { Component, input } from '@angular/core';
 import { KeyValuePipe, DecimalPipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { JvmMetrics } from 'app/admin/metrics/metrics.model';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-jvm-memory',
   templateUrl: './jvm-memory.html',
-  imports: [SharedModule, KeyValuePipe, DecimalPipe],
+  imports: [NgbModule, KeyValuePipe, DecimalPipe],
 })
 export class JvmMemory {
   /**

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/jvm-threads/jvm-threads.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/jvm-threads/jvm-threads.ts.ejs
@@ -20,14 +20,14 @@ import { Component, inject, computed, input } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
-import SharedModule from 'app/shared/shared.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { Thread, ThreadState } from 'app/admin/metrics/metrics.model';
 import { MetricsModalThreads } from '../metrics-modal-threads/metrics-modal-threads';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-jvm-threads',
   templateUrl: './jvm-threads.html',
-  imports: [SharedModule, DecimalPipe],
+  imports: [NgbModule, DecimalPipe],
 })
 export class JvmThreads {
   threads = input<Thread[] | undefined>();

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-garbagecollector/metrics-garbagecollector.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-garbagecollector/metrics-garbagecollector.ts.ejs
@@ -19,13 +19,13 @@
 import { Component, input } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { GarbageCollector } from 'app/admin/metrics/metrics.model';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-metrics-garbagecollector',
   templateUrl: './metrics-garbagecollector.html',
-  imports: [SharedModule, DecimalPipe],
+  imports: [NgbModule, DecimalPipe],
 })
 export class MetricsGarbageCollector {
   /**

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-request/metrics-request.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-request/metrics-request.ts.ejs
@@ -19,7 +19,7 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { KeyValuePipe, DecimalPipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { HttpServerRequests } from 'app/admin/metrics/metrics.model';
 import { filterNaN } from 'app/core/util/operators';
 
@@ -27,7 +27,7 @@ import { filterNaN } from 'app/core/util/operators';
   selector: '<%= jhiPrefixDashed %>-metrics-request',
   templateUrl: './metrics-request.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [SharedModule, KeyValuePipe, DecimalPipe],
+  imports: [NgbModule, KeyValuePipe, DecimalPipe],
 })
 export class MetricsRequest {
   /**

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-system/metrics-system.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-system/metrics-system.ts.ejs
@@ -19,14 +19,14 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { DecimalPipe, DatePipe } from '@angular/common';
 
-import SharedModule from 'app/shared/shared.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProcessMetrics } from 'app/admin/metrics/metrics.model';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-metrics-system',
   templateUrl: './metrics-system.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [SharedModule, DecimalPipe, DatePipe],
+  imports: [NgbModule, DecimalPipe, DatePipe],
 })
 export class MetricsSystem {
   /**


### PR DESCRIPTION
Target: remove `shared.module.ts`, use only standalone components