### PR TITLE
Update issue types in issue-check.yml

### DIFF
--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -20,7 +20,7 @@
 name: Issue Check
 on:
   issues:
-    types: [reopened, labeled]
+    types: [labeled]
   workflow_dispatch:
     inputs:
       issue:


### PR DESCRIPTION
Remove 'reopened' type from issue check workflow.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
