### PR TITLE
[React] TS6: update tsconfig

### DIFF
--- a/generators/react/templates/tsconfig.json.ejs
+++ b/generators/react/templates/tsconfig.json.ejs
@@ -19,7 +19,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "target": "es2021",
+    "target": "es2024",
     "module": "esnext",
     "moduleResolution": "bundler",
     "sourceMap": true,
@@ -29,7 +29,7 @@
     "noImplicitAny": false,
     "rootDir": "./<%- this.relativeDir(clientRootDir, clientSrcDir) %>app",
     "outDir": "<%- this.relativeDir(clientRootDir, clientDistDir) %>app",
-    "lib": ["dom", "es2015", "es2016", "es2017", "es2019", "es2020", "es2021"],
+    "lib": ["dom", "es2024"],
     "types": ["webpack-env"],
     "allowJs": true,
     "checkJs": false,


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html

`typescript-eslint` doesn't support `es2025`