### PR TITLE
Potential fix for code scanning alert no. 26: Overly permissive regular expression range

### DIFF
--- a/generators/generate-blueprint/constants.ts
+++ b/generators/generate-blueprint/constants.ts
@@ -102,7 +102,7 @@ export const prompts = () => {
       message: 'Comma separated additional sub-generators.',
       validate: (input: string) => {
         if (input) {
-          return /^([\w,-:]*)$/.test(input) ? true : 'Please provide valid generator names (must match ([w,-:]*))';
+          return /^([\w,:-]*)$/.test(input) ? true : 'Please provide valid generator names (must match ([\\w,:-]*))';
         }
         return true;
       },


### PR DESCRIPTION
Potential fix for [https://github.com/jhipster/generator-jhipster/security/code-scanning/26](https://github.com/jhipster/generator-jhipster/security/code-scanning/26)

In general, to fix overly permissive ranges in character classes you should (1) escape `-` when you mean a literal dash, or place it first/last in the class, and (2) explicitly list only the extra symbols you want beyond `\w` instead of relying on a range like `,-:` whose intermediate characters you might not have considered.

Here, the intent appears to be: allow zero or more characters that are word characters (`\w`) or one of `,`, `-`, or `:`. The current pattern `/^([\w,-:]*)$/` actually allows `.` and `/` and all digits a second time due to the `,`–`:` range. To keep existing functionality as close as possible while removing the ambiguous range, the best, minimal fix is to escape the dash so it is treated literally and not as a range operator: `/^([\w,:-]*)$/`. This keeps `\w`, comma, colon, and hyphen as allowed characters, and stops implicitly including `.` and `/`. We should also fix the error message to accurately reflect the regex.

Concretely:
- In `generators/generate-blueprint/constants.ts`, in the `validate` function inside the `ADDITIONAL_SUB_GENERATORS` prompt, replace the regex `/^([\w,-:]*)$/` with `/^([\w,:-]*)$/`.
- In the same block, update the message string from `must match ([w,-:]*))` to `must match ([\\w,:-]*))` so it describes the new pattern correctly.

No new imports or helpers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
