### PR TITLE
Remove offline_access from default OAuth2 scope

### DIFF
--- a/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
@@ -394,7 +394,8 @@ spring:
             client-id: web_app
             client-secret: web_app
     <%_ } _%>
-            scope: openid, profile, email, offline_access # last one for refresh tokens
+            scope: openid, profile, email
+            # Add offline_access to request refresh tokens.
   <%_ } _%>
   <%_ if (authenticationTypeJwt) { _%>
     oauth2:


### PR DESCRIPTION
## Summary
- Drop offline_access from the default scope in application.yml
- Add a comment to opt-in when refresh tokens are needed

## Testing
- Not run (not requested)
