### PR TITLE
Switch Vue Vite microfrontends to @module-federation/vite

### DIFF
--- a/generators/vue/generator.spec.ts
+++ b/generators/vue/generator.spec.ts
@@ -198,4 +198,44 @@ describe(`generator - ${clientFramework}`, () => {
       });
     });
   });
+
+  describe('with vite gateway microfrontend', () => {
+    before(async () => {
+      await helpers
+        .runJHipster(generator)
+        .withJHipsterConfig({
+          ...commonConfig,
+          applicationType: 'gateway',
+          authenticationType: 'jwt',
+          baseName: 'gatewaymf',
+          clientBundler: 'vite',
+          microfrontend: true,
+          microfrontends: [{ baseName: 'remotemf' }],
+          withAdminUi: true,
+        })
+        .withSharedApplication({ getWebappTranslation: () => 'translations', gatewayServicesApiAvailable: true })
+        .withMockedSource()
+        .withMockedGenerators(['jhipster:common', 'jhipster:client:i18n']);
+    });
+
+    it('should add module federation dependencies required by generated vite gateway files', () => {
+      expect(runResult.sourceCallsArg.mergeClientPackageJson).toContainEqual({
+        devDependencies: {
+          '@module-federation/runtime': null,
+          '@module-federation/vite': null,
+        },
+      });
+      expect(JSON.stringify(runResult.sourceCallsArg.mergeClientPackageJson)).not.toContain('@originjs/vite-plugin-federation');
+      runResult.assertFileContent('src/main/webapp/app/main.ts', "import { init } from '@module-federation/runtime';");
+    });
+
+    it('should wire vite federation plugin to the generated module federation config', () => {
+      runResult.assertFileContent('vite.config.ts', "import { federation } from '@module-federation/vite';");
+      runResult.assertFileContent(
+        'vite.config.ts',
+        "const moduleFederationConfig = createRequire(import.meta.url)('./module-federation.config.cjs');",
+      );
+      runResult.assertFileContent('vite.config.ts', 'federation(moduleFederationConfig)');
+    });
+  });
 });

