### PR TITLE
[Vue] Remove numeral dependency

### DIFF
--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -46,7 +46,6 @@
     "jiti": "2.6.1",
     "merge-jsons-webpack-plugin": "2.0.1",
     "mini-css-extract-plugin": "2.10.0",
-    "numeral": "2.0.6",
     "postcss-import": "16.1.1",
     "postcss-loader": "8.2.1",
     "postcss-url": "10.1.3",

--- a/generators/vue/templates/package.json.ejs
+++ b/generators/vue/templates/package.json.ejs
@@ -71,7 +71,6 @@
     "autoprefixer": "<%= nodeDependencies['autoprefixer'] %>",
     "flush-promises": null,
     "happy-dom": "<%= nodeDependencies['happy-dom'] %>",
-    "numeral": "<%= nodeDependencies['numeral'] %>",
     "postcss-import": "<%= nodeDependencies['postcss-import'] %>",
     "postcss-url": "<%= nodeDependencies['postcss-url'] %>",
     "rimraf": "<%= nodeDependencies['rimraf'] %>",

--- a/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
@@ -2,7 +2,6 @@ import { defineComponent, inject, ref, type Ref } from 'vue';
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n';
 <%_ } _%>
-import numeral from 'numeral';
 
 import { useDateFormat } from '@/shared/composables'
 import <%=jhiPrefixCapitalized%>MetricsModal from './metrics-modal.vue';
@@ -97,10 +96,10 @@ export default defineComponent({
       return input;
     },
     formatNumber1(value: any): any {
-      return numeral(value).format('0,0');
+      return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value);
     },
     formatNumber2(value: any): any {
-      return numeral(value).format('0,00');
+      return new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value);
     },
     convertMillisecondsToDuration(ms) {
       const times = {


### PR DESCRIPTION
According to Gemini: _Pour obtenir exactement le même rendu que numeral sans dépendre de la langue du navigateur, il suffit de forcer la locale en-US (qui utilise le format 1,234.56) à l'intérieur de vos fonctions natives._