### PR TITLE
fix: enable autoCrlf by default on Windows

### DIFF
--- a/generators/bootstrap/command.ts
+++ b/generators/bootstrap/command.ts
@@ -25,6 +25,7 @@ const command = {
       cli: {
         type: Boolean,
       },
+      default: process.platform === 'win32',
       scope: 'storage',
     },
     removeNeedles: {


### PR DESCRIPTION
## Motivation

Fixes #33041

On Windows, files often have CRLF line endings which cause needle matching to fail. The `--auto-crlf` flag already exists but must be manually enabled. As @mshima [suggested](https://github.com/jhipster/generator-jhipster/issues/33041#issuecomment-2799946840), this should be enabled by default on Windows.

## Changes

Added `default: process.platform === 'win32'` to the `autoCrlf` config in `generators/bootstrap/command.ts`.

This means:
- On Windows (`win32`): `autoCrlf` is enabled by default, preventing CRLF-related needle failures
- On other platforms: behavior is unchanged (defaults to `false`)
- Users can still explicitly override with `--auto-crlf` or `--no-auto-crlf`

## Testing

- The change is minimal and only affects the default value of an existing config option
- Existing autoCrlf tests remain valid since the transform logic is unchanged
- Manual testing: Windows users running `jhipster jdl` should no longer encounter ehcache needle missing errors