### PR TITLE
Switch Vue microfrontends to use @module-federation/vite

### DIFF
--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -354,12 +354,17 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
         }
       },
       addMicrofrontendDependencies({ application, source }) {
-        const { clientBundlerVite, clientBundlerWebpack, enableTranslation, microfrontend } = application;
+        const { applicationTypeGateway, clientBundlerVite, clientBundlerWebpack, enableTranslation, microfrontend } = application;
         if (!microfrontend) return;
         if (clientBundlerVite) {
           source.mergeClientPackageJson!({
+            dependencies: applicationTypeGateway
+              ? {
+                  '@module-federation/runtime': null,
+                }
+              : {},
             devDependencies: {
-              '@originjs/vite-plugin-federation': '1.3.6',
+              '@module-federation/vite': null,
             },
           });
         } else if (clientBundlerWebpack) {
@@ -393,6 +398,10 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
             },
           });
         }
+      },
+      addMicrofrontendIgnorePatterns({ application, source }) {
+        if (!application.microfrontend || !application.clientBundlerVite) return;
+        source.addPrettierIgnore?.('.__mf__temp');
       },
       addIndexAsset({ source, application }) {
         if (!application.clientBundlerVite) return;

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -4,6 +4,7 @@
     "@fortawesome/free-solid-svg-icons": "7.2.0",
     "@fortawesome/vue-fontawesome": "3.1.3",
     "@stomp/rx-stomp": "2.3.0",
+    "@module-federation/runtime": "0.13.1",
     "@vuelidate/core": "2.0.3",
     "@vuelidate/validators": "2.0.4",
     "@vueuse/core": "14.2.1",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@module-federation/enhanced": "2.3.1",
+    "@module-federation/vite": "1.14.1",
     "@pinia/testing": "1.0.3",
     "@tsconfig/node18": "18.2.6",
     "@types/node": "22.19.17",

--- a/generators/vue/templates/eslint.config.ts.jhi.vue.ejs
+++ b/generators/vue/templates/eslint.config.ts.jhi.vue.ejs
@@ -22,7 +22,13 @@ import vue from 'eslint-plugin-vue';
 
 <&_ } -&>
 <&_ if (fragment.configSection) { -&>
-  { ignores: ['<%- this.relativeDir(clientRootDir, clientDistDir) %>', '<%- temporaryDir %>'] },
+  { ignores: [
+<%_ if (microfrontend) { _%>
+    '.__mf__temp',
+<%_ } _%>
+    '<%- this.relativeDir(clientRootDir, clientDistDir) %>',
+    '<%- temporaryDir %>',
+  ] },
   js.configs.recommended,
   ...tseslint.configs.recommended.map(config =>
     config.name === 'typescript-eslint/base' ? config : { ...config, files: [ '**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts' ] },

--- a/generators/vue/templates/module-federation.config.cjs.ejs
+++ b/generators/vue/templates/module-federation.config.cjs.ejs
@@ -34,6 +34,16 @@ const shareDependencies = ({ skipList = [] } = {}) =>
 /** @type {import('@module-federation/runtime').Options} */
 module.exports = {
   name: '<%- lowercaseBaseName %>',
+<%_ if (applicationTypeGateway) { _%>
+  remotes: [
+  <%_ for (const remote of microfrontends) { _%>
+    {
+      name: '<%- remote.lowercaseBaseName %>',
+      entry: '/<%- remote.endpointPrefix %>/remoteEntry.js',
+    },
+  <%_ } _%>
+  ],
+<%_ } _%>
 <%_ if (applicationTypeMicroservice) { _%>
   exposes: {
     './entities-router': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/router/entities.ts',

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -33,9 +33,15 @@ import { useLoginModal } from '@/account/login-modal';
 import JhiNavbar from './jhi-navbar.vue';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
 
+<%_ if (clientBundlerVite) { _%>
+vi.mock('@module-federation/runtime', () => ({
+  loadRemote: vitest.fn(() => Promise.reject(new Error('Test only'))),
+}));
+<%_ } else { _%>
 vi.mock('@module-federation/enhanced/runtime', () => ({
   loadRemote: vitest.fn(() => Promise.reject(new Error('Test only'))),
 }));
+<%_ } _%>
 <%_ } _%>
 
 type JhiNavbarComponentType = InstanceType<typeof JhiNavbar>;

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -17,7 +17,11 @@ import EntitiesMenu from '@/entities/entities-menu.vue';
 import { useStore } from '@/store';
 import { useRouter } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
+  <%_ if (clientBundlerVite) { _%>
+import { loadRemote } from '@module-federation/runtime';
+  <%_ } else { _%>
 import { loadRemote } from '@module-federation/enhanced/runtime';
+  <%_ } _%>
 <%_ } _%>
 
 export default defineComponent({

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -31,7 +31,7 @@ import TranslationService from '@/locale/translation.service';
 <%_ if (communicationSpringWebsocket) { _%>
 import { useTrackerService } from './admin/tracker/tracker.service';
 <%_ } _%>
-<%_ if (applicationTypeGateway && microfrontend) { _%>
+<%_ if (applicationTypeGateway && microfrontend && clientBundlerWebpack) { _%>
 import { init } from '@module-federation/enhanced/runtime';
 
 init({

--- a/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
@@ -1,6 +1,10 @@
 import { createRouter as createVueRouter, createWebHistory<% if (applicationTypeGateway && microfrontend) { %>, type RouteRecordRaw<% } %> } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
+  <%_ if (clientBundlerVite) { _%>
+import { loadRemote } from '@module-federation/runtime';
+  <%_ } else { _%>
 import { loadRemote } from '@module-federation/enhanced/runtime';
+  <%_ } _%>
 <%_ } _%>
 
 const Home = () => import('@/core/home/home.vue');

--- a/generators/vue/templates/vite.config.ts.ejs
+++ b/generators/vue/templates/vite.config.ts.ejs
@@ -20,28 +20,19 @@ import { fileURLToPath, URL } from 'node:url';
 import path from 'node:path';
 import { normalizePath } from 'vite';
 
-import {
-<%_ if (microfrontend && clientBundlerVite) { _%>
-  mergeConfig,
-<%_ } _%>
-  defineConfig,
-} from 'vite';
+import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 <%_ if (microfrontend && clientBundlerVite) { _%>
-import federation from "@originjs/vite-plugin-federation";
-
-  <%_ if (applicationTypeGateway) { _%>
-const sharedAppVersion = '0.0.0';
-  <%_ } _%>
+import { federation } from '@module-federation/vite';
+import federationConfig from './module-federation.config.cjs';
 <%_ } _%>
 
 const { getAbsoluteFSPath } = await import('swagger-ui-dist');
 const swaggerUiPath = getAbsoluteFSPath();
 const webappDir = fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>/', import.meta.url));
 
-// eslint-disable-next-line prefer-const
-let config = defineConfig({
+const config = defineConfig({
   plugins: [
     vue(),
     viteStaticCopy({
@@ -61,6 +52,9 @@ let config = defineConfig({
         },
       ],
     }),
+<%_ if (microfrontend && clientBundlerVite) { _%>
+    federation(federationConfig),
+<%_ } _%>
   ],
   root: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>', import.meta.url)),
   publicDir: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientDistDir) %>public', import.meta.url)),
@@ -68,6 +62,10 @@ let config = defineConfig({
   build: {
     emptyOutDir: true,
     outDir: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientDistDir) %>', import.meta.url)),
+<%_ if (microfrontend && clientBundlerVite) { _%>
+    modulePreload: false,
+    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
+<%_ } _%>
     rollupOptions: {
       input: {
         app: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>index.html', import.meta.url)),
@@ -123,63 +121,6 @@ let config = defineConfig({
   },
 });
 
-<%_ if (microfrontend && clientBundlerVite) { _%>
-config = mergeConfig(config, {
-  build: {
-    modulePreload: false,
-    minify: false,
-    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
-  },
-  plugins: [
-    federation({
-      name: '<%- lowercaseBaseName %>',
-  <%_ if (applicationTypeGateway) { _%>
-      remotes: {
-    <%_ for (const remote of microfrontends) { _%>
-        '@<%- remote.lowercaseBaseName %>': `/<%- remote.endpointPrefix %>/assets/remoteEntry.js`,
-    <%_ } _%>
-      },
-  <%_ } _%>
-  <%_ if (applicationTypeMicroservice) { _%>
-      exposes: {
-        './entities-router': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/router/entities',
-        './entities-menu': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/entities/entities-menu.vue',
-      },
-  <%_ } _%>
-      shared: {
-        '@vuelidate/core': {},
-        '@vuelidate/validators': {},
-        axios: {},
-        // 'bootstrap-vue': {},
-        vue: {
-          packagePath: 'vue/dist/vue.esm-bundler.js',
-        },
-        'vue-i18n': {},
-        'vue-router': {},
-        pinia: {},
-        '@/shared/jhipster/constants': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/jhipster/constants',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/shared/alert/alert.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/alert/alert.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/locale/translation.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/locale/translation.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-      },
-    }),
-  ],
-});
-<%_ } _%>
 // jhipster-needle-add-vite-config - JHipster will add custom config
 
 export default config;

--- a/lib/jhipster/default-application-options.ts
+++ b/lib/jhipster/default-application-options.ts
@@ -122,7 +122,7 @@ function getConfigForClientApplication(options: ApplicationDefaults = {}): Appli
   }
   switch (clientFramework) {
     case 'vue': {
-      options.clientBundler ??= options.microfrontend || options.applicationType === 'microservice' ? 'webpack' : 'vite';
+      options.clientBundler ??= 'vite';
       options.devServerPort ??= options.clientBundler === 'webpack' ? 9060 : 9000;
       break;
     }


### PR DESCRIPTION
## Summary

Fix https://github.com/jhipster/generator-jhipster/issues/27489

- Switch Vue microfrontend bundler default from webpack to vite
- Replace `@originjs/vite-plugin-federation` with `@module-federation/vite` (v1.14.1) in vite config
- Use `@module-federation/runtime` for `loadRemote` in vite builds (instead of `@module-federation/enhanced/runtime` used by webpack)
- Leverage the vite plugin's auto-init (skip manual `init()` call for vite builds)
- Reuse existing `module-federation.config.cjs` for both webpack and vite plugin configuration
- Add `.__mf__temp` to eslint and prettier ignore patterns (temp directory created by the vite plugin)

## Key changes

| File | Change |
|------|--------|
| `lib/jhipster/default-application-options.ts` | Vue bundler defaults to `vite` (was `webpack` for microfrontend) |
| `generators/vue/resources/package.json` | Add `@module-federation/vite` + `@module-federation/runtime` |
| `generators/vue/generator.ts` | Wire `@module-federation/vite` dep for vite MF builds; add prettierignore for `.__mf__temp` |
| `generators/vue/templates/vite.config.ts.ejs` | Replace old federation plugin with `federation(federationConfig)` from `@module-federation/vite` |
| `generators/vue/templates/module-federation.config.cjs.ejs` | Add `remotes` for gateway type |
| `generators/vue/templates/src/main/webapp/app/main.ts.ejs` | Skip `init()` for vite (plugin auto-injects) |
| `generators/vue/templates/src/main/webapp/app/router/index.ts.ejs` | Use `@module-federation/runtime` for vite |
| `generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs` | Use `@module-federation/runtime` for vite |
| `generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs` | Mock `@module-federation/runtime` for vite |
| `generators/vue/templates/eslint.config.ts.jhi.vue.ejs` | Ignore `.__mf__temp` directory |

## Test plan

- [ ] CI tests pass for Vue microfrontend samples
- [ ] Verify `ms-mf-vue-consul-oauth2-mysql-memcached` sample generates and builds correctly
- [ ] Verify gateway correctly loads remote entries from microservices
- [ ] Verify `npm run ci:frontend:test` passes in generated workspaces
- [ ] Verify `npm run ci:e2e:package` works for microfrontend builds

- [ ] Checking this box is mandatory (this is just to show you read everything)