### PR TITLE
Update proxy config regex for login path

### DIFF
--- a/generators/angular/templates/proxy.config.mjs.ejs
+++ b/generators/angular/templates/proxy.config.mjs.ejs
@@ -13,7 +13,7 @@ export default {
     ws: true,
   },
 <%_ } _%>
-  '^/(api|management|v3/api-docs<% if (locals.databaseTypeSql && locals.devDatabaseTypeH2Any) { %>|h2-console<% } %><% if (authenticationTypeOauth2) { %>|oauth2|login<% } %><% if (authenticationTypeSession) { %>|login<% } %><% if (applicationTypeGateway || applicationTypeMicroservice) { %>|services<% } %>)': {
+  '^/(api|management|v3/api-docs<% if (locals.databaseTypeSql && locals.devDatabaseTypeH2Any) { %>|h2-console<% } %><% if (authenticationTypeOauth2) { %>|oauth2|login$<% } %><% if (authenticationTypeSession) { %>|login$<% } %><% if (applicationTypeGateway || applicationTypeMicroservice) { %>|services<% } %>)': {
 <%_ if (clientBundlerEsbuild) { _%>
     target: `http://${backendHost}:${backendPort}`,
 <%_ } else { _%>


### PR DESCRIPTION
since we have a login component, its chunk is named like `login-E4DMF4MC.js` it gets picked up by the config and redirected to the the backend, which fails when starting backend with -x webapp for dev

---

Please make sure the below checklist is followed for Pull Requests.

- [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X] Tests are added where necessary
- [X] The JDL part is updated if necessary
- [X] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
