### PR TITLE
fix: export-jdl preserves destination-side relationship annotations

### DIFF
--- a/generators/export-jdl/__snapshots__/export-jdl.spec.ts.snap
+++ b/generators/export-jdl/__snapshots__/export-jdl.spec.ts.snap
@@ -97,7 +97,7 @@ relationship OneToOne {
   JobHistory{employee} to Employee
 }
 relationship OneToMany {
-  Department{employee required} to Employee{department(foo)}
+  Department{employee required} to @DestinationAnnotation Employee{department(foo)}
   Employee{job} to Job{employee}
 }
 relationship ManyToOne {
@@ -218,7 +218,7 @@ relationship OneToOne {
   JobHistory{employee} to Employee
 }
 relationship OneToMany {
-  Department{employee required} to Employee{department(foo)}
+  Department{employee required} to @DestinationAnnotation Employee{department(foo)}
   Employee{job} to Job{employee}
 }
 relationship ManyToOne {

--- a/generators/export-jdl/export-jdl.spec.ts
+++ b/generators/export-jdl/export-jdl.spec.ts
@@ -81,6 +81,7 @@ const files = {
         relationshipType: 'many-to-one',
         otherEntityField: 'foo',
         otherEntityRelationshipName: 'employee',
+        options: { destinationAnnotation: true },
       },
       {
         relationshipType: 'one-to-many',

--- a/lib/jdl/converters/json-to-jdl-entity-converter.spec.ts
+++ b/lib/jdl/converters/json-to-jdl-entity-converter.spec.ts
@@ -209,6 +209,45 @@ describe('jdl - JSONToJDLEntityConverter', () => {
           expect(relationship!.commentInFrom).to.equal('Another side of the same relationship');
           expect(relationship!.commentInTo).to.equal('A relationship');
         });
+        it('should parse destination-side relationship options', () => {
+          const entities = new Map<string, any>([
+            [
+              'EntityA',
+              {
+                fields: [{ fieldName: 'name', fieldType: 'String' }],
+                relationships: [
+                  {
+                    relationshipType: 'one-to-many',
+                    relationshipName: 'entityB',
+                    otherEntityName: 'entityB',
+                    relationshipSide: 'left',
+                    otherEntityRelationshipName: 'entityA',
+                  },
+                ],
+              },
+            ],
+            [
+              'EntityB',
+              {
+                fields: [{ fieldName: 'name', fieldType: 'String' }],
+                relationships: [
+                  {
+                    relationshipType: 'many-to-one',
+                    relationshipName: 'entityA',
+                    otherEntityName: 'entityA',
+                    relationshipSide: 'right',
+                    otherEntityRelationshipName: 'entityB',
+                    options: { destAnnotation: true },
+                  },
+                ],
+              },
+            ],
+          ]);
+          const result = convertEntitiesToJDL(entities);
+          const relationship = result.relationships.getOneToMany('OneToMany_EntityA{entityB}_EntityB{entityA}');
+          expect(relationship).not.to.be.undefined;
+          expect(relationship!.options.destination).to.deep.equal({ destAnnotation: true });
+        });
         it('should parse required relationships in owner', () => {
           const relationship = jdlObject.relationships.getManyToOne('ManyToOne_Employee{department(foo)}_Department{employee}');
           if (!relationship) {

--- a/lib/jdl/converters/json-to-jdl-entity-converter.ts
+++ b/lib/jdl/converters/json-to-jdl-entity-converter.ts
@@ -217,6 +217,12 @@ function getRelationship(relationship: JSONRelationship, entityName: string) {
     isInjectedFieldInToRequired: destinationSideAttributes.injectedFieldInDestinationIsRequired ?? false,
     commentInTo: destinationSideAttributes.commentForDestinationEntity,
   };
+  if (destinationSideAttributes.optionsForDestinationEntity) {
+    relationshipConfiguration.options = {
+      ...relationshipConfiguration.options,
+      destination: destinationSideAttributes.optionsForDestinationEntity,
+    };
+  }
   return new JDLRelationship(relationshipConfiguration);
 }
 
@@ -253,6 +259,7 @@ function getDestinationEntitySideAttributes(
     injectedFieldInDestinationEntity,
     injectedFieldInDestinationIsRequired,
     commentForDestinationEntity,
+    optionsForDestinationEntity: foundDestinationSideEntity.options,
   };
 }
 


### PR DESCRIPTION
## Summary
- Destination-side relationship annotations were lost during `export-jdl` because `getDestinationEntitySideAttributes()` never extracted `options` from the matched right-side relationship
- Now extracts and maps destination relationship options into `JDLRelationship.options.destination`

## Example
JDL example that demonstrates the fix:

// Before the fix, @CustomTag annotation was lost during export-jdl round-trip

```
entity Author {
  name String
}
entity Book {
  title String
}
relationship OneToMany {
  Author{book} to @CustomTag Book{author}
}

```
The @CustomTag on the destination side (Book) would be silently dropped when running jhipster export-jdl. After the fix, it is now preserved.


Closes https://github.com/jhipster/generator-jhipster/pull/32655

## Test plan
- [x] Added unit test for destination-side relationship options in `json-to-jdl-entity-converter.spec.ts`
- [x] Added `options: { destinationAnnotation: true }` to right-side relationship in `export-jdl.spec.ts`
- [x] All 30 tests passing, snapshots updated

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
