### PR TITLE
fix: adjust cypress coverage to work outside Angular dev-server workflow

### DIFF
--- a/generators/cypress/templates/cypress.config.ts.ejs
+++ b/generators/cypress/templates/cypress.config.ts.ejs
@@ -1,5 +1,5 @@
 <%#
- Copyright 2013-2025 the original author or authors from the JHipster project.
+ Copyright 2013-2026 the original author or authors from the JHipster project.
 
  This file is part of the JHipster project, see https://www.jhipster.tech/
  for more information.
@@ -28,24 +28,29 @@ export default defineConfig({
   viewportWidth: 1200,
   viewportHeight: 720,
   retries: 2,
+  allowCypressEnv: false,
 <%_ if (clientFrameworkReact) { _%>
   scrollBehavior: 'center',
 <%_ } _%>
+  expose: {
+<%_ if (cypressCoverage && !cypressCoverageWebpack) { _%>
+    CYPRESS_COVERAGE: false,
+<%_ } _%>
+    adminUsername: 'admin',
+    adminPassword: 'admin',
+    username: 'user',
+    password: 'user',
 <%_ if (authenticationTypeJwt) { _%>
-  env: {
     authenticationUrl: '/api/authenticate',
     jwtStorageName: '<%= jhiPrefixDashed %>-authenticationToken',
-  },
 <%_ } else if (authenticationTypeSession) { _%>
-  env: {
     authenticationUrl: '/api/authentication',
-  },
 <%_ } _%>
+  },
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     async setupNodeEvents(on, config) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return (await import('./<%= this.relativeDir(clientRootDir, cypressDir) %>plugins/index')).default(on, config);
     },
     baseUrl: 'http://localhost:<%= gatewayServerPort || serverPort %>/',

--- a/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
@@ -1,5 +1,5 @@
 <%#
- Copyright 2013-2025 the original author or authors from the JHipster project.
+ Copyright 2013-2026 the original author or authors from the JHipster project.
 
  This file is part of the JHipster project, see https://www.jhipster.tech/
  for more information.
@@ -69,7 +69,28 @@ export default <% if (cypressCoverage) { %>async <% } %>(on: Cypress.PluginEvent
   });
 <%_ } _%>
 <%_ if (cypressCoverage) { _%>
+  <%_ if (cypressCoverageWebpack) { _%>
   (await import('@cypress/code-coverage/task')).default(on, config);
+  <%_ } else { _%>
+  if (config.env.CYPRESS_COVERAGE) {
+    // Propagate to expose for browser-side access via Cypress.expose()
+    config.expose = { ...config.expose, CYPRESS_COVERAGE: true };
+    (await import('cypress-monocart-coverage')).default(on, config, {
+      name: 'Cypress Coverage Report',
+      entryFilter: {
+        '**/node_modules/**': false,
+        '**/swagger-ui/**': false,
+        '**/polyfills.js': false,
+        '**/*.js': true,
+      },
+      sourceFilter: {
+        '**/<%- clientSrcDir %>**': true,
+      },
+      outputDir: './<%- temporaryDir %>/cypress-coverage-reports',
+      reports: ['v8', 'console-details'],
+    });
+  }
+  <%_ } _%>
 <%_ } _%>
   return config;
 }


### PR DESCRIPTION
Fix the code coverage configuration so it works outside the Angular dev-server workflow.

As noted by @mshima in https://github.com/jhipster/generator-jhipster/pull/32327#pullrequestreview-3807664757, the `Cypress.expose('CYPRESS_COVERAGE')` check in the support file only works when running via Angular's dev-server (which sets `env: { CYPRESS_COVERAGE: true }` in the Angular config).

### Changes

1. **`cypress.config.ts.ejs`**: Added `CYPRESS_COVERAGE: false` as a default value in the `expose` config block (for non-webpack coverage). This ensures `Cypress.expose('CYPRESS_COVERAGE')` always resolves to a value.

2. **`plugins/index.ts.ejs`**: When `config.env.CYPRESS_COVERAGE` is `true` (set by Angular builder), propagate the value to `config.expose` so that `Cypress.expose('CYPRESS_COVERAGE')` returns `true` in the browser-side support file.

This makes the coverage support work consistently whether Cypress is launched via Angular dev-server or directly.

---

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed