### PR TITLE
fix(client): sanitize template literal injection in all client string properties

### DIFF
--- a/generators/client/generators/bootstrap/generator.spec.ts
+++ b/generators/client/generators/bootstrap/generator.spec.ts
@@ -68,24 +68,41 @@ describe(`generator - ${generator}`, () => {
 
   describe('security hardening', () => {
     before(async () => {
-      await helpers.runJHipster(generator).withJHipsterConfig(
-        {
-          skipServer: true,
-          skipUserManagement: true,
-        },
-        [
+      await helpers
+        .runJHipster(generator)
+        .withJHipsterConfig(
           {
-            name: 'Foo',
-            // eslint-disable-next-line no-template-curly-in-string
-            annotations: { entityProperty: '${foo}' },
-            fields: [{ fieldName: 'myField', fieldType: 'String' }],
+            skipServer: true,
+            skipUserManagement: true,
           },
-        ],
-      );
+          [
+            {
+              name: 'Foo',
+              // eslint-disable-next-line no-template-curly-in-string
+              annotations: { entityProperty: '${foo}' },
+              fields: [
+                {
+                  fieldName: 'myField',
+                  fieldType: 'String',
+                  // eslint-disable-next-line no-template-curly-in-string
+                  fieldValidateRulesPattern: '${injected}',
+                  // eslint-disable-next-line no-template-curly-in-string
+                  options: { fieldProperty: '${foot}' },
+                },
+              ],
+            },
+          ],
+        )
+        .withSkipWritingPriorities();
     });
 
-    it('should strip ${ from entity properties', () => {
-      expect(runResult.entities?.Foo?.entityProperty).not.toContain('${');
+    it('should be applied', () => {
+      expect(runResult.entities?.Foo).toMatchObject(
+        expect.objectContaining({
+          entityProperty: '',
+          fields: expect.arrayContaining([expect.objectContaining({ fieldProperty: '', fieldValidateRulesPattern: '' })]),
+        }),
+      );
     });
   });
 });

--- a/generators/client/generators/bootstrap/generator.spec.ts
+++ b/generators/client/generators/bootstrap/generator.spec.ts
@@ -76,6 +76,7 @@ describe(`generator - ${generator}`, () => {
         [
           {
             name: 'Foo',
+            // eslint-disable-next-line no-template-curly-in-string
             annotations: { entityProperty: '${foo}' },
             fields: [{ fieldName: 'myField', fieldType: 'String' }],
           },
@@ -84,7 +85,7 @@ describe(`generator - ${generator}`, () => {
     });
 
     it('should strip ${ from entity properties', () => {
-      expect(runResult.entities?.['Foo']?.entityProperty).not.toContain('${');
+      expect(runResult.entities?.Foo?.entityProperty).not.toContain('${');
     });
   });
 });

--- a/generators/client/generators/bootstrap/generator.spec.ts
+++ b/generators/client/generators/bootstrap/generator.spec.ts
@@ -65,4 +65,26 @@ describe(`generator - ${generator}`, () => {
   });
 
   testBootstrapEntities(generator);
+
+  describe('security hardening', () => {
+    before(async () => {
+      await helpers.runJHipster(generator).withJHipsterConfig(
+        {
+          skipServer: true,
+          skipUserManagement: true,
+        },
+        [
+          {
+            name: 'Foo',
+            annotations: { entityProperty: '${foo}' },
+            fields: [{ fieldName: 'myField', fieldType: 'String' }],
+          },
+        ],
+      );
+    });
+
+    it('should strip ${ from entity properties', () => {
+      expect(runResult.entities?.['Foo']?.entityProperty).not.toContain('${');
+    });
+  });
 });

