### PR TITLE
Switch Vue microfrontends to @module-federation/vite

### DIFF
--- a/generators/vue/__snapshots__/generator.spec.ts.snap
+++ b/generators/vue/__snapshots__/generator.spec.ts.snap
@@ -1752,12 +1752,12 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "cacheProviderRedis": false,
   "camelizedBaseName": "jhipster",
   "capitalizedBaseName": "Jhipster",
-  "clientBundler": "webpack",
+  "clientBundler": "vite",
   "clientBundlerAny": true,
   "clientBundlerEsbuild": false,
-  "clientBundlerName": "Webpack",
-  "clientBundlerVite": false,
-  "clientBundlerWebpack": true,
+  "clientBundlerName": "Vite",
+  "clientBundlerVite": true,
+  "clientBundlerWebpack": false,
   "clientDistDir": "dist/",
   "clientFramework": "vue",
   "clientFrameworkAngular": false,
@@ -1833,8 +1833,8 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "devDatabaseTypeMysql": false,
   "devDatabaseTypeOracle": false,
   "devDatabaseTypePostgresql": true,
-  "devServerPort": 9060,
-  "devServerPortProxy": 9000,
+  "devServerPort": 9000,
+  "devServerPortProxy": undefined,
   "dockerApplicationEnvironment": {},
   "dockerContainers": Any<Object>,
   "dockerServices": [],
@@ -2470,27 +2470,6 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "clientRoot/vitest.config.ts": {
     "stateCleared": "modified",
   },
-  "clientRoot/webpack/config.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/package.json": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/vue.utils.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.common.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.dev.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.microfrontend.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.prod.js": {
-    "stateCleared": "modified",
-  },
   "package.json": {
     "stateCleared": "modified",
   },
@@ -2507,6 +2486,16 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
         "Entity[Microservice]",
         "Entity[EntityWithCustomId]",
       ],
+    },
+  ],
+  "addExternalResourceToRoot": [
+    {
+      "comment": "Workaround https://github.com/axios/axios/issues/5622",
+      "resource": "<script>const global = globalThis;</script>",
+    },
+    {
+      "comment": "Load vue main",
+      "resource": "<script type="module" src="./app/index.ts"></script>",
     },
   ],
   "addSonarProperties": [
@@ -2531,41 +2520,20 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
       },
     ],
   ],
