### PR TITLE
kafka: don't start kafka in backend tests

### DIFF
--- a/generators/spring-cloud/generators/kafka/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-cloud/generators/kafka/__snapshots__/generator.spec.ts.snap
@@ -67,23 +67,6 @@ exports[`generator - spring-cloud:kafka with defaults options should call source
       "name": "org.I0Itec",
     },
   ],
-  "editJavaFile": [
-    [
-      "src/test/java/com/mycompany/myapp/IntegrationTest.java",
-      {
-        "annotations": [
-          {
-            "annotation": "ImportTestcontainers",
-            "package": "org.springframework.boot.testcontainers.context",
-            "parameters": [Function],
-          },
-        ],
-        "imports": [
-          "com.mycompany.myapp.config.KafkaTestContainer",
-        ],
-      },
-    ],
-  ],
 }
 `;
 

--- a/generators/spring-cloud/generators/kafka/generator.ts
+++ b/generators/spring-cloud/generators/kafka/generator.ts
@@ -111,18 +111,6 @@ export default class KafkaGenerator extends SpringBootApplicationGenerator {
         source.addTestLog?.({ name: 'kafka', level: 'WARN' });
         source.addTestLog?.({ name: 'org.I0Itec', level: 'WARN' });
       },
-      integrationTest({ application, source }) {
-        source.editJavaFile!(`${application.javaPackageTestDir}IntegrationTest.java`, {
-          imports: [`${application.packageName}.config.KafkaTestContainer`],
-          annotations: [
-            {
-              package: 'org.springframework.boot.testcontainers.context',
-              annotation: 'ImportTestcontainers',
-              parameters: (_, cb) => cb.addKeyValue('value', 'KafkaTestContainer.class'),
-            },
-          ],
-        });
-      },
       addDependencies({ source }) {
         source.addJavaDependencies?.([
           {

--- a/generators/spring-cloud/generators/kafka/templates/src/test/java/_package_/config/KafkaTestContainer.java.ejs
+++ b/generators/spring-cloud/generators/kafka/templates/src/test/java/_package_/config/KafkaTestContainer.java.ejs
@@ -28,6 +28,10 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 
+/**
+ * Sample Kafka Test Container configuration for integration tests. This will start a Kafka container before the tests and stop it afterwards.
+ * To use it, add @ImportTestcontainers(KafkaTestContainer.class) to your test class.
+ */
 public interface KafkaTestContainer {
     @Container
     KafkaContainer kafkaContainer = new KafkaContainer("<%- dockerContainers.kafka %>")


### PR DESCRIPTION
Follow-up to https://github.com/jhipster/generator-jhipster/pull/32079 and https://github.com/jhipster/generator-jhipster/pull/32090.

Closes https://github.com/jhipster/generator-jhipster/pull/31863.
Fixes https://github.com/jhipster/generator-jhipster/issues/31133

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
