### PR TITLE
fix: remove offline_access from default OAuth2 scope

### DIFF
--- a/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/spring-boot/templates/src/main/resources/config/application.yml.ejs
@@ -362,7 +362,7 @@ spring:
             client-id: web_app
             client-secret: web_app
     <%_ } _%>
-            scope: openid, profile, email, offline_access # last one for refresh tokens
+            scope: openid, profile, email
   <%_ } _%>
   <%_ if (authenticationTypeJwt) { _%>
     oauth2:

--- a/generators/spring-cloud/generators/feign-client/templates/src/test/java/_package_/client/AuthorizationHeaderUtilTest.java.ejs
+++ b/generators/spring-cloud/generators/feign-client/templates/src/test/java/_package_/client/AuthorizationHeaderUtilTest.java.ejs
@@ -257,7 +257,7 @@ class AuthorizationHeaderUtilTest {
         dto.setSessionState("ccea4a55");
         dto.setExpiresIn(300l);
         dto.setRefreshToken(hasRefreshToken ? "tokenVal" : null);
-        dto.setScope("openid email profile offline_access");
+        dto.setScope("openid email profile");
         return Optional.of(dto);
     }
 }


### PR DESCRIPTION
## Description

Since Keycloak 26.1.0 ([keycloak/keycloak#36921](https://github.com/keycloak/keycloak/issues/36921)), requesting the `offline_access` scope causes Keycloak to create **only an offline session** — no regular SSO session is established. This breaks:

1. **SSO redirect** between clients in the same realm silently fails
2. **Logout** returns `LOGOUT_ERROR: session_expired` because no live session exists
3. **Orphaned offline sessions** accumulate on every login/logout cycle

### Root Cause

The `offline_access` scope instructs Keycloak to issue an offline token and create an offline session, skipping the regular session entirely. This behavior changed in Keycloak 26.1.0 and is documented in the upstream issue.

### Fix

Remove `offline_access` from the default `scope` in the generated `application.yml`. Standard OAuth2 refresh tokens work via `grant_type=refresh_token` and **do not** require `offline_access` in the initial scope. The `offline_access` scope is only appropriate for long-running background/batch processes that need API access when the user is completely offline.

### What stays unchanged

- **Keycloak realm config** (`jhipster-realm.json.ejs`) — `offline_access` correctly remains as an _optional_ client scope in the realm. Clients can still request it when explicitly needed.
- **Kubernetes Keycloak configmap** — same reasoning, the realm can offer it; the default client config should not request it.

### Note on JHipster Ionic Blueprint

The Ionic blueprint adds `offline_access` from its **own client-side code**, not from `application.yml`:

```typescript
// generator-jhipster-ionic: auth.factory.ts
environment.oidcConfig.scopes += ' offline_access'
```

This is set at the Capacitor/mobile layer and is independent of the Spring backend's `application.yml` configuration. Therefore, this change **does not affect** the Ionic blueprint.

This addresses the concern raised in PR #30254's review.

Fix #30206

---

- [x] All continuous integration tests are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed