### PR TITLE
[React] TS6: deprecated: esModuleInterop and allowSyntheticDefaultImports false

### DIFF
--- a/generators/react/templates/tsconfig.json.ejs
+++ b/generators/react/templates/tsconfig.json.ejs
@@ -36,9 +36,7 @@
     "paths": {
         "app/*": ["<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/*"]
     },
-    "importHelpers": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "importHelpers": true
   },
   "include": ["<%- this.relativeDir(clientRootDir, clientSrcDir) %>app"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.spec.tsx"]


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html
<img width="915" height="250" alt="image" src="https://github.com/user-attachments/assets/f5298a10-3a92-4f2e-bc3a-2bc29a724c04" />
Related to #33117 