### PR TITLE
[React] Remove redux-mock-store

### DIFF
--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -64,7 +64,6 @@
     "postcss-loader": "8.2.1",
     "postcss-rtlcss": "5.7.1",
     "react-infinite-scroll-component": "6.1.1",
-    "redux-mock-store": "1.5.5",
     "rimraf": "6.1.3",
     "sass": "1.77.6",
     "sass-loader": "16.0.7",

--- a/generators/react/templates/package.json.ejs
+++ b/generators/react/templates/package.json.ejs
@@ -93,7 +93,6 @@
     "postcss-rtlcss": "<%= nodeDependencies['postcss-rtlcss'] %>",
 <%_ } _%>
     "react-infinite-scroll-component": "<%= nodeDependencies['react-infinite-scroll-component'] %>",
-    "redux-mock-store": "<%= nodeDependencies['redux-mock-store'] %>",
     "rimraf": "<%= nodeDependencies['rimraf'] %>",
     "sass": "<%= nodeDependencies['sass'] %>",
     "sass-loader": "<%= nodeDependencies['sass-loader'] %>",

--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.spec.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.spec.tsx.ejs
@@ -20,7 +20,7 @@
 import { shallow } from 'enzyme';
 import axios from 'axios';
 
-import configureStore from 'redux-mock-store';
+import { configureStore } from '@reduxjs/toolkit';
 import { spy, sandbox } from 'sinon';
 
 import { RegisterPage } from 'app/modules/account/register/register';
@@ -30,13 +30,12 @@ describe('RegisterComponent', () => {
   describe('RegisterPage', () => {
     let mountedWrapper;
     let localSandbox;
-    const mockStore = configureStore();
     const handleRegisterSpy = spy();
 
     const wrapper = () => {
       localSandbox = sandbox.create();
       const initialState = {};
-      // const store = mockStore(initialState);
+      // const store = configureStore({ reducer: () => ({ initialState }) });
       const props = {
         handleRegister: handleRegisterSpy,
         reset: spy(),

--- a/generators/react/templates/src/main/webapp/app/shared/auth/private-route.spec.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/auth/private-route.spec.tsx.ejs
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 <%_ if (enableTranslation) { _%>
 import { TranslatorContext } from 'react-jhipster';
 <%_ } _%>
-import configureStore from 'redux-mock-store';
+import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 
 import { Authority } from 'app/shared/jhipster/constants';
@@ -21,9 +21,12 @@ describe('private-route component', () => {
   });
 <%_ } _%>
 
-  const mockStore = configureStore();
   const wrapper = (Elem: JSX.Element, authentication) => {
-    const store = mockStore({ authentication });
+    const store = configureStore({
+      reducer: {
+        authentication: () => authentication,
+      },
+    });
     return render(
       <Provider store={store}>
         <MemoryRouter>{Elem}</MemoryRouter>


### PR DESCRIPTION
`redux-mock-store` is deprecated
<img width="747" height="384" alt="image" src="https://github.com/user-attachments/assets/20e25d1d-87e4-45c8-aac7-3133ed858843" />
