### PR TITLE
angular: remove string from event-manager

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.spec.ts.ejs
@@ -33,7 +33,7 @@ describe('Event Manager tests', () => {
   });
 
   describe('EventManager', () => {
-    let receivedEvent: EventWithContent<unknown> | string | null;
+    let receivedEvent: EventWithContent<unknown> | null;
     let eventManager: EventManager;
 
     beforeEach(() => {
@@ -51,7 +51,7 @@ describe('Event Manager tests', () => {
 
     it('should create an observable and callback when broadcasted EventWithContent', () => {
       // GIVEN
-      eventManager.subscribe('modifier', (event: EventWithContent<unknown> | string) => (receivedEvent = event));
+      eventManager.subscribe('modifier', (event: EventWithContent<unknown>) => (receivedEvent = event));
 
       // WHEN
       eventManager.broadcast({ name: 'unrelatedModifier', content: 'unrelated modification' });
@@ -66,7 +66,7 @@ describe('Event Manager tests', () => {
 
     it('should create an observable and callback when broadcasted string', () => {
       // GIVEN
-      eventManager.subscribe('modifier', (event: EventWithContent<unknown> | string) => (receivedEvent = event));
+      eventManager.subscribe('modifier', (event: EventWithContent<unknown>) => (receivedEvent = event));
 
       // WHEN
       eventManager.broadcast('unrelatedModifier');
@@ -81,7 +81,7 @@ describe('Event Manager tests', () => {
 
     it('should subscribe to multiple events', () => {
       // GIVEN
-      eventManager.subscribe(['modifier', 'modifier2'], (event: EventWithContent<unknown> | string) => (receivedEvent = event));
+      eventManager.subscribe(['modifier', 'modifier2'], (event: EventWithContent<unknown>) => (receivedEvent = event));
 
       // WHEN
       eventManager.broadcast('unrelatedModifier');

--- a/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.spec.ts.ejs
@@ -64,27 +64,12 @@ describe('Event Manager tests', () => {
       expect(receivedEvent).toEqual({ name: 'modifier', content: 'modified something' });
     });
 
-    it('should create an observable and callback when broadcasted string', () => {
-      // GIVEN
-      eventManager.subscribe('modifier', (event: EventWithContent<unknown>) => (receivedEvent = event));
-
-      // WHEN
-      eventManager.broadcast('unrelatedModifier');
-      // THEN
-      expect(receivedEvent).toBeNull();
-
-      // WHEN
-      eventManager.broadcast('modifier');
-      // THEN
-      expect(receivedEvent).toEqual('modifier');
-    });
-
     it('should subscribe to multiple events', () => {
       // GIVEN
       eventManager.subscribe(['modifier', 'modifier2'], (event: EventWithContent<unknown>) => (receivedEvent = event));
 
       // WHEN
-      eventManager.broadcast('unrelatedModifier');
+      eventManager.broadcast({ name: 'unrelatedModifier', content: 'unrelated modification' });
       // THEN
       expect(receivedEvent).toBeNull();
 
@@ -94,9 +79,9 @@ describe('Event Manager tests', () => {
       expect(receivedEvent).toEqual({ name: 'modifier', content: 'modified something' });
 
       // WHEN
-      eventManager.broadcast('modifier2');
+      eventManager.broadcast({ name: 'modifier2', content: 'modified something 2' });
       // THEN
-      expect(receivedEvent).toEqual('modifier2');
+      expect(receivedEvent).toEqual({ name: 'modifier2', content: 'modified something 2' });
     });
   });
 });

--- a/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.ts.ejs
@@ -60,7 +60,7 @@ export class EventManager {
     }
     return this.observable
       .pipe(
-        filter((event: EventWithContent<unknown>) => eventNames.includes(typeof event === 'string' ? event : event.name)),
+        filter((event: EventWithContent<unknown>) => eventNames.includes(event.name)),
       )
       .subscribe(callback);
   }

--- a/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.ts.ejs
@@ -31,11 +31,11 @@ export class EventWithContent<T> {
  */
 @Service()
 export class EventManager {
-  observable: Observable<EventWithContent<unknown> | string>;
-  observer?: Observer<EventWithContent<unknown> | string>;
+  observable: Observable<EventWithContent<unknown>>;
+  observer?: Observer<EventWithContent<unknown>>;
 
   constructor() {
-    this.observable = new Observable((observer: Observer<EventWithContent<unknown> | string>) => {
+    this.observable = new Observable((observer: Observer<EventWithContent<unknown>>) => {
       this.observer = observer;
     }).pipe(share());
   }
@@ -43,7 +43,7 @@ export class EventManager {
   /**
    * Method to broadcast the event to observer
    */
-  broadcast(event: EventWithContent<unknown> | string): void {
+  broadcast(event: EventWithContent<unknown>): void {
     if (this.observer) {
       this.observer.next(event);
     }
@@ -54,13 +54,13 @@ export class EventManager {
    * @param eventNames  Single event name or array of event names to what subscribe
    * @param callback    Callback to run when the event occurs
    */
-  subscribe(eventNames: string | string[], callback: (event: EventWithContent<unknown> | string) => void): Subscription {
+  subscribe(eventNames: string | string[], callback: (event: EventWithContent<unknown>) => void): Subscription {
     if (typeof eventNames === 'string') {
       eventNames = [eventNames];
     }
     return this.observable
       .pipe(
-        filter((event: EventWithContent<unknown> | string) => eventNames.includes(typeof event === 'string' ? event : event.name)),
+        filter((event: EventWithContent<unknown>) => eventNames.includes(typeof event === 'string' ? event : event.name)),
       )
       .subscribe(callback);
   }

--- a/generators/angular/templates/src/main/webapp/app/shared/alert/alert-error.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/alert/alert-error.ts.ejs
@@ -46,12 +46,12 @@ export class AlertError implements OnDestroy {
 <% } %>
 
   constructor() {
-    this.errorListener = this.eventManager.subscribe('<%- frontendAppName %>.error', (response: EventWithContent<unknown> | string) => {
+    this.errorListener = this.eventManager.subscribe('<%- frontendAppName %>.error', (response: EventWithContent<unknown>) => {
       const errorResponse = (response as EventWithContent<AlertErrorModel>).content;
       this.addErrorAlert(errorResponse.message<%- enableTranslation ? ', errorResponse.key, errorResponse.params' : '' %>);
     });
 
-    this.httpErrorListener = this.eventManager.subscribe('<%- frontendAppName %>.httpError', (response: EventWithContent<unknown> | string) => {
+    this.httpErrorListener = this.eventManager.subscribe('<%- frontendAppName %>.httpError', (response: EventWithContent<unknown>) => {
       this.handleHttpError(response);
     });
   }
@@ -77,7 +77,7 @@ export class AlertError implements OnDestroy {
     this.alertService.addAlert({ type: 'danger', message<%- enableTranslation ? ', translationKey, translationParams' : '' %> }, this.alerts);
   }
 
-  private handleHttpError(response: EventWithContent<unknown> | string): void {
+  private handleHttpError(response: EventWithContent<unknown>): void {
     const httpErrorResponse = (response as EventWithContent<HttpErrorResponse>).content;
     switch (httpErrorResponse.status) {
       // connection refused, server not reachable


### PR DESCRIPTION
EventManager currently supports string events, but this is not used in application besides tests.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
