### PR TITLE
fix: export-jdl now preserves field-level annotations (@Id, custom op…

### DIFF
--- a/generators/export-jdl/__snapshots__/export-jdl.spec.ts.snap
+++ b/generators/export-jdl/__snapshots__/export-jdl.spec.ts.snap
@@ -36,6 +36,7 @@ entity Country (country) {
   /**
    * The country Id
    */
+  @Id
   countryId Long
   countryName String
 }
@@ -47,7 +48,9 @@ entity Department (department) {
  * The Employee entity.
  */
 entity Employee (emp) {
+  @Id
   employeeId Long
+  @CustomAnnotation("customValue")
   employeeUuid UUID
   /**
    * The firstname attribute.
@@ -154,6 +157,7 @@ entity Country (country) {
   /**
    * The country Id
    */
+  @Id
   countryId Long
   countryName String
 }
@@ -165,7 +169,9 @@ entity Department (department) {
  * The Employee entity.
  */
 entity Employee (emp) {
+  @Id
   employeeId Long
+  @CustomAnnotation("customValue")
   employeeUuid UUID
   /**
    * The firstname attribute.

--- a/generators/export-jdl/export-jdl.spec.ts
+++ b/generators/export-jdl/export-jdl.spec.ts
@@ -22,6 +22,7 @@ const files = {
         fieldName: 'countryId',
         fieldType: 'Long',
         documentation: 'The country Id',
+        options: { id: true },
       },
       {
         fieldName: 'countryName',
@@ -100,10 +101,12 @@ const files = {
       {
         fieldName: 'employeeId',
         fieldType: 'Long',
+        options: { id: true },
       },
       {
         fieldName: 'employeeUuid',
         fieldType: 'UUID',
+        options: { customAnnotation: 'customValue' },
       },
       {
         fieldName: 'firstName',

--- a/lib/jdl/converters/json-to-jdl-entity-converter.spec.ts
+++ b/lib/jdl/converters/json-to-jdl-entity-converter.spec.ts
@@ -87,6 +87,25 @@ describe('jdl - JSONToJDLEntityConverter', () => {
           expect(jdlObject.entities.Employee.fields.salary.validations.max.value).eq(1000000);
           expect(jdlObject.entities.Employee.fields.employeeId.validations).to.be.empty;
         });
+        it('should parse field options', () => {
+          const entities = new Map<string, any>([
+            [
+              'TestEntity',
+              {
+                fields: [
+                  { fieldName: 'myId', fieldType: 'Long', options: { id: true } },
+                  { fieldName: 'customField', fieldType: 'String', options: { customAnnotation: 'customValue' } },
+                  { fieldName: 'noOptionsField', fieldType: 'String' },
+                ],
+                relationships: [],
+              },
+            ],
+          ]);
+          const result = convertEntitiesToJDL(entities);
+          expect(result.entities.TestEntity.fields.myId.options).to.deep.equal({ id: true });
+          expect(result.entities.TestEntity.fields.customField.options).to.deep.equal({ customAnnotation: 'customValue' });
+          expect(result.entities.TestEntity.fields.noOptionsField.options).to.deep.equal({});
+        });
         it('should parse enums', () => {
           const languageEnum = jdlObject.getEnum('Language');
           if (!languageEnum) {

--- a/lib/jdl/converters/json-to-jdl-entity-converter.ts
+++ b/lib/jdl/converters/json-to-jdl-entity-converter.ts
@@ -97,6 +97,7 @@ function convertJSONToJDLField(field: JSONField): JDLField {
     name: lowerFirst(field.fieldName),
     type: field.fieldType,
     comment: field.documentation,
+    options: field.options,
   });
   addValidations(jdlField, field);
   return jdlField;


### PR DESCRIPTION
The JSON-to-JDL entity converter was not passing field.options to the JDLField constructor, causing all field-level annotations to be silently dropped during JDL export.

## Summary
- Field-level annotations (like `@Id`, custom `@AnnotationName(value)`) were silently dropped during `export-jdl` because `field.options` was not passed to the `JDLField` constructor in `json-to-jdl-entity-converter.ts`
- Added `options: field.options` to the constructor call (1-line fix)
- Added test coverage with `@Id` and `@CustomAnnotation("customValue")` field options

## Test plan
- [x] Run `npx esmocha generators/export-jdl --no-insight` — all 5 tests pass
- [x] Snapshots updated to verify `@Id` and `@CustomAnnotation("customValue")` appear in exported JDL
- [ ] Manual test: run `jhipster export-jdl` on a project with field annotations and verify they appear in the output

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

Closes https://github.com/jhipster/generator-jhipster/issues/32435