### PR TITLE
fix: allow swagger docs in gateway prod endpoints

### DIFF
--- a/generators/spring-boot/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application-prod.yml.ejs
@@ -223,7 +223,7 @@ jhipster:
       enabled: false
   <%_ if (!reactive) { _%>
     authorized-microservices-endpoints: # Access Control Policy, if left empty for a route, all endpoints will be accessible
-      app1: /api<% if (enableSwaggerCodegen) { %>,/v3/api-docs<% } %> # recommended prod configuration
+      app1: /api,/v3/api-docs # recommended prod configuration
   <%_ } _%>
 <%_ } _%>
   http:


### PR DESCRIPTION
Fixes #27035

- allow /v3/api-docs in gateway authorized microservice endpoints when Swagger is enabled
