### PR TITLE
[React] Remove Sinon (use only Jest)

### DIFF
--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -63,7 +63,6 @@
     "sass": "1.77.6",
     "sass-loader": "16.0.7",
     "simple-progress-webpack-plugin": "2.0.0",
-    "sinon": "21.0.2",
     "source-map-loader": "5.0.0",
     "style-loader": "4.0.0",
     "terser-webpack-plugin": "5.4.0",

--- a/generators/react/templates/jest.conf.js.ejs
+++ b/generators/react/templates/jest.conf.js.ejs
@@ -23,7 +23,6 @@ export default {
   coveragePathIgnorePatterns: ['<rootDir>/<%= this.relativeDir(clientRootDir, clientTestDir) %>'],
   moduleNameMapper: mapTypescriptAliasToJestAlias({
     '\\.(css|scss)$': 'identity-obj-proxy',
-    sinon: import.meta.resolve('sinon/pkg/sinon.js'),
   }),
   reporters: [
     'default',

--- a/generators/react/templates/package.json.ejs
+++ b/generators/react/templates/package.json.ejs
@@ -91,7 +91,6 @@
     "sass": "<%= nodeDependencies['sass'] %>",
     "sass-loader": "<%= nodeDependencies['sass-loader'] %>",
     "simple-progress-webpack-plugin": "<%= nodeDependencies['simple-progress-webpack-plugin'] %>",
-    "sinon": "<%= nodeDependencies['sinon'] %>",
     "source-map-loader": "<%= nodeDependencies['source-map-loader'] %>",
     "style-loader": "<%= nodeDependencies['style-loader'] %>",
     "swagger-ui-dist": "<%= nodeDependencies['swagger-ui-dist'] %>",

--- a/generators/react/templates/src/main/webapp/app/config/axios-interceptor.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/config/axios-interceptor.spec.ts.ejs
@@ -17,14 +17,13 @@
  limitations under the License.
 -%>
 import axios from 'axios';
-import sinon from 'sinon';
 
 import setupAxiosInterceptors from './axios-interceptor';
 
 describe('Axios Interceptor', () => {
   describe('setupAxiosInterceptors', () => {
     const client = axios;
-    const onUnauthenticated = sinon.spy();
+    const onUnauthenticated = jest.fn();
     setupAxiosInterceptors(onUnauthenticated);
 
     it('onRequestSuccess is called on fulfilled request', () => {
@@ -44,7 +43,7 @@ describe('Axios Interceptor', () => {
         },
       };
       expect((client.interceptors.response as any).handlers[0].rejected(rejectError)).rejects.toEqual(rejectError);
-      expect(onUnauthenticated.calledOnce).toBe(true);
+      expect(onUnauthenticated).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/generators/react/templates/src/main/webapp/app/config/notification-middleware.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/config/notification-middleware.spec.ts.ejs
@@ -19,7 +19,6 @@
 
 import { configureStore } from '@reduxjs/toolkit';
 import * as toastify from 'react-toastify'; // synthetic default import doesn't work here due to mocking.
-import sinon from 'sinon';
 <%_ if (enableTranslation) { _%>
 import { TranslatorContext } from 'react-jhipster';
 <%_ } _%>
@@ -187,81 +186,80 @@ describe('Notification Middleware', () => {
 <%_ } _%>
   beforeEach(() => {
     store = makeStore();
-    sinon.spy(toastify.toast, 'error');
-    sinon.spy(toastify.toast, 'success');
+    jest.spyOn(toastify.toast, 'error');
+    jest.spyOn(toastify.toast, 'success');
     // ignore console errors
     jest.spyOn(globalThis.console, 'error').mockImplementation();
   });
 
   afterEach(() => {
-    (toastify.toast as any).error.restore();
-    (toastify.toast as any).success.restore();
+    jest.restoreAllMocks();
   });
 
   it('should not trigger a toast message but should return action', () => {
     expect(store.dispatch(DEFAULT).payload).toEqual('foo');
-    expect((toastify.toast as any).error.called).toEqual(false);
-    expect((toastify.toast as any).success.called).toEqual(false);
+    expect(toastify.toast.error).not.toHaveBeenCalled();
+    expect(toastify.toast.success).not.toHaveBeenCalled();
   });
 
   it('should trigger a success toast message for header alerts', () => {
     expect(store.dispatch(HEADER_SUCCESS).payload.status).toEqual(201);
-    sinon.assert.calledWithMatch((toastify.toast as any).success, 'foo.created');
+    expect(toastify.toast.success).toHaveBeenCalledWith(expect.stringContaining('foo.created'));
   });
 
   it('should trigger an error toast message and return error', () => {
     expect(store.dispatch(DEFAULT_ERROR).error.message).toEqual('foo');
-    sinon.assert.calledWithMatch((toastify.toast as any).error, 'foo');
+    expect(toastify.toast.error).toHaveBeenCalledWith('foo');
   });
 
   it('should trigger an error toast message and return error for generic message', () => {
     expect(store.dispatch(GENERIC_ERROR).error.response.data.message).toEqual('Error');
-    sinon.assert.calledWithMatch((toastify.toast as any).error, 'Error');
+    expect(toastify.toast.error).toHaveBeenCalledWith('Error');
   });
 
   it('should trigger an error toast message and return error for 400 response code', () => {
     expect(store.dispatch(VALIDATION_ERROR).error.response.data.message).toEqual('error.validation');
-    sinon.assert.calledWithMatch((toastify.toast as any).error, <% if (enableTranslation) { %>'error.Size'<% } else { %>'Error on field "MinField"'<% } %>);
+    expect(toastify.toast.error).toHaveBeenCalledWith(expect.stringContaining(<% if (enableTranslation) { %>'error.Size'<% } else { %>'Error on field "MinField"'<% } %>));
   });
 
   it('should trigger an error toast message and return error for 404 response code', () => {
     expect(store.dispatch(NOT_FOUND_ERROR).error.response.data.message).toEqual('Not found');
-    sinon.assert.calledWithMatch((toastify.toast as any).error, <% if (enableTranslation) { %>'error.url.not.found'<% } else { %>'Not found'<% } %>);
+    expect(toastify.toast.error).toHaveBeenCalledWith(expect.stringContaining(<% if (enableTranslation) { %>'error.url.not.found'<% } else { %>'Not found'<% } %>));
   });
 
   it('should trigger an error toast message and return error for 0 response code', () => {
     expect(store.dispatch(NO_SERVER_ERROR).error.response.status).toEqual(0);
-    sinon.assert.calledWithMatch((toastify.toast as any).error, <% if (enableTranslation) { %>'error.server.not.reachable'<% } else { %>'Server not reachable'<% } %>);
+    expect(toastify.toast.error).toHaveBeenCalledWith(expect.stringContaining(<% if (enableTranslation) { %>'error.server.not.reachable'<% } else { %>'Server not reachable'<% } %>));
   });
 
   it('should trigger an error toast message and return error for headers containing errors', () => {
     expect(store.dispatch(HEADER_ERRORS).error.response.status).toEqual(400);
-    sinon.assert.calledWithMatch((toastify.toast as any).error, 'foo.creation');
+    expect(toastify.toast.error).toHaveBeenCalledWith(expect.stringContaining('foo.creation'));
   });
 
   it('should not trigger an error toast message and return error for 401 response code', () => {
     expect(store.dispatch(LOGIN_REJECTED_ERROR).error.response.status).toEqual(401);
-    expect((toastify.toast as any).error.called).toEqual(false);
-    expect((toastify.toast as any).success.called).toEqual(false);
+    expect(toastify.toast.error).not.toHaveBeenCalled();
+    expect(toastify.toast.success).not.toHaveBeenCalled();
   });
 
   it('should trigger an error toast message and return error for 400 response code', () => {
     expect(store.dispatch(TITLE_ERROR).error.response.status).toEqual(400);
-    sinon.assert.calledWithMatch((toastify.toast as any).error, 'Incorrect password');
+    expect(toastify.toast.error).toHaveBeenCalledWith('Incorrect password');
   });
 
   it('should trigger an error toast message and return error for string in data', () => {
     expect(store.dispatch(STRING_DATA_ERROR).error.response.status).toEqual(400);
-    sinon.assert.calledWithMatch((toastify.toast as any).error, 'Incorrect password string');
+    expect(toastify.toast.error).toHaveBeenCalledWith('Incorrect password string');
   });
 
   it('should trigger an error toast message and return error for unknown 400 error', () => {
     expect(store.dispatch(UNKNOWN_400_ERROR).error.response.status).toEqual(400);
-    sinon.assert.calledWithMatch((toastify.toast as any).error, 'Unknown error!');
+    expect(toastify.toast.error).toHaveBeenCalledWith('Unknown error!');
   });
 
   it('should trigger an error toast message and return error for unknown error', () => {
     expect(store.dispatch(UNKNOWN_ERROR).error.isAxiosError).toEqual(true);
-    sinon.assert.calledWithMatch((toastify.toast as any).error, 'Unknown error!');
+    expect(toastify.toast.error).toHaveBeenCalledWith('Unknown error!');
   });
 });

--- a/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-reducer.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-reducer.spec.ts.ejs
@@ -23,7 +23,6 @@ _%>
 import axios from 'axios';
 
 import { configureStore } from '@reduxjs/toolkit';
-import sinon from 'sinon';
 <%_ if (paginationInfiniteScroll) { _%>
 import { getPageNumberFromLinkHeader } from 'app/shared/jhipster/link-header';
 <%_ } _%>
@@ -276,11 +275,11 @@ describe('Entities reducer tests', () => {
       store = configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.post = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.put = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.patch = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.delete = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
+      axios.post = jest.fn().mockResolvedValue(resolvedObject);
+      axios.put = jest.fn().mockResolvedValue(resolvedObject);
+      axios.patch = jest.fn().mockResolvedValue(resolvedObject);
+      axios.delete = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches FETCH_<%= entityActionName %>_LIST actions', async () => {

--- a/generators/react/templates/src/main/webapp/app/modules/account/activate/activate.reducer.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/activate/activate.reducer.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 import axios from 'axios';
-import sinon from 'sinon';
 import { configureStore } from '@reduxjs/toolkit';
 
 import activate, { activateAction, reset } from './activate.reducer';
@@ -79,7 +78,7 @@ describe('Activate reducer tests', () => {
       store = configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches ACTIVATE_ACCOUNT_PENDING and ACTIVATE_ACCOUNT_FULFILLED actions', async () => {

--- a/generators/react/templates/src/main/webapp/app/modules/account/password/password.reducer.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/password/password.reducer.spec.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 
 import axios from 'axios';
-import sinon from 'sinon';
 import { configureStore } from '@reduxjs/toolkit';
 <%_ if (enableTranslation) { _%>
 import { TranslatorContext } from 'react-jhipster';
@@ -96,7 +95,7 @@ describe('Password reducer tests', () => {
       store = configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.post = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.post = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches UPDATE_PASSWORD_PENDING and UPDATE_PASSWORD_FULFILLED actions', async () => {

--- a/generators/react/templates/src/main/webapp/app/modules/account/register/register.reducer.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/register/register.reducer.spec.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 
 import axios from 'axios';
-import sinon from 'sinon';
 import { configureStore } from '@reduxjs/toolkit';
 <%_ if (enableTranslation) { _%>
 import { TranslatorContext } from 'react-jhipster';
@@ -104,7 +103,7 @@ describe('Creating account tests', () => {
       store = configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.post = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.post = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches CREATE_ACCOUNT_PENDING and CREATE_ACCOUNT_FULFILLED actions', async () => {

--- a/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.reducer.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/account/settings/settings.reducer.spec.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 import { configureStore } from '@reduxjs/toolkit';
 import axios from 'axios';
-import sinon from 'sinon';
 <%_ if (enableTranslation) { _%>
 import { TranslatorContext } from 'react-jhipster';
 <%_ } _%>
@@ -96,8 +95,8 @@ describe('Settings reducer tests', () => {
       store = configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.post = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
+      axios.post = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches UPDATE_ACCOUNT_PENDING and UPDATE_ACCOUNT_FULFILLED actions', async () => {

--- a/generators/react/templates/src/main/webapp/app/modules/administration/administration.reducer.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/administration/administration.reducer.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 import axios from 'axios';
-import sinon from 'sinon';
 
 import administration, {
 <%_ if (applicationTypeGateway && gatewayServicesApiAvailable) { _%>
@@ -267,8 +266,8 @@ describe('Administration reducer tests', () => {
     const dispatch = jest.fn();
     const extra = {};
     beforeEach(() => {
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.post = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
+      axios.post = jest.fn().mockResolvedValue(resolvedObject);
     });
 <%_ } _%>
 <%_ if (applicationTypeGateway && gatewayServicesApiAvailable) { _%>

--- a/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 import { configureStore } from '@reduxjs/toolkit';
 import axios from 'axios';
-import sinon from 'sinon';
 
 import userManagement, {
   getUsers,
@@ -211,10 +210,10 @@ describe('User management reducer tests', () => {
       store = configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.put = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.post = sinon.stub().returns(Promise.resolve(resolvedObject));
-      axios.delete = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
+      axios.put = jest.fn().mockResolvedValue(resolvedObject);
+      axios.post = jest.fn().mockResolvedValue(resolvedObject);
+      axios.delete = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches FETCH_USERS_AS_ADMIN_PENDING and FETCH_USERS_AS_ADMIN_FULFILLED actions', async () => {

--- a/generators/react/templates/src/main/webapp/app/shared/reducers/application-profile.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/reducers/application-profile.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 import axios from 'axios';
-import sinon from 'sinon';
 
 import profile, { getProfile } from './application-profile';
 
@@ -70,7 +69,7 @@ describe('Profile reducer tests', () => {
     const dispatch = jest.fn();
     const extra = {};
     beforeEach(() => {
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches GET_SESSION_PENDING and GET_SESSION_FULFILLED actions', async () => {

--- a/generators/react/templates/src/main/webapp/app/shared/reducers/authentication.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/reducers/authentication.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 import axios from 'axios';
-import sinon from 'sinon';
 <%_ if (authenticationTypeJwt) { _%>
 import { Storage } from 'react-jhipster';
 <%_ } _%>
@@ -210,7 +209,7 @@ describe('Authentication reducer tests', () => {
       store = configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches GET_SESSION_PENDING and GET_SESSION_FULFILLED actions', async () => {
@@ -227,7 +226,7 @@ describe('Authentication reducer tests', () => {
 
     it('dispatches LOGOUT actions', async () => {
     <%_ if (!authenticationTypeJwt) { _%>
-      axios.post = sinon.stub().returns(Promise.resolve({}));
+      axios.post = jest.fn().mockResolvedValue({});
 
       const result = await logoutServer()(dispatch, getState, extra);
 
@@ -252,7 +251,7 @@ describe('Authentication reducer tests', () => {
 <%_ if (!authenticationTypeOauth2) { _%>
     it('dispatches LOGIN, GET_SESSION and SET_LOCALE success and request actions', async () => {
       const loginResponse = { headers: { authorization: 'auth' } };
-      axios.post = sinon.stub().returns(Promise.resolve(loginResponse));
+      axios.post = jest.fn().mockResolvedValue(loginResponse);
 
       const result = await authenticate('test', 'test')(dispatch, getState, extra);
 
@@ -280,7 +279,7 @@ describe('Authentication reducer tests', () => {
     it('clears the session token on clearAuthToken', async () => {
       const AUTH_TOKEN_KEY = '<%= jhiPrefixDashed %>-authenticationToken';
       const loginResponse = { headers: { authorization: 'Bearer TestToken' } };
-      axios.post = sinon.stub().returns(Promise.resolve(loginResponse));
+      axios.post = jest.fn().mockResolvedValue(loginResponse);
 
       await store.dispatch(login('test', 'test'));
       expect(Storage.session.get(AUTH_TOKEN_KEY)).toBe('TestToken');
@@ -292,7 +291,7 @@ describe('Authentication reducer tests', () => {
     it('clears the local storage token on clearAuthToken', async () => {
       const AUTH_TOKEN_KEY = '<%= jhiPrefixDashed %>-authenticationToken';
       const loginResponse = { headers: { authorization: 'Bearer TestToken' } };
-      axios.post = sinon.stub().returns(Promise.resolve(loginResponse));
+      axios.post = jest.fn().mockResolvedValue(loginResponse);
 
       await store.dispatch(login('user', 'user', true));
       expect(Storage.session.get(AUTH_TOKEN_KEY)).toBe(undefined);

--- a/generators/react/templates/src/main/webapp/app/shared/reducers/locale.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/reducers/locale.spec.ts.ejs
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import sinon from 'sinon';
 import { TranslatorContext } from 'react-jhipster';
 
 import locale, { setLocale, updateLocale, loaded, addTranslationSourcePrefix } from 'app/shared/reducers/locale';
@@ -45,7 +44,7 @@ describe('Locale reducer tests', () => {
   describe('setLocale reducer', () => {
     describe('with default language loaded', () => {
       beforeEach(() => {
-        axios.get = sinon.stub().returns(Promise.resolve({ key: 'value' }));
+        axios.get = jest.fn().mockResolvedValue({ key: 'value' });
       });
 
       it('dispatches updateLocale action for default locale', async () => {
@@ -68,7 +67,7 @@ describe('Locale reducer tests', () => {
 
     describe('with no language loaded', () => {
       beforeEach(() => {
-        axios.get = sinon.stub().returns(Promise.resolve({ key: 'value' }));
+        axios.get = jest.fn().mockResolvedValue({ key: 'value' });
       });
 
       it('dispatches loaded and updateLocale action for default locale', async () => {
@@ -95,7 +94,7 @@ describe('Locale reducer tests', () => {
 
     describe('with no prefixes and keys loaded', () => {
       beforeEach(() => {
-        axios.get = sinon.stub().returns(Promise.resolve({ key: 'value' }));
+        axios.get = jest.fn().mockResolvedValue({ key: 'value' });
       });
 
       it('dispatches loaded action with keys and sourcePrefix', async () => {
@@ -117,7 +116,7 @@ describe('Locale reducer tests', () => {
 
     describe('with prefix already added', () => {
       beforeEach(() => {
-        axios.get = sinon.stub().returns(Promise.resolve({ key: 'value' }));
+        axios.get = jest.fn().mockResolvedValue({ key: 'value' });
       });
 
       it("doesn't dispatch loaded action", async () => {
@@ -139,7 +138,7 @@ describe('Locale reducer tests', () => {
 
     describe('with key already loaded', () => {
       beforeEach(() => {
-        axios.get = sinon.stub().returns(Promise.resolve({ key: 'value' }));
+        axios.get = jest.fn().mockResolvedValue({ key: 'value' });
       });
 
       it("doesn't dispatch loaded action", async () => {

--- a/generators/react/templates/src/main/webapp/app/shared/reducers/user-management.spec.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/reducers/user-management.spec.ts.ejs
@@ -19,7 +19,6 @@
 
 import { configureStore } from '@reduxjs/toolkit';
 import axios from 'axios';
-import sinon from 'sinon';
 
 import userManagement, {
   getUsers,
@@ -69,7 +68,7 @@ describe('User management reducer tests', () => {
       configureStore({
         reducer: (state = [], action) => [...state, action],
       });
-      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.get = jest.fn().mockResolvedValue(resolvedObject);
     });
 
     it('dispatches FETCH_USERS_PENDING and FETCH_USERS_FULFILLED actions', async () => {


### PR DESCRIPTION
💡 Remove `Sinon` in preparation for replacing `Jest` with `Vitest` later.

cc @mshima @DanielFran 