### PR TITLE
Fix: bump org.graalvm.buildtools:native-gradle-plugin from 0.11.5 to 1.0.0

### DIFF
--- a/generators/java-simple-application/generators/graalvm/internal/constants.ts
+++ b/generators/java-simple-application/generators/graalvm/internal/constants.ts
@@ -1,2 +1,2 @@
 // renovate: datasource=github-releases depName=graalvm-reachability-metadata packageName=oracle/graalvm-reachability-metadata
-export const GRAALVM_REACHABILITY_METADATA = '0.3.35';
+export const GRAALVM_REACHABILITY_METADATA = '1.0-M1';

--- a/generators/java-simple-application/generators/graalvm/resources/gradle/libs.versions.toml
+++ b/generators/java-simple-application/generators/graalvm/resources/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-nativeBuildTools = '0.11.5'
+nativeBuildTools = '1.0.0'
 
 [libraries]
 nativeGradlePlugin = { module = 'org.graalvm.buildtools:native-gradle-plugin', version.ref = 'nativeBuildTools' }


### PR DESCRIPTION
Fix #32914 

<img width="1088" height="510" alt="image" src="https://github.com/user-attachments/assets/06e75741-bf57-40cd-8534-1bc926f9ef0c" />
https://github.com/graalvm/native-build-tools/releases/tag/1.0.0