### PR TITLE
Fix: bump npm from 11.11.1 to 11.12.0

### DIFF
--- a/generators/common/resources/package.json
+++ b/generators/common/resources/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "concurrently": "9.2.1",
-    "npm": "11.11.1",
+    "npm": "11.12.0",
     "wait-on": "9.0.4"
   },
   "packageManager": "npm@11"

--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -12,7 +12,7 @@
     "react-bootstrap": "2.10.10",
     "react-dom": "19.2.4",
     "react-hook-form": "7.72.0",
-    "react-jhipster": "github:jhipster/react-jhipster#main",
+    "react-jhipster": "1.0.0",
     "react-redux": "9.2.0",
     "react-redux-loading-bar": "5.0.8",
     "react-router": "7.13.2",


### PR DESCRIPTION
Fix #32751 