### PR TITLE
[Angular] Replace SharedModule import with only TranslateDirective/TranslateModule import

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.ts.ejs
@@ -20,13 +20,16 @@ import { Component, inject, OnInit, AfterViewInit, ElementRef, signal, viewChild
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import PasswordStrengthBar from 'app/account/password/password-strength-bar/password-strength-bar';
-import SharedModule from 'app/shared/shared.module';
+<%_ if (enableTranslation) { _%>
+import { TranslateDirective } from 'app/shared/language';
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 
 import { PasswordResetFinishService } from './password-reset-finish.service';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-password-reset-finish',
-  imports: [SharedModule, RouterLink, ReactiveFormsModule, PasswordStrengthBar],
+  imports: [<%_ if (enableTranslation) { _%>TranslateDirective, TranslateModule, <%_ } _%>RouterLink, ReactiveFormsModule, PasswordStrengthBar],
   templateUrl: './password-reset-finish.html',
 })
 export default class PasswordResetFinish implements OnInit, AfterViewInit {

--- a/generators/angular/templates/src/main/webapp/app/account/password/password.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password.ts.ejs
@@ -20,7 +20,10 @@ import { Component, Injector, OnInit, Signal, inject, signal } from '@angular/co
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { toSignal } from '@angular/core/rxjs-interop';
 
-import SharedModule from 'app/shared/shared.module';
+<%_ if (enableTranslation) { _%>
+import { TranslateDirective } from 'app/shared/language';
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/auth/account.model';
 import { PasswordService } from './password.service';
@@ -28,7 +31,7 @@ import PasswordStrengthBar from './password-strength-bar/password-strength-bar';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-password',
-  imports: [SharedModule, ReactiveFormsModule, PasswordStrengthBar],
+  imports: [<%_ if (enableTranslation) { _%>TranslateDirective, TranslateModule, <%_ } _%>ReactiveFormsModule, PasswordStrengthBar],
   templateUrl: './password.html',
 })
 export default class Password implements OnInit {

--- a/generators/angular/templates/src/main/webapp/app/account/register/register.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/register/register.ts.ejs
@@ -26,12 +26,15 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { EMAIL_ALREADY_USED_TYPE, LOGIN_ALREADY_USED_TYPE } from 'app/config/error.constants';
 import { RegisterService } from './register.service';
-import SharedModule from 'app/shared/shared.module';
+<%_ if (enableTranslation) { _%>
+import { TranslateDirective } from 'app/shared/language';
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 import PasswordStrengthBar from '../password/password-strength-bar/password-strength-bar';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-register',
-  imports: [SharedModule, RouterLink, ReactiveFormsModule, PasswordStrengthBar],
+  imports: [<%_ if (enableTranslation) { _%>TranslateDirective, TranslateModule, <%_ } _%>RouterLink, ReactiveFormsModule, PasswordStrengthBar],
   templateUrl: './register.html',
 })
 export default class Register implements AfterViewInit {

--- a/generators/angular/templates/src/main/webapp/app/admin/health/modal/health-modal.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/health/modal/health-modal.ts.ejs
@@ -20,13 +20,16 @@ import { Component, inject } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
-import SharedModule from 'app/shared/shared.module';
+<%_ if (enableTranslation) { _%>
+import { TranslateDirective } from 'app/shared/language';
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 import { HealthKey, HealthDetails } from '../health.model';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-health-modal',
   templateUrl: './health-modal.html',
-  imports: [SharedModule, KeyValuePipe],
+  imports: [<%_ if (enableTranslation) { _%>TranslateDirective, TranslateModule, <%_ } _%>KeyValuePipe],
 })
 export default class HealthModal {
   health?: { key: HealthKey; value: HealthDetails };

--- a/generators/angular/templates/src/main/webapp/app/home/home.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/home/home.ts.ejs
@@ -32,7 +32,10 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 <%_ } _%>
 
-import SharedModule from 'app/shared/shared.module';
+<%_ if (enableTranslation) { _%>
+import { TranslateDirective } from 'app/shared/language';
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 <%_ if (authenticationTypeOauth2) { _%>
 import { LoginService } from 'app/login/login.service';
 <%_ } _%>
@@ -43,7 +46,7 @@ import { Account } from 'app/core/auth/account.model';
   selector: '<%= jhiPrefixDashed %>-home',
   templateUrl: './home.html',
   styleUrl: './home.scss',
-  imports: [SharedModule<%_ if (generateUserManagement) { _%>, RouterLink<%_ } _%>],
+  imports: [<%_ if (enableTranslation) { _%>TranslateDirective, TranslateModule, <%_ } _%><%_ if (generateUserManagement) { _%>RouterLink<%_ } _%>],
 })
 export default class Home implements OnInit<% if (!authenticationTypeOauth2) { %>, OnDestroy<% } %> {
   account = signal<Account | null>(null);

--- a/generators/angular/templates/src/main/webapp/app/layouts/profiles/page-ribbon.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/profiles/page-ribbon.ts.ejs
@@ -21,7 +21,10 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { toSignal } from '@angular/core/rxjs-interop';
 
-import SharedModule from 'app/shared/shared.module';
+<%_ if (enableTranslation) { _%>
+import { TranslateDirective } from 'app/shared/language';
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 import { ProfileService } from './profile.service';
 
 @Component({
@@ -34,7 +37,7 @@ import { ProfileService } from './profile.service';
     }
   `,
   styleUrl: './page-ribbon.scss',
-  imports: [SharedModule],
+  <%_ if (enableTranslation) { _%>imports: [TranslateDirective, TranslateModule],<%_ } _%>
 })
 export default class PageRibbon implements OnInit {
   ribbonEnvSignal?: Signal<string | undefined>;

--- a/generators/angular/templates/src/main/webapp/app/login/login.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/login/login.ts.ejs
@@ -20,13 +20,16 @@ import { Component, OnInit, AfterViewInit, ElementRef, inject, signal, viewChild
 import { FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router<% if (generateUserManagement) { %>, RouterLink<% } %> } from '@angular/router';
 
-import SharedModule from 'app/shared/shared.module';
+<%_ if (enableTranslation) { _%>
+import { TranslateDirective } from 'app/shared/language';
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 import { LoginService } from 'app/login/login.service';
 import { AccountService } from 'app/core/auth/account.service';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-login',
-  imports: [SharedModule, ReactiveFormsModule<% if (generateUserManagement) { %>, RouterLink<% } %>],
+  imports: [<%_ if (enableTranslation) { _%>TranslateDirective, TranslateModule, <%_ } _%>ReactiveFormsModule<% if (generateUserManagement) { %>, RouterLink<% } %>],
   templateUrl: './login.html',
 })
 export default class LoginComponent implements OnInit, AfterViewInit {


### PR DESCRIPTION
Target: remove `shared.module.ts`, use only standalone components