### PR TITLE
fix: resolve OAuth2 authentication issues with Istio and Kubernetes

### DIFF
--- a/generators/kubernetes/templates/istio/virtual-service.yml.ejs
+++ b/generators/kubernetes/templates/istio/virtual-service.yml.ejs
@@ -15,3 +15,27 @@ spec:
     retries:
       attempts: 3
       perTryTimeout: 2s
+    headers:
+      request:
+        set:
+          x-forwarded-proto: https
+      response:
+        set:
+          Strict-Transport-Security: "max-age=31536000; includeSubDomains"
+    corsPolicy:
+      allowOrigins:
+      - exact: "https://<%= app.baseName.toLowerCase() %>"
+      allowMethods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+      - OPTIONS
+      allowHeaders:
+      - Authorization
+      - Content-Type
+      - X-Requested-With
+      exposeHeaders:
+      - Authorization
+      - Content-Length
+      allowCredentials: true

--- a/generators/kubernetes/templates/kubernetes.yml.ejs
+++ b/generators/kubernetes/templates/kubernetes.yml.ejs
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <%= app.baseName.toLowerCase() %>
+  namespace: <%= kubernetesNamespace %>
+  labels:
+    app: <%= app.baseName.toLowerCase() %>
+spec:
+  replicas: <%= kubernetesReplicas %>
+  selector:
+    matchLabels:
+      app: <%= app.baseName.toLowerCase() %>
+  template:
+    metadata:
+      labels:
+        app: <%= app.baseName.toLowerCase() %>
+      annotations:
+        sidecar.istio.io/inject: "true"
+        proxy.istio.io/config: |
+          holdApplicationUntilProxyStarts: true
+          proxyMetadata:
+            ISTIO_META_DNS_CAPTURE: "true"
+    spec:
+      serviceAccountName: <%= app.baseName.toLowerCase() %>
+      containers:
+      - name: <%= app.baseName.toLowerCase() %>
+        image: <%= dockerPushCommand %>/<%= app.baseName.toLowerCase() %>:<%= dockerImageVersion %>
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: "prod,kubernetes"
+        - name: OAUTH2_ISSUER_URI
+          valueFrom:
+            secretKeyRef:
+              name: <%= app.baseName.toLowerCase() %>-oauth2
+              key: issuer-uri
+        - name: OAUTH2_JWK_SET_URI
+          valueFrom:
+            secretKeyRef:
+              name: <%= app.baseName.toLowerCase() %>-oauth2
+              key: jwk-set-uri
+        - name: OAUTH2_AUDIENCE
+          valueFrom:
+            secretKeyRef:
+              name: <%= app.baseName.toLowerCase() %>-oauth2
+              key: audience
+        readinessProbe:
+          httpGet:
+            path: /actuator/health/readiness
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /actuator/health/liveness
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: <%= app.baseName.toLowerCase() %>
+              topologyKey: kubernetes.io/hostname
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: <%= app.baseName.toLowerCase() %>
+  namespace: <%= kubernetesNamespace %>
+  labels:
+    app: <%= app.baseName.toLowerCase() %>
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    name: http
+  selector:
+    app: <%= app.baseName.toLowerCase() %>
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-oauth2
+  namespace: <%= kubernetesNamespace %>
+type: Opaque
+stringData:
+  issuer-uri: "https://keycloak.example.com/realms/myrealm"
+  jwk-set-uri: "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs"
+  audience: "<%= app.baseName %>-api"

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -1,0 +1,62 @@
+package <%= packageName %>.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/public/**").permitAll()
+                .requestMatchers("/actuator/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt
+                    .jwtAuthenticationConverter(jwtAuthenticationConverter())
+                )
+            );
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setPrincipalClaimName("sub");
+        return converter;
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Length"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -1,0 +1,28 @@
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${OAUTH2_ISSUER_URI:https://keycloak.example.com/realms/myrealm}
+          jwk-set-uri: ${OAUTH2_JWK_SET_URI:https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs}
+          audience: ${OAUTH2_AUDIENCE:<%= app.baseName %>-api}
+  
+  cloud:
+    gateway:
+      routes:
+      - id: <%= app.baseName.toLowerCase() %>
+        uri: lb://<%= app.baseName.toLowerCase() %>
+        predicates:
+        - Path=/api/**
+        filters:
+        - PreserveHeader=Authorization
+        - PreserveHeader=X-Forwarded-For
+        - PreserveHeader=X-Forwarded-Proto
+
+server:
+  forward-headers-strategy: framework
+  
+logging:
+  level:
+    org.springframework.security: DEBUG
+    org.springframework.security.oauth2: DEBUG


### PR DESCRIPTION
## Summary
This PR fixes OAuth2 authentication failures when deploying to Kubernetes with Istio. Changes include:
- Added OAuth2 authorization header forwarding rules and CORS policy to Istio VirtualService.
- Created SecurityConfiguration with JWT token validation and CORS settings.
- Configured OAuth2 JWT validation and header forwarding for production.
- Updated Kubernetes deployment to enable Istio sidecar injection and manage OAuth2 secrets.

Closes #17384

## Testing
Run the test suite to verify authentication flows:
```bash
npm test
```

## Notes
- Ensure Istio sidecar injection is enabled in the target namespace.
- OAuth2 secrets must be configured in the Kubernetes cluster before deployment.