### PR TITLE
[React] ESLint 10 + Migration eslint-plugin-react to @eslint-react/eslint-plugin

### DIFF
--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -25,7 +25,8 @@
     "webstomp-client": "1.2.6"
   },
   "devDependencies": {
-    "@eslint/js": "9.39.2",
+    "@eslint-react/eslint-plugin": "4.2.3",
+    "@eslint/js": "10.0.1",
     "@module-federation/enhanced": "2.3.3",
     "@module-federation/utilities": "3.1.83",
     "@testing-library/react": "16.3.2",
@@ -40,10 +41,9 @@
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
     "css-minimizer-webpack-plugin": "8.0.0",
-    "eslint": "9.39.2",
+    "eslint": "10.2.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.5",
-    "eslint-plugin-react": "7.37.5",
     "eslint-webpack-plugin": "6.0.0",
     "folder-hash": "4.1.2",
     "fork-ts-checker-webpack-plugin": "9.1.0",

--- a/generators/react/templates/eslint.config.ts.jhi.react.ejs
+++ b/generators/react/templates/eslint.config.ts.jhi.react.ejs
@@ -18,7 +18,7 @@
 -%>
 <&_ if (fragment.importsSection) { -&>
 import eslint from '@eslint/js';
-import react from 'eslint-plugin-react/configs/recommended.js';
+import react from '@eslint-react/eslint-plugin';
 <&_ } -&>
 <&_ if (fragment.configSection) { -&>
   { ignores: ['<%- this.relativeDir(clientRootDir, clientDistDir) %>', '<%- temporaryDir %>'] },
@@ -31,12 +31,7 @@ import react from 'eslint-plugin-react/configs/recommended.js';
   },
   {
     files: ['<%- this.relativeDir(clientRootDir, clientSrcDir) %>**/*.{ts,tsx}'],
-    extends: [...tseslint.configs.recommendedTypeChecked, react],
-    settings: {
-      react: {
-        version: 'detect',
-      },
-    },
+    extends: [...tseslint.configs.recommendedTypeChecked, react.configs['recommended-type-checked']],
     languageOptions: {
       globals: {
         ...globals.browser,
@@ -46,6 +41,11 @@ import react from 'eslint-plugin-react/configs/recommended.js';
       },
     },
     rules: {
+      '@eslint-react/exhaustive-deps': 'off',
+      '@eslint-react/use-state': 'off',
+      '@eslint-react/rules-of-hooks': 'off',
+      '@eslint-react/set-state-in-effect': 'off',
+      '@eslint-react/no-array-index-key': 'off',
       '@typescript-eslint/member-ordering': [
         'error',
         {
@@ -88,8 +88,6 @@ import react from 'eslint-plugin-react/configs/recommended.js';
       'default-case': 'error',
       complexity: ['warn', 40],
       'no-invalid-this': 'off',
-      'react/prop-types': 'off',
-      'react/display-name': 'off',
     },
   },
   {

--- a/generators/react/templates/package.json.ejs
+++ b/generators/react/templates/package.json.ejs
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@eslint/js": null,
+    "@eslint-react/eslint-plugin": "<%- nodeDependencies['@eslint-react/eslint-plugin'] %>",
     "@testing-library/react": "<%- nodeDependencies['@testing-library/react'] %>",
     "@types/jest": "<%- nodeDependencies['@types/jest'] %>",
     "@types/node": "<%- nodeDependencies['@types/node'] %>",
@@ -67,7 +68,6 @@
     "eslint": "<%- nodeDependencies.eslint %>",
     "eslint-config-prettier": "<%- nodeDependencies['eslint-config-prettier'] %>",
     "eslint-plugin-prettier": "<%- nodeDependencies['eslint-plugin-prettier'] %>",
-    "eslint-plugin-react": "<%- nodeDependencies['eslint-plugin-react'] %>",
     "eslint-webpack-plugin": "<%- nodeDependencies['eslint-webpack-plugin'] %>",
     "fork-ts-checker-webpack-plugin": "<%- nodeDependencies['fork-ts-checker-webpack-plugin'] %>",
     "html-webpack-plugin": "<%- nodeDependencies['html-webpack-plugin'] %>",


### PR DESCRIPTION
- [x] ESLint 10 - Fix #32258 
- [x] Migrate `eslint-plugin-react` to `@eslint-react/eslint-plugin`

**eslint-plugin-react**
<img width="333" height="71" alt="image" src="https://github.com/user-attachments/assets/beed3264-3e50-4480-b548-a8e2c6c92d4f" />

**@eslint-react/eslint-plugin**
<img width="334" height="78" alt="image" src="https://github.com/user-attachments/assets/3ecefd1b-4f5e-4285-9a48-7a85c067c665" />

Doc: https://www.eslint-react.xyz/docs/migrating-from-eslint-plugin-react