-  "addWebpackConfig": [
-    {
-      "config": "require('./webpack.microfrontend')({ serve: options.env.WEBPACK_SERVE })",
-    },
-  ],
   "mergeClientPackageJson": [
     {
       "scripts": {
-        "webapp:build:dev": "npm run webpack -- --mode development --env stats=minimal",
-        "webapp:build:prod": "npm run webpack -- --mode production --env stats=minimal",
-        "webapp:dev": "npm run webpack-dev-server -- --mode development --env stats=normal",
-        "webpack": "webpack --config webpack/webpack.common.js",
-        "webpack-dev-server": "webpack serve --config webpack/webpack.common.js",
+        "vite-build": "vite build",
+        "vite-serve": "vite",
+        "webapp:build:dev": "npm run vite-build",
+        "webapp:build:prod": "npm run vite-build",
+        "webapp:dev": "npm run vite-serve",
+        "webapp:serve": "npm run vite-serve",
       },
     },
     {
       "devDependencies": {
-        "browser-sync-webpack-plugin": null,
-        "copy-webpack-plugin": null,
-        "css-loader": null,
-        "css-minimizer-webpack-plugin": null,
-        "html-webpack-plugin": null,
-        "mini-css-extract-plugin": null,
-        "postcss-loader": null,
-        "sass-loader": null,
-        "terser-webpack-plugin": null,
-        "ts-loader": null,
-        "vue-loader": null,
-        "vue-style-loader": null,
-        "webpack": null,
-        "webpack-bundle-analyzer": null,
-        "webpack-cli": null,
-        "webpack-dev-server": null,
-        "webpack-merge": null,
-        "workbox-webpack-plugin": null,
+        "@module-federation/vite": null,
       },
     },
     {
@@ -2615,12 +2583,12 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "cacheProviderRedis": false,
   "camelizedBaseName": "jhipster",
   "capitalizedBaseName": "Jhipster",
-  "clientBundler": "webpack",
+  "clientBundler": "vite",
   "clientBundlerAny": true,
   "clientBundlerEsbuild": false,
-  "clientBundlerName": "Webpack",
-  "clientBundlerVite": false,
-  "clientBundlerWebpack": true,
+  "clientBundlerName": "Vite",
+  "clientBundlerVite": true,
+  "clientBundlerWebpack": false,
   "clientDistDir": "dist/",
   "clientFramework": "vue",
   "clientFrameworkAngular": false,
@@ -2696,8 +2664,8 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "devDatabaseTypeMysql": false,
   "devDatabaseTypeOracle": false,
   "devDatabaseTypePostgresql": true,
-  "devServerPort": 9060,
-  "devServerPortProxy": 9000,
+  "devServerPort": 9000,
+  "devServerPortProxy": undefined,
   "dockerApplicationEnvironment": {},
   "dockerContainers": Any<Object>,
   "dockerServices": [],
@@ -3392,27 +3360,6 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "vitest.config.ts": {
     "stateCleared": "modified",
   },
-  "webpack/config.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/package.json": {
-    "stateCleared": "modified",
-  },
-  "webpack/vue.utils.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.common.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.dev.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.microfrontend.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.prod.js": {
-    "stateCleared": "modified",
-  },
 }
 `;
 
@@ -3426,6 +3373,16 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
         "Entity[Microservice]",
         "Entity[EntityWithCustomId]",
       ],
+    },
+  ],
+  "addExternalResourceToRoot": [
+    {
+      "comment": "Workaround https://github.com/axios/axios/issues/5622",
+      "resource": "<script>const global = globalThis;</script>",
+    },
+    {
+      "comment": "Load vue main",
+      "resource": "<script type="module" src="./app/index.ts"></script>",
     },
   ],
   "addSonarProperties": [
@@ -3450,43 +3407,20 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
       },
     ],
   ],
-  "addWebpackConfig": [
-    {
-      "config": "require('./webpack.microfrontend')({ serve: options.env.WEBPACK_SERVE })",
-    },
-  ],
   "mergeClientPackageJson": [
     {
       "scripts": {
-        "webapp:build:dev": "npm run webpack -- --mode development --env stats=minimal",
-        "webapp:build:prod": "npm run webpack -- --mode production --env stats=minimal",
-        "webapp:dev": "npm run webpack-dev-server -- --mode development --env stats=normal",
-        "webpack": "webpack --config webpack/webpack.common.js",
-        "webpack-dev-server": "webpack serve --config webpack/webpack.common.js",
+        "vite-build": "vite build",
+        "vite-serve": "vite",
+        "webapp:build:dev": "npm run vite-build",
+        "webapp:build:prod": "npm run vite-build",
+        "webapp:dev": "npm run vite-serve",
+        "webapp:serve": "npm run vite-serve",
       },
     },
     {
       "devDependencies": {
-        "browser-sync-webpack-plugin": null,
-        "copy-webpack-plugin": null,
-        "css-loader": null,
-        "css-minimizer-webpack-plugin": null,
-        "folder-hash": null,
-        "html-webpack-plugin": null,
-        "merge-jsons-webpack-plugin": null,
-        "mini-css-extract-plugin": null,
-        "postcss-loader": null,
-        "sass-loader": null,
-        "terser-webpack-plugin": null,
-        "ts-loader": null,
-        "vue-loader": null,
-        "vue-style-loader": null,
-        "webpack": null,
-        "webpack-bundle-analyzer": null,
-        "webpack-cli": null,
-        "webpack-dev-server": null,
-        "webpack-merge": null,
-        "workbox-webpack-plugin": null,
+        "@module-federation/vite": null,
       },
     },
     {

--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -358,8 +358,15 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
         if (!microfrontend) return;
         if (clientBundlerVite) {
           source.mergeClientPackageJson!({
+            ...(applicationTypeGateway
+              ? {
+                  dependencies: {
+                    '@module-federation/runtime': null,
+                  },
+                }
+              : {}),
             devDependencies: {
-              '@originjs/vite-plugin-federation': '1.3.6',
+              '@module-federation/vite': null,
             },
           });
         } else if (clientBundlerWebpack) {

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -3,6 +3,7 @@
     "@fortawesome/fontawesome-svg-core": "7.2.0",
     "@fortawesome/free-solid-svg-icons": "7.2.0",
     "@fortawesome/vue-fontawesome": "3.2.0",
+    "@module-federation/runtime": "2.4.0",
     "@stomp/rx-stomp": "2.4.0",
     "@vuelidate/core": "2.0.3",
     "@vuelidate/validators": "2.0.4",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@module-federation/enhanced": "2.4.0",
+    "@module-federation/vite": "1.15.4",
     "@pinia/testing": "1.0.3",
     "@tsconfig/node18": "18.2.6",
     "@types/node": "22.19.18",

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -33,9 +33,15 @@ import { useLoginModal } from '@/account/login-modal';
 import JhiNavbar from './jhi-navbar.vue';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
 
+  <%_ if (clientBundlerVite) { _%>
+vi.mock('@module-federation/runtime', () => ({
+  loadRemote: vitest.fn(() => Promise.reject(new Error('Test only'))),
+}));
+  <%_ } else { _%>
 vi.mock('@module-federation/enhanced/runtime', () => ({
   loadRemote: vitest.fn(() => Promise.reject(new Error('Test only'))),
 }));
+  <%_ } _%>
 <%_ } _%>
 
 type JhiNavbarComponentType = InstanceType<typeof JhiNavbar>;

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -17,7 +17,11 @@ import EntitiesMenu from '@/entities/entities-menu.vue';
 import { useStore } from '@/store';
 import { useRouter } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
+  <%_ if (clientBundlerVite) { _%>
+import { loadRemote } from '@module-federation/runtime';
+  <%_ } else { _%>
 import { loadRemote } from '@module-federation/enhanced/runtime';
+  <%_ } _%>
 <%_ } _%>
 
 export default defineComponent({

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -31,7 +31,7 @@ import TranslationService from '@/locale/translation.service';
 <%_ if (communicationSpringWebsocket) { _%>
 import { useTrackerService } from './admin/tracker/tracker.service';
 <%_ } _%>
-<%_ if (applicationTypeGateway && microfrontend) { _%>
+<%_ if (applicationTypeGateway && microfrontend && clientBundlerWebpack) { _%>
 import { init } from '@module-federation/enhanced/runtime';
 
 init({

--- a/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
@@ -1,6 +1,10 @@
 import { createRouter as createVueRouter, createWebHistory<% if (applicationTypeGateway && microfrontend) { %>, type RouteRecordRaw<% } %> } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
+  <%_ if (clientBundlerVite) { _%>
+import { loadRemote } from '@module-federation/runtime';
+  <%_ } else { _%>
 import { loadRemote } from '@module-federation/enhanced/runtime';
+  <%_ } _%>
 <%_ } _%>
 
 const Home = () => import('@/core/home/home.vue');

--- a/generators/vue/templates/vite.config.ts.ejs
+++ b/generators/vue/templates/vite.config.ts.ejs
@@ -20,25 +20,22 @@ import { fileURLToPath, URL } from 'node:url';
 import path from 'node:path';
 import { normalizePath } from 'vite';
 
-import {
-<%_ if (microfrontend && clientBundlerVite) { _%>
-  mergeConfig,
-<%_ } _%>
-  defineConfig,
-} from 'vite';
+import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 <%_ if (microfrontend && clientBundlerVite) { _%>
-import federation from "@originjs/vite-plugin-federation";
-
-  <%_ if (applicationTypeGateway) { _%>
-const sharedAppVersion = '0.0.0';
-  <%_ } _%>
+import { federation } from '@module-federation/vite';
+import federationConfig from './module-federation.config.cjs';
 <%_ } _%>
 
 const { getAbsoluteFSPath } = await import('swagger-ui-dist');
 const swaggerUiPath = getAbsoluteFSPath();
 const webappDir = fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>/', import.meta.url));
+<%_ if (microfrontend && clientBundlerVite) { _%>
+const federationSharedDependencies = Object.fromEntries(
+  Object.entries(federationConfig.shared ?? {}).filter(([shared]) => !shared.startsWith('@/')),
+);
+<%_ } _%>
 
 // eslint-disable-next-line prefer-const
 let config = defineConfig({
@@ -61,6 +58,24 @@ let config = defineConfig({
         },
       ],
     }),
+<%_ if (microfrontend && clientBundlerVite) { _%>
+    federation({
+      ...federationConfig,
+      shared: federationSharedDependencies,
+      virtualModuleDir: '__mf__virtual_<%- lowercaseBaseName %>',
+  <%_ if (applicationTypeGateway) { _%>
+      remotes: {
+    <%_ for (const remote of microfrontends) { _%>
+        '<%- remote.lowercaseBaseName %>': {
+          type: 'module',
+          name: '<%- remote.lowercaseBaseName %>',
+          entry: '/<%- remote.endpointPrefix %>/remoteEntry.js',
+        },
+    <%_ } _%>
+      },
+  <%_ } _%>
+    }),
+<%_ } _%>
   ],
   root: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>', import.meta.url)),
   publicDir: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientDistDir) %>public', import.meta.url)),
@@ -68,6 +83,11 @@ let config = defineConfig({
   build: {
     emptyOutDir: true,
     outDir: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientDistDir) %>', import.meta.url)),
+<%_ if (microfrontend && clientBundlerVite) { _%>
+    modulePreload: false,
+    minify: false,
+    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
+<%_ } _%>
     rollupOptions: {
       input: {
         app: fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>index.html', import.meta.url)),
@@ -76,7 +96,7 @@ let config = defineConfig({
   },
   resolve: {
     alias: {
-      vue: 'vue/dist/vue.esm-bundler.js',
+      vue: <%_ if (microfrontend && clientBundlerVite) { _%>fileURLToPath(new URL('./node_modules/vue/dist/vue.esm-bundler.js', import.meta.url))<%_ } else { _%>'vue/dist/vue.esm-bundler.js'<%_ } _%>,
       '@': fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/', import.meta.url)),
       '@content': fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>content/', import.meta.url)),
     },
@@ -123,63 +143,6 @@ let config = defineConfig({
   },
 });
 
-<%_ if (microfrontend && clientBundlerVite) { _%>
-config = mergeConfig(config, {
-  build: {
-    modulePreload: false,
-    minify: false,
-    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
-  },
-  plugins: [
-    federation({
-      name: '<%- lowercaseBaseName %>',
-  <%_ if (applicationTypeGateway) { _%>
-      remotes: {
-    <%_ for (const remote of microfrontends) { _%>
-        '@<%- remote.lowercaseBaseName %>': `/<%- remote.endpointPrefix %>/assets/remoteEntry.js`,
-    <%_ } _%>
-      },
-  <%_ } _%>
-  <%_ if (applicationTypeMicroservice) { _%>
-      exposes: {
-        './entities-router': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/router/entities',
-        './entities-menu': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/entities/entities-menu.vue',
-      },
-  <%_ } _%>
-      shared: {
-        '@vuelidate/core': {},
-        '@vuelidate/validators': {},
-        axios: {},
-        // 'bootstrap-vue': {},
-        vue: {
-          packagePath: 'vue/dist/vue.esm-bundler.js',
-        },
-        'vue-i18n': {},
-        'vue-router': {},
-        pinia: {},
-        '@/shared/jhipster/constants': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/jhipster/constants',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/shared/alert/alert.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/alert/alert.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/locale/translation.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/locale/translation.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-      },
-    }),
-  ],
-});
-<%_ } _%>
 // jhipster-needle-add-vite-config - JHipster will add custom config
 
 export default config;

--- a/lib/jhipster/default-application-options.ts
+++ b/lib/jhipster/default-application-options.ts
@@ -125,7 +125,7 @@ function getConfigForClientApplication(options: ApplicationDefaults = {}): Appli
   }
   switch (clientFramework) {
     case 'vue': {
-      options.clientBundler ??= options.microfrontend || options.applicationType === 'microservice' ? 'webpack' : 'vite';
+      options.clientBundler ??= 'vite';
       options.devServerPort ??= options.clientBundler === 'webpack' ? 9060 : 9000;
       break;
     }


### PR DESCRIPTION
Fixes #27489.

## Summary

- Switch Vue Vite microfrontends from `@originjs/vite-plugin-federation` to `@module-federation/vite`.
- Keep the existing webpack path on `@module-federation/enhanced`, while Vite gateways load remotes through `@module-federation/runtime`.
- Make Vue microservices default to Vite and update the Vue generator snapshots accordingly.
- Preserve the shared module federation config for webpack, but only pass package dependencies to the Vite plugin so app-local `@/...` modules do not trigger package-resolution or alias-conflict warnings.

## Verification

- `npm ci --ignore-scripts --cache ..\..\corepack-cache`
- `npm run build`
- `npm run check-types`
- Generated a gateway + notification Vue microfrontend smoke app with the rebuilt local CLI.
- `npm install --ignore-scripts --cache ..\..\corepack-cache` in both generated apps.
- `npm run vite-build` in both generated apps; both emitted `remoteEntry.js` without the previous `@/package.json` or shared-alias Module Federation warnings.
- `git diff --check`

## Notes

- `npx esmocha generators/vue --no-insight --forbid-only` still fails on this Windows checkout with existing harness issues: `ERR_UNSUPPORTED_ESM_URL_SCHEME` for `c:` imports plus an `autoCrlf: true` snapshot delta. It reached 891 passing tests before those environment-specific failures.
- `npx vitest --run` in the generated apps still shows existing generated-spec globals missing (`showLogin` / `loginService`), unrelated to the federation switch.
