### PR TITLE
[BOUNTY #17550] Fix: Add configurable JWK retrieval timeout for Okta/Auth0

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_imperative.java.ejs
@@ -349,9 +349,19 @@ public class SecurityConfiguration {
     }
   <%_ } _%>
 
+    @Value("${jhipster.security.oauth2.jwk-connect-timeout:500}")
+    private int jwkConnectTimeout;
+
+    @Value("${jhipster.security.oauth2.jwk-read-timeout:5000}")
+    private int jwkReadTimeout;
+
     @Bean
     JwtDecoder jwtDecoder(<%_ if (!applicationTypeMicroservice) { _%>ClientRegistrationRepository clientRegistrationRepository, RestTemplateBuilder restTemplateBuilder<%_ } _%>) {
         NimbusJwtDecoder jwtDecoder = JwtDecoders.fromOidcIssuerLocation(issuerUri);
+
+        // Configure custom timeout for JWK retrieval to handle slow networks
+        // Default connect: 500ms, read: 5000ms (Spring Security default is ~500ms for both)
+        jwtDecoder.setResourceRetriever(new com.nimbusds.jose.proc.DefaultResourceRetriever(jwkConnectTimeout, jwkReadTimeout));
 
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
         OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);

--- a/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_reactive.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/config/SecurityConfiguration_reactive.java.ejs
@@ -151,6 +151,12 @@ public class SecurityConfiguration {
 <%_ if (authenticationTypeOauth2) { _%>
     @Value("${spring.security.oauth2.client.provider.oidc.issuer-uri}")
     private String issuerUri;
+
+    @Value("${jhipster.security.oauth2.jwk-connect-timeout:500}")
+    private int jwkConnectTimeout;
+
+    @Value("${jhipster.security.oauth2.jwk-read-timeout:5000}")
+    private int jwkReadTimeout;
   <%_ if (!applicationTypeMicroservice) { _%>
 
     private final ReactiveClientRegistrationRepository clientRegistrationRepository;
@@ -396,6 +402,9 @@ public class SecurityConfiguration {
     <%_ if (applicationTypeMicroservice) { _%>
         NimbusReactiveJwtDecoder jwtDecoder = (NimbusReactiveJwtDecoder) ReactiveJwtDecoders.fromOidcIssuerLocation(issuerUri);
 
+        // Configure custom timeout for JWK retrieval to handle slow networks
+        jwtDecoder.setResourceRetriever(new com.nimbusds.jose.proc.DefaultResourceRetriever(jwkConnectTimeout, jwkReadTimeout));
+
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
         OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
         OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);
@@ -417,6 +426,10 @@ public class SecurityConfiguration {
 
     private ReactiveJwtDecoder createJwtDecoder(String issuerUri, String jwkSetUri, String userInfoUri) {
         NimbusReactiveJwtDecoder jwtDecoder = new NimbusReactiveJwtDecoder(jwkSetUri);
+
+        // Configure custom timeout for JWK retrieval to handle slow networks
+        jwtDecoder.setResourceRetriever(new com.nimbusds.jose.proc.DefaultResourceRetriever(jwkConnectTimeout, jwkReadTimeout));
+
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
         OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
         OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);


### PR DESCRIPTION
## Problem

Spring Security's default JWK retrieval timeout (~500ms) causes failures on slow networks:
`Couldn't retrieve remote JWK set: Read timed out`

## Solution

Add two configurable properties:
- `jhipster.security.oauth2.jwk-connect-timeout` (default: 500ms)
- `jhipster.security.oauth2.jwk-read-timeout` (default: 5000ms)

Users can override in `application.yml`:
```yaml
jhipster:
  security:
    oauth2:
      jwk-connect-timeout: 1000
      jwk-read-timeout: 10000
```

## Changes
- `SecurityConfiguration_imperative.java.ejs` - Add timeout properties + `setResourceRetriever()`
- `SecurityConfiguration_reactive.java.ejs` - Same fix for reactive apps

Closes #17550