### PR TITLE
fix CLI failing when yeoman-test is not installed

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -50,6 +50,14 @@ jobs:
         shell: bash
       - run: npm ci
       - run: npm run prettier:check
+      - name: Test production CLI (no devDependencies)
+        run: |
+          npm pack --pack-destination=/tmp
+          TEST_DIR=$(mktemp -d)
+          cd "$TEST_DIR"
+          npm init -y
+          npm install /tmp/generator-jhipster-*.tgz
+          ./node_modules/.bin/jhipster --version
       - run: npm test
         if: >-
           !contains(github.event.head_commit.message, '[ci skip]') &&

--- a/cli/program.ts
+++ b/cli/program.ts
@@ -29,7 +29,7 @@ import baseCommand from '../generators/base/command.ts';
 import { type JHipsterCommandDefinition, extractArgumentsFromConfigs } from '../lib/command/index.ts';
 import { packageJson } from '../lib/index.ts';
 import { buildJDLApplicationConfig } from '../lib/jdl-config/jhipster-jdl-config.ts';
-import { getGithubOutputFile, setGithubTaskOutput } from '../lib/testing/index.ts';
+import { getGithubOutputFile, setGithubTaskOutput } from '../lib/testing/github.ts';
 import { packageNameToNamespace } from '../lib/utils/index.ts';
 
 import SUB_GENERATORS from './commands.ts';


### PR DESCRIPTION
When installing `generator-jhipster` globally, `jhipster --version` fails because `cli/program.ts` imports from `lib/testing/index.ts`, which re-exports `helpers.ts` that imports `yeoman-test` at the top level.

## Changes

1. Import `getGithubOutputFile` and `setGithubTaskOutput` directly from `lib/testing/github.ts` instead of `lib/testing/index.ts`
2. Add CI step to test production installation without devDependencies

Fix #32114