### PR TITLE
Introduce automatic request cancellation

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.spec.ts.ejs
@@ -24,7 +24,6 @@ _%>
 <%_ if (clientTestFrameworkVitest) { _%>
 import { MockInstance, afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
 <%_ } _%>
-import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import {
   ComponentFixture, TestBed,
@@ -40,15 +39,9 @@ import { faEye, faPencilAlt, faPlus<% if (searchEngineAny) { %>, faSearch<% } %>
 import { TranslateModule } from '@ngx-translate/core';
 <%_ } _%>
 import {
-<%_ if (!paginationInfiniteScroll) { _%>
-  delay,
-<%_ } _%>
   of,
 <%_ if (!readOnly) { _%>
   Subject,
-<%_ } _%>
-<%_ if (!paginationInfiniteScroll) { _%>
-  throwError,
 <%_ } _%>
 } from 'rxjs';
 <%_ if (!readOnly) { _%>
@@ -265,63 +258,50 @@ describe('<%= entityAngularName %> Management Component', () => {
 <%_ if (!paginationInfiniteScroll) { _%>
 
   it('should cancel previous load when new load is triggered', async () => {
-    <%= clientTestFramework %>.useFakeTimers();
-    // GIVEN
-    const firstResponse = new HttpResponse({
-      body: [<%- testEntityPrimaryKey %>],
-      headers: new HttpHeaders(),
-    });
-    const secondResponse = new HttpResponse({
-      body: [<%- testEntityPrimaryKey2 %>],
-      headers: new HttpHeaders(),
-    });
-
-    // Reset the spy from beforeEach and set up delayed responses
-    <%= clientTestFramework %>.spyOn(service, 'query')
-      .mockReturnValueOnce(of(firstResponse).pipe(delay(200)))  // Slow response
-      .mockReturnValueOnce(of(secondResponse).pipe(delay(10))); // Fast response
-
-    comp.ngOnInit();
-
-    // WHEN - trigger two loads in quick succession
+    // WHEN - trigger two loads (on init, one extra) in quick succession
     comp.load();
-    comp.load();
+    TestBed.tick();
 
-    // Advance time to complete fast response but not slow one
-    await <%= clientTestFramework %>.advanceTimersByTimeAsync(50);
+    // THEN - should cancels the first in-flight request; flushing it has no effect
+    const [firstReq, secondReq] = httpMock.match({ method: 'GET' });
+    firstReq.flush(
+      [<%- testEntityPrimaryKey %>],
+      { headers: { link: '<http://localhost/api/foo?page=1&size=20>; rel="next"' } },
+    );
+    secondReq.flush(
+      [<%- testEntityPrimaryKey2 %>],
+      { headers: { link: '<http://localhost/api/foo?page=1&size=20>; rel="next"' } },
+    );
+    await vitest.runAllTimersAsync();
 
     // THEN - only the latest (second) response should be applied
     expect(comp.<%= entityInstancePlural %>()).toEqual([<%- testEntityPrimaryKey2 %>]);
     expect(comp.<%= entityInstancePlural %>()).not.toContain(expect.objectContaining(<%- testEntityPrimaryKey %>));
-    <%= clientTestFramework %>.useRealTimers();
   });
 
-  it('should keep subscription alive after HTTP error', () => {
-    // GIVEN
-    const successResponse = new HttpResponse({
-      body: [<%- testEntityPrimaryKey %>],
-      headers: new HttpHeaders(),
-    });
+  it('should keep subscription alive after HTTP error', async () => {
+    // GIVEN - first load triggers an HTTP error
+    TestBed.tick();
+    const errorReq = httpMock.expectOne({ method: 'GET' });
+    errorReq.flush('error', { status: 500, statusText: 'Server Error' });
+    await vitest.runAllTimersAsync();
 
-    // Reset the spy from beforeEach and simulate error then success
-    <%= clientTestFramework %>.spyOn(service, 'query')
-      .mockReset()
-      .mockReturnValueOnce(throwError(() => new Error('HTTP Error')))
-      .mockReturnValueOnce(of(successResponse));
-
-    comp.ngOnInit();
-
-    // WHEN - first implicit load triggers an error
-    // Verify loading state was reset
+    // THEN - loading state was reset and list is empty
     expect(comp.isLoading()).toBe(false);
-    expect(comp.<%= entityInstancePlural %>()).toEqual([]);
+    expect(comp.<%- entityInstancePlural %>()).toEqual([]);
 
     // WHEN - second load should still work
     comp.load();
+    TestBed.tick();
+    const successReq = httpMock.expectOne({ method: 'GET' });
+    successReq.flush(
+      [<%- testEntityPrimaryKey %>],
+      { headers: { link: '<http://localhost/api/foo?page=1&size=20>; rel="next"' } },
+    );
+    await vitest.runAllTimersAsync();
 
     // THEN - subscription is still alive and second load succeeds
-    expect(service.query).toHaveBeenCalledTimes(2);
-    expect(comp.<%= entityInstancePlural %>()).toEqual([<%- testEntityPrimaryKey %>]);
+    expect(comp.<%- entityInstancePlural %>()[0]).toEqual(expect.objectContaining(<%- testEntityPrimaryKey %>));
   });
 <%_ } _%>
 });

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.spec.ts.ejs
@@ -40,9 +40,15 @@ import { faEye, faPencilAlt, faPlus<% if (searchEngineAny) { %>, faSearch<% } %>
 import { TranslateModule } from '@ngx-translate/core';
 <%_ } _%>
 import {
+<%_ if (!paginationInfiniteScroll) { _%>
+  delay,
+<%_ } _%>
   of,
 <%_ if (!readOnly) { _%>
   Subject,
+<%_ } _%>
+<%_ if (!paginationInfiniteScroll) { _%>
+  throwError,
 <%_ } _%>
 } from 'rxjs';
 <%_ if (!readOnly) { _%>
@@ -254,6 +260,68 @@ describe('<%= entityAngularName %> Management Component', () => {
       expect(ngbModal.open).toHaveBeenCalled();
       expect(comp.load).not.toHaveBeenCalled();
     }));
+  });
+<%_ } _%>
+<%_ if (!paginationInfiniteScroll) { _%>
+
+  it('should cancel previous load when new load is triggered', async () => {
+    <%= clientTestFramework %>.useFakeTimers();
+    // GIVEN
+    const firstResponse = new HttpResponse({
+      body: [<%- testEntityPrimaryKey %>],
+      headers: new HttpHeaders(),
+    });
+    const secondResponse = new HttpResponse({
+      body: [<%- testEntityPrimaryKey2 %>],
+      headers: new HttpHeaders(),
+    });
+
+    // Reset the spy from beforeEach and set up delayed responses
+    <%= clientTestFramework %>.spyOn(service, 'query')
+      .mockReturnValueOnce(of(firstResponse).pipe(delay(200)))  // Slow response
+      .mockReturnValueOnce(of(secondResponse).pipe(delay(10))); // Fast response
+
+    comp.ngOnInit();
+
+    // WHEN - trigger two loads in quick succession
+    comp.load();
+    comp.load();
+
+    // Advance time to complete fast response but not slow one
+    await <%= clientTestFramework %>.advanceTimersByTimeAsync(50);
+
+    // THEN - only the latest (second) response should be applied
+    expect(comp.<%= entityInstancePlural %>()).toEqual([<%- testEntityPrimaryKey2 %>]);
+    expect(comp.<%= entityInstancePlural %>()).not.toContain(expect.objectContaining(<%- testEntityPrimaryKey %>));
+    <%= clientTestFramework %>.useRealTimers();
+  });
+
+  it('should keep subscription alive after HTTP error', () => {
+    // GIVEN
+    const successResponse = new HttpResponse({
+      body: [<%- testEntityPrimaryKey %>],
+      headers: new HttpHeaders(),
+    });
+
+    // Reset the spy from beforeEach and simulate error then success
+    <%= clientTestFramework %>.spyOn(service, 'query')
+      .mockReset()
+      .mockReturnValueOnce(throwError(() => new Error('HTTP Error')))
+      .mockReturnValueOnce(of(successResponse));
+
+    comp.ngOnInit();
+
+    // WHEN - first implicit load triggers an error
+    // Verify loading state was reset
+    expect(comp.isLoading()).toBe(false);
+    expect(comp.<%= entityInstancePlural %>()).toEqual([]);
+
+    // WHEN - second load should still work
+    comp.load();
+
+    // THEN - subscription is still alive and second load succeeds
+    expect(service.query).toHaveBeenCalledTimes(2);
+    expect(comp.<%= entityInstancePlural %>()).toEqual([<%- testEntityPrimaryKey %>]);
   });
 <%_ } _%>
 });

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.ts.ejs
@@ -29,13 +29,12 @@
 
   const componentName = entityAngularName;
 _%>
