### PR TITLE
Revert "build(deps): bump sonarqube from 25.11.0.114957-community to 25.12.0.117093-community in /.github/actions/sonar"

### DIFF
--- a/.github/actions/sonar/Dockerfile
+++ b/.github/actions/sonar/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official SonarQube 10.6.0 community image as the base
-FROM sonarqube:25.12.0.117093-community
+FROM sonarqube:25.11.0.114957-community
 
 # Define version and plugin JAR name as environment variables
 # renovate: datasource=github-releases depName=sonarqube-community-branch-plugin packageName=mc1arke/sonarqube-community-branch-plugin


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#31656

@DanielFran it seems that this PR breaks:
https://github.com/jhipster/generator-jhipster/actions/runs/20451965958/job/58781363221?pr=31781
https://github.com/jhipster/generator-jhipster/actions/runs/20450166771/job/58783028531?pr=31779
https://github.com/jhipster/generator-jhipster/actions/runs/20472096628/job/58829527778?pr=31784