### PR TITLE
refactor: use asSubclass for SqlTestContainer discovery

### DIFF
--- a/generators/spring-boot/generators/data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
+++ b/generators/spring-boot/generators/data-relational/templates/src/test/java/_package_/config/SqlTestContainersSpringContextCustomizerFactory.java.ejs
@@ -63,7 +63,7 @@ public class SqlTestContainersSpringContextCustomizerFactory implements ContextC
                     log.info("Warming up the sql database");
                     if (null == prodTestcontainer) {
                         try {
-                            Class<? extends SqlTestContainer> containerClass = (Class<? extends SqlTestContainer>) Class.forName(this.getClass().getPackageName() + ".DatabaseTestcontainer");
+                            Class<? extends SqlTestContainer> containerClass = Class.forName(this.getClass().getPackageName() + ".DatabaseTestcontainer").asSubclass(SqlTestContainer.class);
                             prodTestcontainer = beanFactory.createBean(containerClass);
                             beanFactory.registerSingleton(containerClass.getName(), prodTestcontainer);
                             /**


### PR DESCRIPTION
### PR Description

This PR refactors the dynamic discovery of the `SqlTestContainer` class within the `SqlTestContainersSpringContextCustomizerFactory` template. 

The current implementation uses a manual unchecked cast:
`Class<? extends SqlTestContainer> containerClass = (Class<? extends SqlTestContainer>) Class.forName(...)`

This is replaced with the more robust and type-safe approach using the Java Reflection API's `asSubclass()` method:
`Class<? extends SqlTestContainer> containerClass = Class.forName(...).asSubclass(SqlTestContainer.class)`

**Changes:**
- Improved type safety during runtime class discovery.
- Eliminated potential unchecked cast warnings.
- Verified by generating a sample SQL-based application and ensuring the generated code compiles correctly.

Fixes #33261

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed