### PR TITLE
spring-boot: re-add in-memory user credentials to application config

### DIFF
--- a/generators/spring-boot/templates/src/main/resources/config/application-secret-samples.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application-secret-samples.yml.ejs
@@ -55,17 +55,17 @@ jhipster:
   registry:
     password: admin
 <%_ } _%>
-  security:
 <%_ if (authenticationTypeJwt) { _%>
+  security:
     authentication:
       jwt:
         base64-secret: <%= jwtSecretKey %>
 <%_ } _%>
 <%_ if (authenticationTypeSession && !reactive) { _%>
+  security:
     remember-me:
       key: <%= rememberMeKey %>
 <%_ } _%>
-
 <%_ if (devDatabaseTypeH2Any) { _%>
 ---
 spring:


### PR DESCRIPTION
Added in-memory user credentials configuration for admin.

Fix daily-builds https://github.com/hipster-labs/jhipster-daily-builds/actions/workflows/no-database.yaml

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
