### PR TITLE
[React] TS6: baseUrl is deprecated

### DIFF
--- a/generators/react/templates/tsconfig.json.ejs
+++ b/generators/react/templates/tsconfig.json.ejs
@@ -27,14 +27,14 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "noImplicitAny": false,
+    "rootDir": "./<%- this.relativeDir(clientRootDir, clientSrcDir) %>app",
     "outDir": "<%- this.relativeDir(clientRootDir, clientDistDir) %>app",
     "lib": ["dom", "es2015", "es2016", "es2017", "es2019", "es2020", "es2021"],
     "types": ["webpack-env"],
     "allowJs": true,
     "checkJs": false,
-    "baseUrl": "./",
     "paths": {
-        "app/*": ["<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/*"]
+        "app/*": ["./<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/*"]
     },
     "importHelpers": true,
     "esModuleInterop": true,

--- a/generators/react/templates/tsconfig.test.json.ejs
+++ b/generators/react/templates/tsconfig.test.json.ejs
@@ -22,7 +22,7 @@
   "exclude": [],
   "compilerOptions": {
     "paths": {
-      "app/*": ["<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/*"]
+      "app/*": ["./<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/*"]
    },
     "types": ["jest", "webpack-env"]
   }


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html
<img width="887" height="106" alt="image" src="https://github.com/user-attachments/assets/b068c31d-a718-47a3-9f6c-934c7e22a168" />
<img width="343" height="297" alt="image" src="https://github.com/user-attachments/assets/63778e93-c0ef-470a-99b0-267b7f42beb9" />
