### PR TITLE
Adapt getCurrentUserJWT() to the return value of authentication.getCredentials().

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
@@ -144,8 +144,8 @@ public final class SecurityUtils {
         SecurityContext securityContext = SecurityContextHolder.getContext();
         return Optional.ofNullable(securityContext.getAuthentication())
   <%_ } _%>
-            .filter(authentication -> authentication.getCredentials() instanceof String)
-            .map(authentication -> (String) authentication.getCredentials());
+            .filter(authentication -> authentication.getCredentials() instanceof Jwt)
+            .map(authentication -> ((Jwt) authentication.getCredentials()).getTokenValue());
     }
   <%_ if (user) { _%>
 

--- a/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_imperative.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_imperative.java.ejs
@@ -20,6 +20,8 @@ package <%= packageName %>.security;
 
 <%_ if (authenticationTypeJwt) { _%>
 import static <%= packageName %>.security.SecurityUtils.USER_ID_CLAIM;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 <%_ } _%>
 
 import org.junit.jupiter.api.AfterEach;
@@ -33,6 +35,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 <%_ if (authenticationTypeJwt) { _%>
 import java.time.Instant;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 <%_ } _%>
 <%_ if (authenticationTypeOauth2) { _%>
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -132,7 +135,9 @@ class SecurityUtilsUnitTest {
     @Test
     void testGetCurrentUserJWT() {
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken("admin", "token"));
+        Jwt jwtMock = mock(Jwt.class);
+        when(jwtMock.getTokenValue()).thenReturn("token");
+        securityContext.setAuthentication(new JwtAuthenticationToken(jwtMock));
         SecurityContextHolder.setContext(securityContext);
         Optional<String> jwt = SecurityUtils.getCurrentUserJWT();
         assertThat(jwt).contains("token");


### PR DESCRIPTION
A fix for #32399.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
