### PR TITLE
fix: handle CRLF line endings in needle matching

### DIFF
--- a/generators/base-core/support/needles.spec.ts
+++ b/generators/base-core/support/needles.spec.ts
@@ -262,6 +262,32 @@ ${needlePrefix} jhipster-needle-a-needle"
     });
   });
 
+  describe('insertContentBeforeNeedle with CRLF line endings', () => {
+    const needle = 'a-needle';
+    const contentToAdd = 'a bar value';
+
+    it('should insert content when file has CRLF line endings', () => {
+      const content = insertContentBeforeNeedle({
+        content: `first line\r\n        // jhipster-needle-${needle}\r\nlast line\r\n`,
+        contentToAdd,
+        needle,
+      });
+
+      expect(content).toContain(contentToAdd);
+      expect(content).toContain(`// jhipster-needle-${needle}`);
+    });
+
+    it('should insert content when needle line ends with CRLF at end of file', () => {
+      const content = insertContentBeforeNeedle({
+        content: `// jhipster-needle-${needle}\r\n`,
+        contentToAdd,
+        needle,
+      });
+
+      expect(content).toContain(contentToAdd);
+    });
+  });
+
   describe('createNeedleCallback', () => {
     const needle = 'a-needle';
     const contentToAdd = 'content to add';

--- a/generators/base-core/support/needles.ts
+++ b/generators/base-core/support/needles.ts
@@ -105,7 +105,7 @@ const isArrayOfContentToAdd = (value: unknown): value is ContentToAdd[] => {
 };
 
 export const createNeedleRegexp = (needle: string): RegExp =>
-  new RegExp(String.raw`(?://|<!--|\{?/\*|#) ${needle}(?: [^$\n]*)?(?:$|\n)`, 'g');
+  new RegExp(String.raw`(?://|<!--|\{?/\*|#) ${needle}(?: [^$\r\n]*)?(?:$|\r?\n)`, 'g');
 
 type NeedleLinePosition = {
   start: number;
@@ -158,7 +158,7 @@ const addNeedlePrefix = (needle: string): string => {
 };
 
 const hasNeedleStart = (content: string, needle: string): boolean => {
-  const regexpStart = new RegExp(`(?://|<!--|\\{?/\\*|#) ${addNeedlePrefix(needle)}-start(?:.*)\n`, 'g');
+  const regexpStart = new RegExp(`(?://|<!--|\\{?/\\*|#) ${addNeedlePrefix(needle)}-start(?:[^\\r\\n]*)\\r?\\n`, 'g');
   const startMatch = regexpStart.exec(content);
   return Boolean(startMatch);
 };
@@ -187,7 +187,7 @@ export const insertContentBeforeNeedle = ({ content, contentToAdd, needle, autoI
     throw new Error(`Multiple needles found for ${needle}`);
   }
 
-  const regexpStart = new RegExp(`(?://|<!--|\\{?/\\*|#) ${needle}-start(?:.*)\n`, 'g');
+  const regexpStart = new RegExp(`(?://|<!--|\\{?/\\*|#) ${needle}-start(?:[^\\r\\n]*)\\r?\\n`, 'g');
   const startMatch = regexpStart.exec(content);
   if (startMatch) {
     const needleLineIndex = content.lastIndexOf('\n', firstMatch.index) + 1;


### PR DESCRIPTION
## Summary

Fixes #33041

When files have CRLF (`\r\n`) line endings (common on Windows), the needle regex patterns fail to match because they only account for LF (`\n`). This causes `Missing required jhipster-needle ehcache-add-entry` errors when running `jhipster jdl` on Windows.

## Changes

Updated all three needle-related regex patterns in `generators/base-core/support/needles.ts` to handle both LF and CRLF line endings:

1. **`createNeedleRegexp`** — Changed `[^$\n]` to `[^$\r\n]` and `(?:$|\n)` to `(?:$|\r?\n)` so that `\r` before `\n` doesn't break the match.
2. **`hasNeedleStart`** — Same CRLF-aware pattern update for needle start detection.
3. **`insertContentBeforeNeedle`** — Same CRLF-aware pattern update for the start marker regex.

Added tests for CRLF line ending scenarios in `needles.spec.ts`.

## Root cause

The regex `(?:$|\n)` at the end of needle patterns expects either end-of-string or `\n`. With CRLF files, the character after the needle text is `\r`, which matches neither `$` nor `\n`, causing the needle to not be found.

## Test plan

- [x] Added CRLF-specific tests for `insertContentBeforeNeedle`
- [ ] Verify existing needle tests still pass
- [ ] Test on Windows with `jhipster jdl` and ehcache configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)