### PR TITLE
Fix ResourceIT createEntity for manual primary keys

### DIFF
--- a/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
@@ -534,7 +534,7 @@ filterTestableRelationships.filter(rel => !rel.otherEntity.builtInUser).forEach(
     public static <%= persistClass %> create<% if (fieldStatus === 'UPDATED_') { _%>Updated<%_ } %>Entity(<% if (databaseTypeSql && anyRelationshipIsRequired) { %>EntityManager em<% } %>) {
   <%_ if (fluentMethods) { _%>
         <% if (!anyRelationshipIsRequired) { %>return <% } else { %><%= persistClass %> <%= createInstance %> = <% } %>new <%= persistClass %>()
-    <%_ if (!primaryKey.derived && !primaryKey.composite && !isUsingMapsId) { _%>
+    <%_ if (!primaryKey.derived && !isUsingMapsId) { _%>
       <%_ for (const idField of primaryKey.fields.filter(field => !field.autoGenerateByRepository)) { _%>
             .<%= idField.fieldName %>(<%- idField.fieldJavaValueGenerator %>)
       <%_ } _%>
@@ -551,7 +551,7 @@ filterTestableRelationships.filter(rel => !rel.otherEntity.builtInUser).forEach(
     <%_ } _%>
   <%_ } else { _%>
         <%= persistClass %> <%= createInstance %> = new <%= persistClass %>();
-    <%_ if (!primaryKey.derived && !primaryKey.composite && !isUsingMapsId) { _%>
+    <%_ if (!primaryKey.derived && !isUsingMapsId) { _%>
       <%_ for (const idField of primaryKey.fields.filter(field => !field.autoGenerateByRepository)) { _%>
         <%= createInstance %>.set<%= idField.fieldInJavaBeanMethod %>(<%- idField.fieldJavaValueGenerator %>);
       <%_ } _%>


### PR DESCRIPTION
Fixes #29641

Summary:
- Seed manual/service-generated primary keys in ResourceIT createEntity
- Only null UUID IDs on create when the ID is auto-generated
