### PR TITLE
Fix #31133: use test binder for Kafka tests

### DIFF
--- a/generators/spring-cloud/generators/kafka/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-cloud/generators/kafka/__snapshots__/generator.spec.ts.snap
@@ -73,13 +73,20 @@ exports[`generator - spring-cloud:kafka with defaults options should call source
       {
         "annotations": [
           {
-            "annotation": "ImportTestcontainers",
-            "package": "org.springframework.boot.testcontainers.context",
+            "annotation": "ImportAutoConfiguration",
+            "package": "org.springframework.boot.autoconfigure",
+            "parameters": [Function],
+          },
+          {
+            "annotation": "TestPropertySource",
+            "package": "org.springframework.test.context",
             "parameters": [Function],
           },
         ],
         "imports": [
-          "com.mycompany.myapp.config.KafkaTestContainer",
+          "org.springframework.boot.autoconfigure.ImportAutoConfiguration",
+          "org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration",
+          "org.springframework.test.context.TestPropertySource",
         ],
       },
     ],

--- a/generators/spring-cloud/generators/kafka/generator.ts
+++ b/generators/spring-cloud/generators/kafka/generator.ts
@@ -69,12 +69,24 @@ export default class KafkaGenerator extends SpringBootApplicationGenerator {
       },
       integrationTest({ application, source }) {
         source.editJavaFile!(`${application.javaPackageTestDir}IntegrationTest.java`, {
-          imports: [`${application.packageName}.config.KafkaTestContainer`],
+          imports: [
+            'org.springframework.boot.autoconfigure.ImportAutoConfiguration',
+            'org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration',
+            'org.springframework.test.context.TestPropertySource',
+          ],
           annotations: [
             {
-              package: 'org.springframework.boot.testcontainers.context',
-              annotation: 'ImportTestcontainers',
-              parameters: (_, cb) => cb.addKeyValue('value', 'KafkaTestContainer.class'),
+              package: 'org.springframework.boot.autoconfigure',
+              annotation: 'ImportAutoConfiguration',
+              parameters: (_, cb) => cb.addKeyValue('value', 'TestChannelBinderConfiguration.class'),
+            },
+            {
+              package: 'org.springframework.test.context',
+              annotation: 'TestPropertySource',
+              parameters: (_, cb) => {
+                cb.addKeyValue('properties', '"spring.cloud.stream.defaultBinder=test"');
+                cb.addKeyValue('properties', '"spring.cloud.stream.binders.test.type=test"');
+              },
             },
           ],
         });


### PR DESCRIPTION
## Summary
- Avoid starting Kafka containers for general integration tests by switching to the test binder.
- Keep Kafka-related tests working via TestChannelBinderConfiguration and test-binder defaults.

## Context
Fix #31133.

## Testing
Not run (generator change + snapshot update).
