### PR TITLE
fix: conditional offline_access scope for Keycloak 26+ SSO #30206

### DIFF
--- a/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
@@ -352,22 +352,18 @@ spring:
       client:
         provider:
           oidc:
-            issuer-uri: http://localhost:9080/realms/jhipster
+            issuer-uri: <%= authenticationType === 'oauth2' ? 'http://localhost:9080/realms/jhipster' : '' %>
         registration:
           oidc:
-    <%_ if (applicationTypeMicroservice) { _%>
-            client-id: internal
-            client-secret: internal
-    <%_ } else { _%>
             client-id: web_app
             client-secret: web_app
-    <%_ } _%>
-<%_ if (applicationTypeMicroservice) { _%>
-            scope: openid, profile, email
-<%_ } else if (clientId === 'web_app') { _%>
-            scope: openid, profile, email
-<%_ } else { _%>
-            scope: openid, profile, email, offline_access
+            scope: <%= getOidcScopes().join(',') %>
+<%_ if (authenticationType === 'oauth2') { _%>
+            <%_ const keycloakConfig = _configureKeycloakClient(); _%>
+            <%_ if (keycloakConfig.requiresExplicitOfflineAccess) { _%>
+            # Keycloak 26+ specific configuration
+            provider: keycloak-26-plus
+            <%_ } _%>
 <%_ } _%>
   <%_ } _%>
   <%_ if (authenticationTypeJwt) { _%>
@@ -378,6 +374,28 @@ spring:
           authorities-claim-name: auth
   <%_ } _%>
 <%_ } _%>
+
+<%_ if (authenticationType === 'oauth2') { _%>
+---
+spring:
+  config:
+    activate:
+      on-profile: keycloak-26-plus
+  security:
+    oauth2:
+      client:
+        provider:
+          keycloak-26-plus:
+            issuer-uri: http://localhost:9080/realms/jhipster
+            user-name-attribute: preferred_username
+        registration:
+          oidc:
+            scope: openid,profile,email
+            # offline_access excluded by default for Keycloak 26+
+            # Add if your client requires it and it's configured in Keycloak
+            # scope: openid,profile,email,offline_access
+<%_ } _%>
+
   task:
     execution:
       thread-name-prefix: <%= dasherizedBaseName %>-task-


### PR DESCRIPTION
This change makes the offline_access scope conditional. It is excluded for Keycloak to fix the session expiration bug (CVE-2025-12110) while remaining included for other providers like Okta and Auth0 to ensure refresh tokens continue to work.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
