### PR TITLE
[React] bump react-infinite-scroll-component from 6.1.1 to 7.0.1

### DIFF
--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -58,7 +58,7 @@
     "mini-css-extract-plugin": "2.10.2",
     "postcss-loader": "8.2.1",
     "postcss-rtlcss": "6.0.0",
-    "react-infinite-scroll-component": "6.1.1",
+    "react-infinite-scroll-component": "7.0.1",
     "rimraf": "6.1.3",
     "sass": "1.77.6",
     "sass-loader": "16.0.7",


### PR DESCRIPTION
Fix #32981

Related to issue that I reported https://github.com/ankeetmaini/react-infinite-scroll-component/issues/419