### PR TITLE
Use JWK set URI for imperative OAuth2 decoder

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
@@ -99,6 +99,7 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthen
 import org.springframework.security.oauth2.server.resource.web.access.BearerTokenAccessDeniedHandler;
 <%_ } _%>
 <%_ if (authenticationTypeOauth2 && !applicationTypeMicroservice) { _%>
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import <%= packageName %>.security.oauth2.CustomClaimConverter;
@@ -351,7 +352,14 @@ public class SecurityConfiguration {
 
     @Bean
     JwtDecoder jwtDecoder(<%_ if (!applicationTypeMicroservice) { _%>ClientRegistrationRepository clientRegistrationRepository, RestTemplateBuilder restTemplateBuilder<%_ } _%>) {
+  <%_ if (!applicationTypeMicroservice) { _%>
+        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId("oidc");
+        NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(clientRegistration.getProviderDetails().getJwkSetUri())
+            .restOperations(restTemplateBuilder.build())
+            .build();
+  <%_ } else { _%>
         NimbusJwtDecoder jwtDecoder = JwtDecoders.fromOidcIssuerLocation(issuerUri);
+  <%_ } _%>
 
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
         OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);


### PR DESCRIPTION
## What does this PR do?

This changes the imperative OAuth2 security template to build the `NimbusJwtDecoder` directly from the generated OIDC client registration JWK Set URI instead of calling `JwtDecoders.fromOidcIssuerLocation(issuerUri)`.

That avoids the Spring Security discovery/JWK retrieval path that can fail with socket timeouts on slow connections, while still preserving the existing issuer and audience validation.

It also wires the decoder through `RestTemplateBuilder`, so timeout customization can hook into the standard Spring client path used by the generated application.

## Why is this needed?

In the generated imperative OAuth2 setup, startup currently depends on the OIDC discovery flow completing quickly enough. On slow connections this can fail with `RemoteKeySourceException` / `SocketTimeoutException`, which is the problem described in #17550.

The reactive non-microservice branch already works from an explicit `jwkSetUri`; this aligns the imperative branch with that approach.

## Test plan

Verified locally:
- `npm run lint`
- `npm run check-types`

I also attempted to run the focused Spring Boot generator tests locally, but the JHipster test harness in this environment is affected by local generator lookup assumptions unrelated to this patch, so I could not get a reliable targeted snapshot run from the repo tooling.

## Related issue

Fixes #17550
