### PR TITLE
feat(vue): switch microfrontends to @module-federation/vite v1.0.0

### DIFF
--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -359,7 +359,7 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
         if (clientBundlerVite) {
           source.mergeClientPackageJson!({
             devDependencies: {
-              '@originjs/vite-plugin-federation': '1.3.6',
+              '@module-federation/vite': '^1.0.0',
             },
           });
         } else if (clientBundlerWebpack) {

--- a/generators/vue/templates/vite.config.ts.ejs
+++ b/generators/vue/templates/vite.config.ts.ejs
@@ -29,11 +29,8 @@ import {
 import vue from '@vitejs/plugin-vue';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 <%_ if (microfrontend && clientBundlerVite) { _%>
-import federation from "@originjs/vite-plugin-federation";
+import { federation } from '@module-federation/vite';
 
-  <%_ if (applicationTypeGateway) { _%>
-const sharedAppVersion = '0.0.0';
-  <%_ } _%>
 <%_ } _%>
 
 const { getAbsoluteFSPath } = await import('swagger-ui-dist');
@@ -133,6 +130,10 @@ config = mergeConfig(config, {
   plugins: [
     federation({
       name: '<%- lowercaseBaseName %>',
+  <%_ if (applicationTypeMicroservice) { _%>
+      filename: 'remoteEntry.js',
+  <%_ } _%>
+      shareScope: 'default',
   <%_ if (applicationTypeGateway) { _%>
       remotes: {
     <%_ for (const remote of microfrontends) { _%>
@@ -150,31 +151,13 @@ config = mergeConfig(config, {
         '@vuelidate/core': {},
         '@vuelidate/validators': {},
         axios: {},
-        // 'bootstrap-vue': {},
-        vue: {
-          packagePath: 'vue/dist/vue.esm-bundler.js',
-        },
+        vue: {},
         'vue-i18n': {},
         'vue-router': {},
         pinia: {},
-        '@/shared/jhipster/constants': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/jhipster/constants',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/shared/alert/alert.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/alert/alert.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/locale/translation.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/locale/translation.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
+        '@/shared/jhipster/constants': {},
+        '@/shared/alert/alert.service': {},
+        '@/locale/translation.service': {},
       },
     }),
   ],


### PR DESCRIPTION
## Description

Closes #27489

This PR switches Vue microfrontends from `@originjs/vite-plugin-federation` (unmaintained) to `@module-federation/vite` v1.0.0+.

### Background

`@module-federation/vite` v1.0.0 switched from `@softarc/native-federation` to `@module-federation/runtime`, which is actively maintained and provides better compatibility with the webpack Module Federation ecosystem.

### Changes

1. **`generators/vue/generator.ts`**: Updated dependency from `@originjs/vite-plugin-federation: 1.3.6` to `@module-federation/vite: ^1.0.0`

2. **`generators/vue/templates/vite.config.ts.ejs`**: 
   - Changed import from default to named export: `import { federation } from '@module-federation/vite'`
   - Removed `packagePath` from shared config (not supported by new plugin)
   - Added `filename: 'remoteEntry.js'` and `shareScope: 'default'` options
   - Removed unused `sharedAppVersion` constant

### Notes

- The webpack path is unchanged (continues using `@module-federation/enhanced/webpack`)
- The `module-federation.config.cjs` is already typed with `@module-federation/runtime` and remains compatible
- The `@module-federation/vite` plugin resolves shared modules from node_modules automatically, so `packagePath` mappings are no longer needed