### PR TITLE
cypress: disable cypressAudit by default

### DIFF
--- a/.blueprint/generate-sample/templates/test-integration/samples/ng-default/.yo-rc.json
+++ b/.blueprint/generate-sample/templates/test-integration/samples/ng-default/.yo-rc.json
@@ -8,6 +8,7 @@
     "clientFramework": "angular",
     "clientTheme": "none",
     "creationTimestamp": 1596513172471,
+    "cypressAudit": true,
     "cypressCoverage": true,
     "databaseType": "sql",
     "devDatabaseType": "h2Disk",


### PR DESCRIPTION
Cypress audit is probably not used often.
I propose to disable by default.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
