### PR TITLE
fix: set `javaFieldType` for domain entities when no database is selected

### DIFF
--- a/generators/java/generators/domain/generator.spec.ts
+++ b/generators/java/generators/domain/generator.spec.ts
@@ -90,6 +90,27 @@ describe(`generator - ${generator}`, () => {
     });
   });
 
+  describe('with no database', () => {
+    before(async () => {
+      await helpers.runJHipster(generator).withJHipsterConfig({ databaseType: 'no' }, [
+        {
+          name: 'DomainEntity',
+          fields: [
+            { fieldName: 'name', fieldType: 'String' },
+            { fieldName: 'description', fieldType: 'byte[]', fieldTypeBlobContent: 'text' },
+          ],
+        },
+      ]);
+    });
+
+    it('should render java field types used by domain templates', () => {
+      result.assertFileContent('src/main/java/com/mycompany/myapp/domain/DomainEntity.java', 'private String name;');
+      result.assertFileContent('src/main/java/com/mycompany/myapp/domain/DomainEntity.java', 'private String description;');
+      result.assertFileContent('src/main/java/com/mycompany/myapp/domain/DomainEntity.java', 'public String getName() {');
+      result.assertFileContent('src/main/java/com/mycompany/myapp/domain/DomainEntity.java', 'public String getDescription() {');
+    });
+  });
+
   describe('with entities disabled', () => {
     before(async () => {
       await helpers

--- a/generators/server/generators/bootstrap/generator.spec.ts
+++ b/generators/server/generators/bootstrap/generator.spec.ts
@@ -19,8 +19,8 @@
 import { before, describe, expect, it } from 'esmocha';
 import { basename, resolve } from 'node:path';
 
-import { defaultHelpers as helpers, runResult } from '../../../../lib/testing/index.ts';
 import type { Entity } from '../../../../lib/jhipster/types/entity.ts';
+import { defaultHelpers as helpers, runResult } from '../../../../lib/testing/index.ts';
 import { testBootstrapEntities } from '../../../../test/support/bootstrap-tests.ts';
 import { shouldSupportFeatures } from '../../../../test/support/tests.ts';
 

--- a/generators/server/generators/bootstrap/generator.spec.ts
+++ b/generators/server/generators/bootstrap/generator.spec.ts
@@ -20,12 +20,24 @@ import { before, describe, expect, it } from 'esmocha';
 import { basename, resolve } from 'node:path';
 
 import { defaultHelpers as helpers, runResult } from '../../../../lib/testing/index.ts';
+import type { Entity } from '../../../../lib/jhipster/types/entity.ts';
 import { testBootstrapEntities } from '../../../../test/support/bootstrap-tests.ts';
 import { shouldSupportFeatures } from '../../../../test/support/tests.ts';
 
 import Generator from './generator.ts';
 
 const generator = `${basename(resolve(import.meta.dirname, '../../'))}:${basename(import.meta.dirname)}`;
+const domainEntities: (Entity & { entityDomainLayer?: boolean })[] = [
+  {
+    name: 'DomainEntity',
+    changelogDate: '20220129000300',
+    entityDomainLayer: true,
+    fields: [
+      { fieldName: 'name', fieldType: 'String' },
+      { fieldName: 'description', fieldType: 'byte[]', fieldTypeBlobContent: 'text' },
+    ],
+  },
+];
 
 describe(`generator - ${generator}`, () => {
   shouldSupportFeatures(Generator);
@@ -60,6 +72,21 @@ describe(`generator - ${generator}`, () => {
   },
 }
 `);
+      });
+    });
+
+    describe('databaseType no and domain-layer entity', () => {
+      before(async () => {
+        await helpers.runJHipster(generator).withJHipsterConfig({ databaseType: 'no' }, domainEntities);
+      });
+
+      it('should populate javaFieldType for domain-layer fields', () => {
+        expect(runResult.entities?.DomainEntity.fields).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ fieldName: 'name', javaFieldType: 'String' }),
+            expect.objectContaining({ fieldName: 'description', javaFieldType: 'String' }),
+          ]),
+        );
       });
     });
   });

--- a/generators/server/generators/bootstrap/generator.ts
+++ b/generators/server/generators/bootstrap/generator.ts
@@ -179,6 +179,8 @@ export default class ServerBootstrapGenerator extends BaseApplicationGenerator<S
       prepareFieldsForTemplates({ application, entity, field }) {
         if (application.databaseTypeAny) {
           prepareServerFieldForTemplates(application, entity, field, this);
+        } else if (entity.entityDomainLayer) {
+          field.javaFieldType = field.blobContentTypeText ? 'String' : field.fieldType;
         }
       },
     });


### PR DESCRIPTION
Fixes: #32906 

When databaseType is "no", [`prepareServerFieldForTemplates`](https://github.com/jhipster/generator-jhipster/blob/e1af33de901dbe21abb28d329c61b4fb9d782d6c/generators/server/generators/bootstrap/generator.ts#L177) was skipped entirely, leaving `javaFieldType` undefined. This caused the `Authority` entity template to render missing type names (e.g., `private  name;`) and a subsequent Java parsing error in the unused-imports transform.

https://claude.ai/code/session_01S55EL7JZgcQxtXZeHShmdz

<!--
PR description.
-->

<img width="1318" height="1100" alt="CleanShot 2026-03-30 at 11 24 22@2x" src="https://github.com/user-attachments/assets/5ad170cc-0aca-430a-b2d1-d5fc2b30a361" />

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
