### PR TITLE
feat: add JSON CLOB support to sample entities

### DIFF
--- a/.blueprint/generate-sample/command.ts
+++ b/.blueprint/generate-sample/command.ts
@@ -40,7 +40,7 @@ const command = {
           gen.entitiesSample = 'document';
         }
       },
-      choices: ['sql', 'sqllight', 'micro', 'sqlfull', 'none', 'neo4j', 'mongodb', 'document', 'cassandra', 'couchbase'],
+      choices: ['sql', 'sqllight', 'micro', 'sqlfull', 'none', 'neo4j', 'mongodb', 'document', 'cassandra', 'couchbase', 'json-clob'],
       scope: 'generator',
     },
     global: {

--- a/.blueprint/generate-sample/templates/test-integration/samples/.jhipster/GeoData.json
+++ b/.blueprint/generate-sample/templates/test-integration/samples/.jhipster/GeoData.json
@@ -1,0 +1,19 @@
+{
+  "applications": "*",
+  "changelogDate": "20240101000000",
+  "clientRootFolder": "",
+  "dto": "no",
+  "embedded": false,
+  "entityTableName": "geo_data",
+  "fields": [
+    { "fieldName": "name", "fieldType": "String", "fieldValidateRules": ["required"] },
+    { "fieldName": "geoJson", "fieldType": "byte[]", "fieldTypeBlobContent": "json", "fieldValidateRules": [] }
+  ],
+  "fluentMethods": true,
+  "jpaMetamodelFiltering": false,
+  "name": "GeoData",
+  "pagination": "no",
+  "readOnly": false,
+  "relationships": [],
+  "service": "no"
+}


### PR DESCRIPTION
## Summary

This PR adds JSON support to CLOB fields within the sample generation logic.

Changes include:
- Added a sample entity demonstrating JSON CLOB field support with fieldTypeBlobContent set to json
- Added the json-clob option to entitiesSample choices for testing purposes

Closes #14526

## Testing

Run the following command to verify the generator functionality:

```bash
npx vitest run .blueprint/generate-sample/generator.spec.ts
```

## Notes

Ensure that the underlying database configuration supports JSON content within CLOB fields when using this sample.