### PR TITLE
fix(vue): correct inverted logic in isClientRelationship filter

### DIFF
--- a/generators/client/support/filter-entities.spec.ts
+++ b/generators/client/support/filter-entities.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it } from 'esmocha';
+import { expect } from 'chai';
+import { isClientRelationship, isClientField, filterEntityPropertiesForClient } from './filter-entities.ts';
+
+describe('generator - client - support - filter-entities', () => {
+  describe('isClientField', () => {
+    it('returns true when skipClient is undefined', () => {
+      expect(isClientField({ skipClient: undefined } as any)).to.be.true;
+    });
+
+    it('returns true when skipClient is false', () => {
+      expect(isClientField({ skipClient: false } as any)).to.be.true;
+    });
+
+    it('returns false when skipClient is true', () => {
+      expect(isClientField({ skipClient: true } as any)).to.be.false;
+    });
+  });
+
+  describe('isClientRelationship', () => {
+    it('returns true for persistable relationship', () => {
+      const rel = {
+        persistableRelationship: true,
+        relationshipEagerLoad: false,
+        otherEntity: { jpaMetamodelFiltering: false },
+      };
+      expect(isClientRelationship(rel as any)).to.be.true;
+    });
+
+    it('returns true for eager load relationship', () => {
+      const rel = {
+        persistableRelationship: false,
+        relationshipEagerLoad: true,
+        otherEntity: { jpaMetamodelFiltering: false },
+      };
+      expect(isClientRelationship(rel as any)).to.be.true;
+    });
+
+    it('returns true when otherEntity has jpaMetamodelFiltering', () => {
+      const rel = {
+        persistableRelationship: false,
+        relationshipEagerLoad: false,
+        otherEntity: { jpaMetamodelFiltering: true },
+      };
+      expect(isClientRelationship(rel as any)).to.be.true;
+    });
+
+    it('returns false when skipClient is true', () => {
+      const rel = {
+        skipClient: true,
+        persistableRelationship: true,
+        relationshipEagerLoad: true,
+        otherEntity: { jpaMetamodelFiltering: true },
+      };
+      expect(isClientRelationship(rel as any)).to.be.false;
+    });
+
+    it('returns false when relationship is not relevant for client', () => {
+      const rel = {
+        persistableRelationship: false,
+        relationshipEagerLoad: false,
+        otherEntity: { jpaMetamodelFiltering: false },
+      };
+      expect(isClientRelationship(rel as any)).to.be.false;
+    });
+
+    it('returns true for ManyToOne relationship (ownerSide=true)', () => {
+      const rel = {
+        persistableRelationship: true,
+        relationshipEagerLoad: true,
+        otherEntity: { jpaMetamodelFiltering: false },
+      };
+      expect(isClientRelationship(rel as any)).to.be.true;
+    });
+  });
+
+  describe('filterEntityPropertiesForClient', () => {
+    it('filters out fields with skipClient=true', () => {
+      const entity = {
+        fields: [{ fieldName: 'a', skipClient: false }, { fieldName: 'b', skipClient: true }],
+        relationships: [],
+      };
+      const result = filterEntityPropertiesForClient(entity as any);
+      expect(result.fields).to.have.length(1);
+      expect(result.fields[0].fieldName).to.equal('a');
+    });
+
+    it('filters out non-client relationships', () => {
+      const entity = {
+        fields: [],
+        relationships: [
+          { relationshipName: 'a', persistableRelationship: true, otherEntity: {} },
+          { relationshipName: 'b', persistableRelationship: false, otherEntity: {} },
+        ],
+      };
+      const result = filterEntityPropertiesForClient(entity as any);
+      expect(result.relationships).to.have.length(1);
+      expect(result.relationships[0].relationshipName).to.equal('a');
+    });
+  });
+});

--- a/generators/client/support/filter-entities.spec.ts
+++ b/generators/client/support/filter-entities.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it } from 'esmocha';
+
 import { expect } from 'chai';
-import { isClientRelationship, isClientField, filterEntityPropertiesForClient } from './filter-entities.ts';
+
+import { filterEntityPropertiesForClient, isClientField, isClientRelationship } from './filter-entities.ts';
 
 describe('generator - client - support - filter-entities', () => {
   describe('isClientField', () => {
@@ -77,7 +79,10 @@ describe('generator - client - support - filter-entities', () => {
   describe('filterEntityPropertiesForClient', () => {
     it('filters out fields with skipClient=true', () => {
       const entity = {
-        fields: [{ fieldName: 'a', skipClient: false }, { fieldName: 'b', skipClient: true }],
+        fields: [
+          { fieldName: 'a', skipClient: false },
+          { fieldName: 'b', skipClient: true },
+        ],
         relationships: [],
       };
       const result = filterEntityPropertiesForClient(entity as any);

--- a/generators/client/support/filter-entities.ts
+++ b/generators/client/support/filter-entities.ts
@@ -22,7 +22,7 @@ import type { Entity as ClientEntity, Field as ClientField, Relationship as Clie
 export const isClientField = (field: ClientField) => !field.skipClient;
 
 export const isClientRelationship = (rel: RelationshipWithEntity<ClientRelationship, ClientEntity>) =>
-  !!(rel.skipClient ?? !(rel.persistableRelationship || rel.relationshipEagerLoad || rel.otherEntity.jpaMetamodelFiltering));
+  !rel.skipClient && (rel.persistableRelationship || rel.relationshipEagerLoad || rel.otherEntity.jpaMetamodelFiltering);
 
 /**
  * Clone entity properties for frontend templates.


### PR DESCRIPTION
# Fix Vue blank Parent column in entity list (#25846)

/claim #25846

## Description

This PR fixes the issue where the Parent column appears blank in the Child entity list for both OneToOne with `@Id` and ManyToOne relationships, while the data displays correctly on view and edit pages.

## Root Cause

The `isClientRelationship` function in `generators/client/support/filter-entities.ts` had inverted logic:

```typescript
// Before (incorrect)
export const isClientRelationship = (rel) =>
  !!(rel.skipClient ?? !(rel.persistableRelationship || rel.relationshipEagerLoad || rel.otherEntity.jpaMetamodelFiltering));
```

This returned `false` for relationships that should be included in the client (persistable/eagerLoad), causing them to be filtered out from the entity model.

## Solution

Corrected the logic to properly return `true` when a relationship should be shown:

```typescript
// After (correct)
export const isClientRelationship = (rel) =>
  !rel.skipClient && (rel.persistableRelationship || rel.relationshipEagerLoad || rel.otherEntity.jpaMetamodelFiltering);
```

## Changes

- `generators/client/support/filter-entities.ts`: Fixed inverted logic in `isClientRelationship`
- `generators/client/support/filter-entities.spec.ts`: Added unit tests for the filter functions

## Testing

- Added 11 unit tests covering `isClientField`, `isClientRelationship`, and `filterEntityPropertiesForClient`
- All existing tests pass

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

Fixes #25846