### PR TITLE
[Vue] Sonar: Use .includes(), rather than .indexOf(), when checking for existence

### DIFF
--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -59,8 +59,8 @@ export default defineComponent({
     const version = `v${APP_VERSION}`;
     const hasAnyAuthorityValues: Ref<any> = ref({});
 
-    const openAPIEnabled = computed(() => store.activeProfiles.indexOf('api-docs') > -1);
-    const inProduction = computed(() => store.activeProfiles.indexOf('prod') > -1);
+    const openAPIEnabled = computed(() => store.activeProfiles.includes('api-docs'));
+    const inProduction = computed(() => store.activeProfiles.includes('prod'));
     const authenticated = computed(() => store.authenticated);
 
     const subIsActive = (input: string | string[]) => {


### PR DESCRIPTION
<img width="747" height="313" alt="image" src="https://github.com/user-attachments/assets/034894cc-272c-49a7-b480-dab7ab32048a" />

Related to #30120 