### PR TITLE
fix: avoid Kafka container in integration tests

### DIFF
--- a/generators/spring-cloud/generators/kafka/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-cloud/generators/kafka/__snapshots__/generator.spec.ts.snap
@@ -67,19 +67,20 @@ exports[`generator - spring-cloud:kafka with defaults options should call source
       "name": "org.I0Itec",
     },
   ],
-  "editJavaFile": [
+      "editJavaFile": [
     [
       "src/test/java/com/mycompany/myapp/IntegrationTest.java",
       {
         "annotations": [
           {
-            "annotation": "ImportTestcontainers",
-            "package": "org.springframework.boot.testcontainers.context",
+            "annotation": "ImportAutoConfiguration",
+            "package": "org.springframework.boot.autoconfigure",
             "parameters": [Function],
           },
         ],
         "imports": [
-          "com.mycompany.myapp.config.KafkaTestContainer",
+          "org.springframework.boot.autoconfigure.ImportAutoConfiguration",
+          "org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration",
         ],
       },
     ],

--- a/generators/spring-cloud/generators/kafka/generator.ts
+++ b/generators/spring-cloud/generators/kafka/generator.ts
@@ -69,12 +69,15 @@ export default class KafkaGenerator extends SpringBootApplicationGenerator {
       },
       integrationTest({ application, source }) {
         source.editJavaFile!(`${application.javaPackageTestDir}IntegrationTest.java`, {
-          imports: [`${application.packageName}.config.KafkaTestContainer`],
+          imports: [
+            'org.springframework.boot.autoconfigure.ImportAutoConfiguration',
+            'org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration',
+          ],
           annotations: [
             {
-              package: 'org.springframework.boot.testcontainers.context',
-              annotation: 'ImportTestcontainers',
-              parameters: (_, cb) => cb.addKeyValue('value', 'KafkaTestContainer.class'),
+              package: 'org.springframework.boot.autoconfigure',
+              annotation: 'ImportAutoConfiguration',
+              parameters: (_, cb) => cb.addKeyValue('value', 'TestChannelBinderConfiguration.class'),
             },
           ],
         });


### PR DESCRIPTION
## Summary
- Replace Kafka Testcontainers injection in IntegrationTest with the in‑memory Stream test binder
- Avoids starting a Kafka container for Cucumber/integration tests that don’t require it

## Related
- Fixes jhipster/generator-jhipster#31133
