### PR TITLE
ci: work around Node.js 22 `require(esm)` V8 crash in CI workflows

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -99,6 +99,9 @@ jobs:
           maven-cache: true
           gradle-cache: ${{ matrix.gradle-cache }}
           binary-dir: ${{ github.workspace }}/generator-jhipster/bin
+      - name: 'WORKAROUND: Node.js 22 require(esm) V8 crash'
+        if: startsWith(matrix.node-version, '22')
+        run: echo "NODE_OPTIONS=${NODE_OPTIONS:+$NODE_OPTIONS }--no-experimental-require-module" >> $GITHUB_ENV
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -99,6 +99,9 @@ jobs:
           maven-cache: true
           gradle-cache: ${{ matrix.gradle-cache }}
           binary-dir: ${{ github.workspace }}/generator-jhipster/bin
+      - name: 'WORKAROUND: Node.js 22 require(esm) V8 crash'
+        if: startsWith(matrix.node-version, '22')
+        run: echo "NODE_OPTIONS=${NODE_OPTIONS:+$NODE_OPTIONS }--no-experimental-require-module" >> $GITHUB_ENV
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -99,6 +99,9 @@ jobs:
           maven-cache: true
           gradle-cache: ${{ matrix.gradle-cache }}
           binary-dir: ${{ github.workspace }}/generator-jhipster/bin
+      - name: 'WORKAROUND: Node.js 22 require(esm) V8 crash'
+        if: startsWith(matrix.node-version, '22')
+        run: echo "NODE_OPTIONS=${NODE_OPTIONS:+$NODE_OPTIONS }--no-experimental-require-module" >> $GITHUB_ENV
       #----------------------------------------------------------------------
       # Install JHipster and generate project+entities
       #----------------------------------------------------------------------


### PR DESCRIPTION
Node.js 22's `require(esm)` feature can trigger a V8 assertion failure (`IsGraphAsync` must be used on an instantiated module) when CJS code calls `require()` on ESM modules. This crashes the generate-sample step for workspace/JDL samples like `stack-vue-no-db` on Node 22.

Disable `require(esm)` via `--no-experimental-require-module` for Node 22 CI jobs. This makes `require()` of ESM modules throw a catchable `ERR_REQUIRE_ESM` error instead. Piscina's worker loader then correctly falls through to `import()`.

https://claude.ai/code/session_013Fi2J8F64m5heeaZBMVVKJ

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
