### PR TITLE
Add LIST keyword in javaReservedKeywords

### DIFF
--- a/generators/java/support/reserved-keywords.ts
+++ b/generators/java/support/reserved-keywords.ts
@@ -43,6 +43,7 @@ export const javaReservedKeywords = [
   'IMPORT',
   'PUBLIC',
   'THROWS',
+  'LIST',
   'CASE',
   'ENUM',
   'INSTANCEOF',


### PR DESCRIPTION
Fix #29566 

With 
```
entity List {
  name String
  closed Boolean
}
```
<img width="1102" height="471" alt="image" src="https://github.com/user-attachments/assets/05e4ebfe-ccb3-4f88-a136-7c30994da69b" />
