### PR TITLE
React: Remove types because they are directly in dependencies

### DIFF
--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -35,7 +35,6 @@
     "@types/node": "22.19.11",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "@types/redux": "3.6.31",
     "@types/webpack-env": "1.18.8",
     "autoprefixer": "10.4.24",
     "browser-sync": "3.0.4",

--- a/generators/react/templates/package.json.ejs
+++ b/generators/react/templates/package.json.ejs
@@ -60,7 +60,6 @@
     "@types/node": "<%= nodeDependencies['@types/node'] %>",
     "@types/react": "<%= nodeDependencies['@types/react'] %>",
     "@types/react-dom": "<%= nodeDependencies['@types/react-dom'] %>",
-    "@types/redux": "<%= nodeDependencies['@types/redux'] %>",
     "@types/webpack-env": "<%= nodeDependencies['@types/webpack-env'] %>",
     "autoprefixer": "<%= nodeDependencies['autoprefixer'] %>",
     "browser-sync": "<%= nodeDependencies['browser-sync'] %>",


### PR DESCRIPTION
https://redux.js.org/tutorials/typescript-quick-start

<img width="763" height="96" alt="image" src="https://github.com/user-attachments/assets/43537879-61cc-4889-9e90-fc21ac46a898" />