--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -359,7 +359,8 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
         if (clientBundlerVite) {
           source.mergeClientPackageJson!({
             devDependencies: {
-              '@originjs/vite-plugin-federation': '1.3.6',
+              ...(applicationTypeGateway ? { '@module-federation/runtime': null } : {}),
+              '@module-federation/vite': null,
             },
           });
         } else if (clientBundlerWebpack) {

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -23,6 +23,8 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@module-federation/enhanced": "2.4.0",
+    "@module-federation/runtime": "2.4.0",
+    "@module-federation/vite": "1.15.4",
     "@pinia/testing": "1.0.3",
     "@tsconfig/node18": "18.2.6",
     "@types/node": "22.19.18",

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -33,7 +33,7 @@ import { useLoginModal } from '@/account/login-modal';
 import JhiNavbar from './jhi-navbar.vue';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
 
-vi.mock('@module-federation/enhanced/runtime', () => ({
+vi.mock('<%- clientBundlerVite ? '@module-federation/runtime' : '@module-federation/enhanced/runtime' %>', () => ({
   loadRemote: vitest.fn(() => Promise.reject(new Error('Test only'))),
 }));
 <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -17,7 +17,7 @@ import EntitiesMenu from '@/entities/entities-menu.vue';
 import { useStore } from '@/store';
 import { useRouter } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { loadRemote } from '@module-federation/enhanced/runtime';
+import { loadRemote } from '<%- clientBundlerVite ? '@module-federation/runtime' : '@module-federation/enhanced/runtime' %>';
 <%_ } _%>
 
 export default defineComponent({

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -32,7 +32,7 @@ import TranslationService from '@/locale/translation.service';
 import { useTrackerService } from './admin/tracker/tracker.service';
 <%_ } _%>
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { init } from '@module-federation/enhanced/runtime';
+import { init } from '<%- clientBundlerVite ? '@module-federation/runtime' : '@module-federation/enhanced/runtime' %>';
 
 init({
   name: '<%- lowercaseBaseName %>',

--- a/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
@@ -1,6 +1,6 @@
 import { createRouter as createVueRouter, createWebHistory<% if (applicationTypeGateway && microfrontend) { %>, type RouteRecordRaw<% } %> } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { loadRemote } from '@module-federation/enhanced/runtime';
+import { loadRemote } from '<%- clientBundlerVite ? '@module-federation/runtime' : '@module-federation/enhanced/runtime' %>';
 <%_ } _%>
 
 const Home = () => import('@/core/home/home.vue');

--- a/generators/vue/templates/vite.config.ts.ejs
+++ b/generators/vue/templates/vite.config.ts.ejs
@@ -17,6 +17,9 @@
  limitations under the License.
 -%>
 import { fileURLToPath, URL } from 'node:url';
+<%_ if (microfrontend && clientBundlerVite) { _%>
+import { createRequire } from 'node:module';
+<%_ } _%>
 import path from 'node:path';
 import { normalizePath } from 'vite';
 
@@ -29,11 +32,9 @@ import {
 import vue from '@vitejs/plugin-vue';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 <%_ if (microfrontend && clientBundlerVite) { _%>
-import federation from "@originjs/vite-plugin-federation";
+import { federation } from '@module-federation/vite';
 
-  <%_ if (applicationTypeGateway) { _%>
-const sharedAppVersion = '0.0.0';
-  <%_ } _%>
+const moduleFederationConfig = createRequire(import.meta.url)('./module-federation.config.cjs');
 <%_ } _%>
 
 const { getAbsoluteFSPath } = await import('swagger-ui-dist');
@@ -131,52 +132,7 @@ config = mergeConfig(config, {
     target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
   },
   plugins: [
-    federation({
-      name: '<%- lowercaseBaseName %>',
-  <%_ if (applicationTypeGateway) { _%>
-      remotes: {
-    <%_ for (const remote of microfrontends) { _%>
-        '@<%- remote.lowercaseBaseName %>': `/<%- remote.endpointPrefix %>/assets/remoteEntry.js`,
-    <%_ } _%>
-      },
-  <%_ } _%>
-  <%_ if (applicationTypeMicroservice) { _%>
-      exposes: {
-        './entities-router': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/router/entities',
-        './entities-menu': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/entities/entities-menu.vue',
-      },
-  <%_ } _%>
-      shared: {
-        '@vuelidate/core': {},
-        '@vuelidate/validators': {},
-        axios: {},
-        // 'bootstrap-vue': {},
-        vue: {
-          packagePath: 'vue/dist/vue.esm-bundler.js',
-        },
-        'vue-i18n': {},
-        'vue-router': {},
-        pinia: {},
-        '@/shared/jhipster/constants': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/jhipster/constants',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/shared/alert/alert.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/alert/alert.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/locale/translation.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/locale/translation.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-      },
-    }),
+    federation(moduleFederationConfig),
   ],
 });
 <%_ } _%>


### PR DESCRIPTION
Fixes #27489.

## Summary
- replace Vue Vite microfrontend support from @originjs/vite-plugin-federation to @module-federation/vite
- reuse the generated module-federation.config.cjs from vite.config.ts instead of keeping a separate inline Vite federation config
- use @module-federation/runtime for generated Vite gateway runtime imports while keeping webpack gateways on @module-federation/enhanced/runtime
- add a focused Vue generator test for Vite gateway microfrontend dependency and Vite config wiring

## Checks
- npm run build
- npm run eslint -- generators/vue/generator.spec.ts generators/vue/generator.ts generators/vue/templates/src/main/webapp/app/main.ts.ejs generators/vue/templates/src/main/webapp/app/router/index.ts.ejs generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
- npx esmocha generators/vue/generator.spec.ts --forbid-only
- generated a Vue Vite microservice microfrontend sample and ran npm install --ignore-scripts && npm run vite-build
- generated a Vue Vite gateway microfrontend sample and ran npm install --ignore-scripts && npm run vite-build