### PR TITLE
fix: support JwtAuthenticationToken and Jwt in getCurrentUserJWT

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
@@ -39,7 +39,6 @@ import org.springframework.security.oauth2.core.ClaimAccessor;
 <%_ if (authenticationTypeOauth2) { _%>
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +54,9 @@ import reactor.core.publisher.Mono;
   <%_ } else { _%>
 import java.util.stream.Stream;
   <%_ } _%>
+<%_ } _%>
+<%_ if (authenticationTypeOauth2 || authenticationTypeJwt) { _%>
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 <%_ } _%>
 <%_ if (authenticationTypeOauth2 || authenticationTypeJwt || !reactive) { _%>
 import java.util.Optional;

--- a/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
@@ -144,8 +144,25 @@ public final class SecurityUtils {
         SecurityContext securityContext = SecurityContextHolder.getContext();
         return Optional.ofNullable(securityContext.getAuthentication())
   <%_ } _%>
-            .filter(authentication -> authentication.getCredentials() instanceof String)
-            .map(authentication -> (String) authentication.getCredentials());
+            .map(authentication -> {
+
+        if (authentication instanceof JwtAuthenticationToken jwtAuth) {
+            return jwtAuth.getToken().getTokenValue();
+        }
+
+        Object credentials = authentication.getCredentials();
+
+        if (credentials instanceof Jwt jwt) {
+            return jwt.getTokenValue();
+        }
+
+        if (credentials instanceof String token) {
+            return token;
+        }
+
+        return null;
+        })
+        .filter(token -> token != null && !token.isBlank());
     }
   <%_ if (user) { _%>
 


### PR DESCRIPTION
<!--
PR description.
-->
Fixes #32399

Updated getCurrentUserJWT() to support modern Spring Security behavior.

Changes:
- Handle JwtAuthenticationToken (default in Spring Security)
- Support Jwt credentials
- Keep backward compatibility with String tokens
- Prevent empty Optional when JWT is present

This ensures compatibility across different authentication configurations.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