-import { Component, computed, DestroyRef, effect, inject, OnInit, signal, WritableSignal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, computed, effect, inject, OnInit, signal, WritableSignal } from '@angular/core';
 <%_ if (!paginationNo) { _%>
 import { HttpHeaders } from '@angular/common/http';
 <%_ } _%>
 import { ActivatedRoute, Data, ParamMap, Router, RouterLink } from '@angular/router';
-import { <%_ if (!paginationInfiniteScroll) { _%>catchError, <%_ } _%>combineLatest<%_ if (!readOnly) { _%>, filter<%_ } _%><%_ if (!paginationInfiniteScroll) { _%>, EMPTY<%_ } _%>, finalize, Observable<%_ if (!paginationInfiniteScroll) { _%>, Subject<%_ } _%><%_ if (!paginationInfiniteScroll) { _%>, switchMap<%_ } _%>, tap } from 'rxjs';
+import { combineLatest<%_ if (!readOnly) { _%>, filter<%_ } _%>, finalize, Observable, Subscription, tap } from 'rxjs';
 <%_ if (!readOnly) { _%>
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 <%_ } _%>
@@ -164,7 +163,6 @@ export class <%= componentName %> implements OnInit {
     readonly isLoading = this.<%= entityInstance %>Service.<%= entityInstancePlural %>Resource.isLoading;
     protected readonly activatedRoute = inject(ActivatedRoute);
     protected readonly sortService = inject(SortService);
-    protected readonly destroyRef = inject(DestroyRef);
 <%_ if (paginationInfiniteScroll) { _%>
     protected parseLinks = inject(ParseLinks);
 <%_ } _%>
@@ -194,19 +192,7 @@ export class <%= componentName %> implements OnInit {
 <%_ } _%>
 
     ngOnInit(): void {
-<%_ if (!paginationInfiniteScroll) { _%>
-      this.loadTrigger$.pipe(
-        switchMap(() => this.queryBackend().pipe(
-          catchError(() => {
-            this.isLoading.set(false);
-            return EMPTY;
-          })
-        )),
-        takeUntilDestroyed(this.destroyRef)
-      ).subscribe((res: EntityArrayResponseType) => this.onResponseSuccess(res));
-
-<%_ } _%>
-      combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.data]).pipe(
+      this.subscription = combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.data]).pipe(
         tap(([params, data]) => this.fillComponentAttributeFromRoute(params, data)),
 <%_ if (paginationInfiniteScroll) { _%>
         tap(() => this.reset()),
@@ -220,13 +206,10 @@ export class <%= componentName %> implements OnInit {
           }
         }),
 <%_ } _%>