--- a/generators/client/generators/bootstrap/generator.ts
+++ b/generators/client/generators/bootstrap/generator.ts
@@ -130,7 +130,7 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
       securityHardening({ application }) {
         for (const [key, value] of Object.entries(application)) {
           if (typeof value === 'string' && !key.startsWith('java')) {
-            (application as any)[key] = value.replace(/\${/g, '') as any;
+            (application as any)[key] = value.replace(/\$\{(?![\w.-]+\})/g, '') as any;
           }
         }
       },
@@ -148,7 +148,7 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
           for (const object of [entity, ...(entity.fields ?? []), ...(entity.relationships ?? []), entity.primaryKey].filter(Boolean)) {
             for (const [key, value] of Object.entries(object as any)) {
               if (typeof value === 'string' && !key.startsWith('java')) {
-                (object as any)[key] = value.replace(/\${/g, '') as any;
+                (object as any)[key] = value.replace(/\$\{(?![\w.-]+\})/g, '') as any;
               }
             }
           }

--- a/generators/client/generators/bootstrap/generator.ts
+++ b/generators/client/generators/bootstrap/generator.ts
@@ -129,7 +129,8 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
     return this.asWritingTaskGroup({
       securityHardening({ application }) {
         for (const [key, value] of Object.entries(application)) {
-          if (typeof value === 'string' && !key.startsWith('java')) {
+          const descriptor = Object.getOwnPropertyDescriptor(application, key);
+          if (typeof value === 'string' && !key.startsWith('java') && descriptor?.writable) {
             (application as any)[key] = value.replace(/\$\{(?![\w.-]+\})/g, '') as any;
           }
         }
@@ -147,7 +148,8 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
         for (const entity of entities) {
           for (const object of [entity, ...(entity.fields ?? []), ...(entity.relationships ?? []), entity.primaryKey].filter(Boolean)) {
             for (const [key, value] of Object.entries(object as any)) {
-              if (typeof value === 'string' && !key.startsWith('java')) {
+              const descriptor = Object.getOwnPropertyDescriptor(object, key);
+              if (typeof value === 'string' && !key.startsWith('java') && descriptor?.writable) {
                 (object as any)[key] = value.replace(/\$\{(?![\w.-]+\})/g, '') as any;
               }
             }

--- a/generators/client/generators/bootstrap/generator.ts
+++ b/generators/client/generators/bootstrap/generator.ts
@@ -124,4 +124,40 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
   get [ClientApplicationGenerator.DEFAULT]() {
     return this.default;
   }
+
+  get writing() {
+    return this.asWritingTaskGroup({
+      securityHardening({ application }) {
+        for (const [key, value] of Object.entries(application)) {
+          if (typeof value === 'string' && !key.startsWith('java')) {
+            (application as any)[key] = value.replace(/\${/g, '') as any;
+          }
+        }
+      },
+    });
+  }
+
+  get [ClientApplicationGenerator.WRITING]() {
+    return this.delegateTasksToBlueprint(() => this.writing);
+  }
+
+  get writingEntities() {
+    return this.asWritingEntitiesTaskGroup({
+      securityHardening({ entities }) {
+        for (const entity of entities) {
+          for (const object of [entity, ...(entity.fields ?? []), ...(entity.relationships ?? []), entity.primaryKey].filter(Boolean)) {
+            for (const [key, value] of Object.entries(object as any)) {
+              if (typeof value === 'string' && !key.startsWith('java')) {
+                (object as any)[key] = value.replace(/\${/g, '') as any;
+              }
+            }
+          }
+        }
+      },
+    });
+  }
+
+  get [ClientApplicationGenerator.WRITING_ENTITIES]() {
+    return this.delegateTasksToBlueprint(() => this.writingEntities);
+  }
 }

--- a/generators/client/generators/bootstrap/generator.ts
+++ b/generators/client/generators/bootstrap/generator.ts
@@ -118,40 +118,31 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
           await preparePostEntityClientDerivedProperties(entity);
         }
       },
-    });
-  }
-
-  get [ClientApplicationGenerator.DEFAULT]() {
-    return this.default;
-  }
-
-  get writing() {
-    return this.asWritingTaskGroup({
-      securityHardening({ application }) {
-        for (const [key, value] of Object.entries(application)) {
-          const descriptor = Object.getOwnPropertyDescriptor(application, key);
-          if (typeof value === 'string' && !key.startsWith('java') && descriptor?.writable) {
-            (application as any)[key] = value.replace(/\${/g, '') as any;
-          }
-        }
-      },
-    });
-  }
-
-  get [ClientApplicationGenerator.WRITING]() {
-    return this.delegateTasksToBlueprint(() => this.writing);
-  }
-
-  get writingEntities() {
-    return this.asWritingEntitiesTaskGroup({
       securityHardening({ entities }) {
+        const stripTemplateLiteral = (value: unknown) => (typeof value === 'string' ? value.replace(/\$\{[^}]*\}/g, '') : value);
+        const sanitizeKeys = (object: any, keys: string[]) => {
+          for (const key of keys) {
+            if (typeof object[key] === 'string') {
+              object[key] = stripTemplateLiteral(object[key]);
+            }
+          }
+        };
         for (const entity of entities) {
-          for (const object of [entity, ...(entity.fields ?? []), ...(entity.relationships ?? []), entity.primaryKey].filter(Boolean)) {
-            for (const [key, value] of Object.entries(object as any)) {
-              const descriptor = Object.getOwnPropertyDescriptor(object, key);
-              if (typeof value === 'string' && !key.startsWith('java') && descriptor?.writable) {
-                (object as any)[key] = value.replace(/\${/g, '') as any;
-              }
+          // Sanitize user-controlled annotation properties spread onto the entity
+          if (entity.annotations) {
+            sanitizeKeys(entity, Object.keys(entity.annotations));
+          }
+          for (const field of entity.fields ?? []) {
+            // Sanitize user-controlled option properties spread onto the field
+            if (field.options) {
+              sanitizeKeys(field, Object.keys(field.options));
+            }
+            // Sanitize the validation pattern and its framework-specific derivatives
+            sanitizeKeys(field, ['fieldValidateRulesPattern', 'fieldValidateRulesPatternAngular', 'fieldValidateRulesPatternReact']);
+          }
+          for (const relationship of entity.relationships ?? []) {
+            if (relationship.options) {
+              sanitizeKeys(relationship, Object.keys(relationship.options));
             }
           }
         }
@@ -159,7 +150,7 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
     });
   }
 
-  get [ClientApplicationGenerator.WRITING_ENTITIES]() {
-    return this.delegateTasksToBlueprint(() => this.writingEntities);
+  get [ClientApplicationGenerator.DEFAULT]() {
+    return this.default;
   }
 }

--- a/generators/client/generators/bootstrap/generator.ts
+++ b/generators/client/generators/bootstrap/generator.ts
@@ -131,7 +131,7 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
         for (const [key, value] of Object.entries(application)) {
           const descriptor = Object.getOwnPropertyDescriptor(application, key);
           if (typeof value === 'string' && !key.startsWith('java') && descriptor?.writable) {
-            (application as any)[key] = value.replace(/\$\{(?![\w.-]+\})/g, '') as any;
+            (application as any)[key] = value.replace(/\${/g, '') as any;
           }
         }
       },
@@ -150,7 +150,7 @@ export default class ClientBootstrap extends ClientApplicationGenerator {
             for (const [key, value] of Object.entries(object as any)) {
               const descriptor = Object.getOwnPropertyDescriptor(object, key);
               if (typeof value === 'string' && !key.startsWith('java') && descriptor?.writable) {
-                (object as any)[key] = value.replace(/\$\{(?![\w.-]+\})/g, '') as any;
+                (object as any)[key] = value.replace(/\${/g, '') as any;
               }
             }
           }


### PR DESCRIPTION
## Summary
- Strips `${` sequences from all string properties before they reach EJS templates, preventing template literal injection across all client frameworks (Angular, React, Vue)
- Implements centralized sanitization in `client:bootstrap` writing/writingEntities phases as suggested by @mshima in #32601
- Covers application, entity, field, relationship, and primaryKey properties

## Description

Strip `${` sequences from all string properties in application, entity, field, relationship, and primaryKey objects before they reach EJS templates. This prevents `${...}` injection in generated JavaScript/TypeScript template literals across all client frameworks.

Applies in the writing and writingEntities phases of client:bootstrap, providing centralized defense-in-depth for Angular, React, and Vue.

## Test plan
- All bootstrap tests pass (6/6)
- All Angular tests pass (1,497/1,497)
- React and Vue tests pass (761 + 929)

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed