### PR TITLE
Fix AnyBlob content type column removal in incremental changelog

### DIFF
--- a/generators/liquibase/incremental-liquibase.spec.ts
+++ b/generators/liquibase/incremental-liquibase.spec.ts
@@ -559,6 +559,40 @@ entity Customer {
     });
   });
 
+  describe('when removing a blob field with content type', () => {
+    before(async () => {
+      await helpers.runJDL(`
+${jdlApplication}
+entity Customer {
+    name String
+    contract AnyBlob
+}
+`);
+
+      await helpers
+        .runJDLInApplication(
+          `
+${jdlApplication}
+entity Customer {
+    name String
+}
+`,
+        )
+        .withMockedSource({ except: exceptSourceMethods })
+        .withMockedJHipsterGenerators({ except: exceptMockedGenerators })
+        .withOptions({
+          creationTimestamp: '2020-01-02',
+        });
+    });
+
+    it('should drop the blob field content type column', () => {
+      const updatedChangelog = `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/20200102000100_updated_entity_Customer.xml`;
+
+      runResult.assertFileContent(updatedChangelog, 'column name="contract"');
+      runResult.assertFileContent(updatedChangelog, 'column name="contract_content_type"');
+    });
+  });
+
   describe('when adding a relationship', () => {
     before(async () => {
       await helpers

--- a/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/updated_entity.xml.ejs
+++ b/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/updated_entity.xml.ejs
@@ -50,6 +50,10 @@
         <dropColumn tableName="<%- entity.entityTableName %>">
   <%_ for (field of removedFields) { _%>
             <column name="<%- field.columnName %>"/>
+    <%_ if (field.shouldCreateContentType) { _%>
+            <column name="<%- field.columnName %>_content_type"/>
+  <%_ }
+    _%>
   <%_ } _%>
         </dropColumn>
     </changeSet>


### PR DESCRIPTION
Fixes #17613.

## Summary
- drop the generated `<field>_content_type` Liquibase column when an `AnyBlob`/blob field is removed in an incremental changelog
- add a regression test covering removal of an `AnyBlob` field

## Verification
- `npm install`
- `npm run check-types`
- `npx prettier --check generators/liquibase/incremental-liquibase.spec.ts`

I also tried to run the focused test with:

```bash
npx esmocha generators/liquibase/incremental-liquibase.spec.ts --forbid-only --grep 'blob field with content type'
```

On Windows this currently fails before the assertion with Node's ESM loader rejecting an absolute `c:` path (`ERR_UNSUPPORTED_ESM_URL_SCHEME`). The added regression test is scoped to the generated changelog output and should run normally in the Linux CI environment.