-        takeUntilDestroyed(this.destroyRef)
       ).subscribe();
 
 <% if (jpaMetamodelFiltering && paginationPagination) { %>
-      this.filters.filterChanges.pipe(
-        takeUntilDestroyed(this.destroyRef)
-      ).subscribe(filterOptions => this.handleNavigation(1, this.sortState(), filterOptions));
+      this.filters.filterChanges.subscribe(filterOptions => this.handleNavigation(1, this.sortState(), filterOptions));
 <%_ } _%>
     }
 
@@ -288,9 +271,9 @@ export class <%= componentName %> implements OnInit {
     }
 
 <%_ } _%>
-    load(): void {
-      this.queryBackend();
-    }
+  load(): void {
+    this.queryBackend();
+  }
 
     navigateToWithComponentValues(event: SortState): void {
       this.handleNavigation(<% if (paginationPagination) { %>this.page(), <% } %>event<% if (jpaMetamodelFiltering && paginationPagination) { %>, this.filters.filterOptions<% } %><% if (searchEngineAny) { %>, this.currentSearch()<% } %>);

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.ts.ejs
@@ -29,12 +29,13 @@
 
   const componentName = entityAngularName;
 _%>
-import { Component, computed, effect, inject, OnInit, signal, WritableSignal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, OnInit, signal, WritableSignal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 <%_ if (!paginationNo) { _%>
 import { HttpHeaders } from '@angular/common/http';
 <%_ } _%>
 import { ActivatedRoute, Data, ParamMap, Router, RouterLink } from '@angular/router';
-import { combineLatest<%_ if (!readOnly) { _%>, filter<%_ } _%>, finalize, Observable, Subscription, tap } from 'rxjs';
+import { <%_ if (!paginationInfiniteScroll) { _%>catchError, <%_ } _%>combineLatest<%_ if (!readOnly) { _%>, filter<%_ } _%><%_ if (!paginationInfiniteScroll) { _%>, EMPTY<%_ } _%>, finalize, Observable<%_ if (!paginationInfiniteScroll) { _%>, Subject<%_ } _%><%_ if (!paginationInfiniteScroll) { _%>, switchMap<%_ } _%>, tap } from 'rxjs';
 <%_ if (!readOnly) { _%>
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 <%_ } _%>
@@ -163,6 +164,7 @@ export class <%= componentName %> implements OnInit {
     readonly isLoading = this.<%= entityInstance %>Service.<%= entityInstancePlural %>Resource.isLoading;
     protected readonly activatedRoute = inject(ActivatedRoute);
     protected readonly sortService = inject(SortService);
+    protected readonly destroyRef = inject(DestroyRef);
 <%_ if (paginationInfiniteScroll) { _%>
     protected parseLinks = inject(ParseLinks);
 <%_ } _%>
@@ -192,7 +194,19 @@ export class <%= componentName %> implements OnInit {
 <%_ } _%>
 
     ngOnInit(): void {
-      this.subscription = combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.data]).pipe(
+<%_ if (!paginationInfiniteScroll) { _%>
+      this.loadTrigger$.pipe(
+        switchMap(() => this.queryBackend().pipe(
+          catchError(() => {
+            this.isLoading.set(false);
+            return EMPTY;
+          })
+        )),
+        takeUntilDestroyed(this.destroyRef)
+      ).subscribe((res: EntityArrayResponseType) => this.onResponseSuccess(res));
+
+<%_ } _%>
+      combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.data]).pipe(
         tap(([params, data]) => this.fillComponentAttributeFromRoute(params, data)),
 <%_ if (paginationInfiniteScroll) { _%>
         tap(() => this.reset()),
@@ -206,10 +220,13 @@ export class <%= componentName %> implements OnInit {
           }
         }),
 <%_ } _%>
+        takeUntilDestroyed(this.destroyRef)
       ).subscribe();
 
 <% if (jpaMetamodelFiltering && paginationPagination) { %>
-      this.filters.filterChanges.subscribe(filterOptions => this.handleNavigation(1, this.sortState(), filterOptions));
+      this.filters.filterChanges.pipe(
+        takeUntilDestroyed(this.destroyRef)
+      ).subscribe(filterOptions => this.handleNavigation(1, this.sortState(), filterOptions));
 <%_ } _%>
     }
 
@@ -271,9 +288,9 @@ export class <%= componentName %> implements OnInit {
     }
 
 <%_ } _%>
-  load(): void {
-    this.queryBackend();
-  }
+    load(): void {
+      this.queryBackend();
+    }
 
     navigateToWithComponentValues(event: SortState): void {
       this.handleNavigation(<% if (paginationPagination) { %>this.page(), <% } %>event<% if (jpaMetamodelFiltering && paginationPagination) { %>, this.filters.filterOptions<% } %><% if (searchEngineAny) { %>, this.currentSearch()<% } %>);


### PR DESCRIPTION
in Angular list views, unless having infinite scroll enabled

We have noticed, that requests in list views do not get automatically canceled when the user may trigger a new request by quickly changing things like search string or removing the search string again. 
The request that finishes later (can be the one started at first) will always override the resulting list. So: If you have a long running search operation (like 3-4s) and then basically remove the search parameters, a new request will be triggered for the unfiltered view again. That one most often finishes much faster than a search on a large dataset, but since the search is not canceled, it will also finish and show search results, even though the user had already removed the search... Can lead to inconsistent views of the results.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
