### PR TITLE
internal: add custom pluralize helper

### DIFF
--- a/generators/base-application/entity.ts
+++ b/generators/base-application/entity.ts
@@ -1,5 +1,4 @@
 import { kebabCase, lowerFirst, snakeCase, startCase, upperFirst } from 'lodash-es';
-import pluralize from 'pluralize';
 
 import type { DerivedPropertiesOnlyOf } from '../../lib/command/types.ts';
 import type { FieldType } from '../../lib/jhipster/field-types.ts';
@@ -10,6 +9,7 @@ import type { Field as BaseField } from '../../lib/jhipster/types/field.ts';
 import type { Relationship as BaseRelationship } from '../../lib/jhipster/types/relationship.ts';
 import { buildMutateDataForProperty } from '../../lib/utils/derived-property.ts';
 import type { MutateDataParam, MutateDataPropertiesWithRequiredProperties } from '../../lib/utils/object.ts';
+import { pluralize } from '../../lib/utils/string-utils.ts';
 
 import { isFieldEnumType } from './internal/types/field-types.ts';
 import type { FakerWithRandexp } from './support/faker.ts';
@@ -194,8 +194,8 @@ export const mutateRelationship = {
   collection: ({ relationshipType }) => relationshipType === 'one-to-many' || relationshipType === 'many-to-many',
 
   relationshipFieldName: ({ relationshipName }) => lowerFirst(relationshipName),
-  relationshipFieldNamePlural: ({ relationshipFieldName }) => pluralize(relationshipFieldName),
-  relationshipNamePlural: ({ relationshipName }) => pluralize(relationshipName),
+  relationshipFieldNamePlural: ({ relationshipFieldName }) => pluralize(relationshipFieldName, { force: true }),
+  relationshipNamePlural: ({ relationshipName }) => pluralize(relationshipName, { force: true }),
   relationshipNameCapitalized: ({ relationshipName }) => upperFirst(relationshipName),
   relationshipNameHumanized: ({ relationshipName }) => startCase(relationshipName),
 
@@ -368,12 +368,12 @@ export const mutateEntity = {
   clientRootFolder: '',
   entityNameCapitalized: ({ name }) => upperFirst(name),
   entityNameKebabCase: ({ name }) => kebabCase(name),
-  entityNamePlural: ({ name }) => pluralize(name),
-  entityNamePluralizedAndSpinalCased: ({ entityNamePlural }) => kebabCase(entityNamePlural),
+  entityNamePlural: ({ name }) => pluralize(name, { force: true }),
+  entityNamePluralizedAndSpinalCased: ({ name }) => kebabCase(pluralize(name, { force: false })),
   entityInstance: ({ name }) => lowerFirst(name),
   entityInstancePlural: ({ entityNamePlural }) => lowerFirst(entityNamePlural),
   entityAuthority: ({ adminEntity }) => (adminEntity ? 'ROLE_ADMIN' : undefined),
 
   entityNameHumanized: ({ entityNameCapitalized }) => startCase(entityNameCapitalized),
-  entityNamePluralHumanized: ({ entityNamePlural }) => startCase(entityNamePlural),
+  entityNamePluralHumanized: ({ entityNameHumanized }) => pluralize(entityNameHumanized, { force: false }),
 } as const satisfies MutateDataPropertiesWithRequiredProperties<MutateDataParam<Entity>, BaseApplicationAddedEntityProperties>;

--- a/generators/client/entity.ts
+++ b/generators/client/entity.ts
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 import { kebabCase, upperFirst } from 'lodash-es';
-import pluralize from 'pluralize';
 
 import type { MutateDataParam, MutateDataPropertiesWithRequiredProperties } from '../../lib/utils/object.ts';
 import { normalizePathEnd } from '../../lib/utils/path.ts';
+import { pluralize } from '../../lib/utils/string-utils.ts';
 import { upperFirstCamelCase } from '../../lib/utils/string.ts';
 import type { Relationship as BaseApplicationRelationship } from '../base-application/types.d.ts';
 import type { Entity as CommonEntity, Field as CommonField, Relationship as CommonRelationship } from '../common/types.ts';
@@ -89,7 +89,7 @@ export const mutateEntity = {
   entityUrl: data => data.entityStateName,
 
   entityAngularName: data => data.entityTsName,
-  entityAngularNamePlural: data => pluralize(data.entityAngularName),
+  entityAngularNamePlural: data => pluralize(data.entityAngularName, { force: true }),
   entityReactName: data => data.entityTsName,
 } as const satisfies MutateDataPropertiesWithRequiredProperties<MutateDataParam<Entity>, ClientAddedEntityProperties>;
 

--- a/generators/java/generators/bootstrap/generator.ts
+++ b/generators/java/generators/bootstrap/generator.ts
@@ -18,9 +18,9 @@
  */
 
 import { upperFirst } from 'lodash-es';
-import pluralize from 'pluralize';
 
 import { mutateData } from '../../../../lib/utils/index.ts';
+import { pluralize } from '../../../../lib/utils/string-utils.ts';
 import { mutateApplicationPreparing, mutateField, mutateRelationship } from '../../application.ts';
 import { JavaApplicationGenerator } from '../../generator.ts';
 import { prepareEntity } from '../../support/index.ts';
@@ -101,7 +101,9 @@ export default class JavaBootstrapGenerator extends JavaApplicationGenerator {
       prepareRelationship({ application, relationship }) {
         mutateData(relationship, mutateRelationship, {
           relationshipNameCapitalizedPlural: ({ relationshipNameCapitalized, relationshipName }) =>
-            relationshipName.length > 1 ? pluralize(relationshipNameCapitalized) : upperFirst(pluralize(relationshipName)),
+            relationshipName.length > 1
+              ? pluralize(relationshipNameCapitalized, { force: true })
+              : upperFirst(pluralize(relationshipName, { force: true })),
           relationshipUpdateBackReference: ({ ownerSide, relationshipRightSide, otherEntity }) =>
             !otherEntity.embedded && (application.databaseTypeNeo4j ? relationshipRightSide : !ownerSide),
         });

--- a/lib/utils/string-utils.ts
+++ b/lib/utils/string-utils.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 import { lowerFirst } from 'lodash-es';
+import pluralizeString from 'pluralize';
 
 export function customCamelCase(string: string): string {
   checkStringIsValid(string);
@@ -30,4 +31,15 @@ function checkStringIsValid(string: string) {
   if (string == null) {
     throw new Error('The passed string cannot be nil.');
   }
+}
+
+/**
+ * Pluralizes a string. If force is passed and the plural is the same as the singular, it adds an "s" or "es" suffix at the end of the string to avoid conflicts.
+ */
+export function pluralize(string: string, { force }: { force: boolean }): string {
+  const plural = pluralizeString(string);
+  if (plural === string && force) {
+    return string.endsWith('s') ? `${string}es` : `${string}s`;
+  }
+  return plural;
 }

--- a/lib/utils/string_utils.spec.ts
+++ b/lib/utils/string_utils.spec.ts
@@ -23,9 +23,17 @@ import { describe, it } from 'esmocha';
 
 import { expect } from 'chai';
 
-import { customCamelCase } from './string-utils.ts';
+import { customCamelCase, pluralize } from './string-utils.ts';
 
 describe('jdl - StringUtils', () => {
+  describe('pluralize', () => {
+    it('should keep it as it is when force is false', () => {
+      expect(pluralize('UserData', { force: false })).to.equal('UserData');
+    });
+    it('should append an "s" when force is true', () => {
+      expect(pluralize('UserData', { force: true })).to.equal('UserDatas');
+    });
+  });
   describe('customCamelCase', () => {
     describe('when passing a valid string', () => {
       describe('with only one letter', () => {


### PR DESCRIPTION
Some properties requires the plural name to be different from singular name to avoid conflicts. Add a helper to force a different value.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
