### PR TITLE
Add Playwright e2e generator foundation

### DIFF
--- a/.blueprint/github-build-matrix/support/git-changes.ts
+++ b/.blueprint/github-build-matrix/support/git-changes.ts
@@ -20,7 +20,7 @@ const patterns = {
   common: ['generators/{app,common,docker,languages}/**'],
   devBlueprint: ['.blueprint/generate-sample/**', '.blueprint/github-build-matrix/**'],
   devserverWorkflow: ['.github/workflows/devserver.yml'],
-  e2e: ['generators/cypress/**'],
+  e2e: ['generators/{cypress,playwright}/**'],
   generateBlueprint: ['generators/{generate-blueprint,javascript-simple-application,ci-cd/generators/bootstrap}/**'],
   graalvm: [
     'generators/java-simple-application/generators/graalvm/**',

--- a/generators/client/command.ts
+++ b/generators/client/command.ts
@@ -24,7 +24,7 @@ import { ALPHANUMERIC_PATTERN } from '../../lib/constants/jdl.ts';
 import { APPLICATION_TYPE_GATEWAY, APPLICATION_TYPE_MICROSERVICE } from '../../lib/core/application-types.ts';
 import { clientFrameworkTypes, testFrameworkTypes } from '../../lib/jhipster/index.ts';
 
-const { CYPRESS } = testFrameworkTypes;
+const { CYPRESS, PLAYWRIGHT } = testFrameworkTypes;
 const { ANGULAR, REACT, VUE, NO: CLIENT_FRAMEWORK_NO } = clientFrameworkTypes;
 
 const microfrontendsToPromptValue = (answer: string | { baseName: string }[]) =>
@@ -164,9 +164,12 @@ const command = {
         when: answers => [ANGULAR, REACT, VUE].includes(answers.clientFramework ?? config.clientFramework),
         type: 'checkbox',
         message: 'Besides Jest/Vitest, which testing frameworks would you like to use?',
-        default: () => intersection([CYPRESS], config.testFrameworks),
+        default: () => intersection([CYPRESS, PLAYWRIGHT], config.testFrameworks),
       }),
-      choices: [{ name: 'Cypress', value: CYPRESS }],
+      choices: [
+        { name: 'Cypress', value: CYPRESS },
+        { name: 'Playwright', value: PLAYWRIGHT },
+      ],
       scope: 'storage',
     },
     withAdminUi: {

--- a/generators/client/generator.spec.ts
+++ b/generators/client/generator.spec.ts
@@ -25,7 +25,7 @@ import { checkEnforcements, shouldSupportFeatures, testBlueprintSupport } from '
 
 import Generator from './index.ts';
 
-const { CYPRESS } = testFrameworkTypes;
+const { CYPRESS, PLAYWRIGHT } = testFrameworkTypes;
 
 const generator = basename(import.meta.dirname);
 
@@ -35,7 +35,7 @@ describe(`generator - ${generator}`, () => {
   checkEnforcements({ client: true }, generator);
 
   describe('composing', () => {
-    const mockedComposedGenerators = ['jhipster:common', 'jhipster:languages', 'jhipster:cypress'];
+    const mockedComposedGenerators = ['jhipster:common', 'jhipster:languages', 'jhipster:cypress', 'jhipster:playwright'];
 
     describe('with translation disabled', () => {
       const options = { enableTranslation: false };
@@ -116,6 +116,28 @@ describe(`generator - ${generator}`, () => {
       });
       it('should compose with jhipster:cypress', () => {
         runResult.assertGeneratorComposedOnce('jhipster:cypress');
+      });
+    });
+
+    describe('with playwright', () => {
+      const options = { testFrameworks: [PLAYWRIGHT] };
+      before(async () => {
+        await helpers
+          .runJHipster(generator)
+          .withSharedApplication({ getWebappTranslation: () => 'translations' })
+          .withJHipsterConfig(options)
+          .withSkipWritingPriorities()
+          .withMockedGenerators(mockedComposedGenerators);
+      });
+
+      it('should compose with jhipster:common', () => {
+        runResult.assertGeneratorComposedOnce('jhipster:common');
+      });
+      it('should compose with jhipster:languages', () => {
+        runResult.assertGeneratorComposedOnce('jhipster:languages');
+      });
+      it('should compose with jhipster:playwright', () => {
+        runResult.assertGeneratorComposedOnce('jhipster:playwright');
       });
     });
   });

--- a/generators/client/generator.ts
+++ b/generators/client/generator.ts
@@ -36,7 +36,7 @@ import type {
 } from './types.d.ts';
 
 const { ANGULAR, NO: CLIENT_FRAMEWORK_NO } = clientFrameworkTypes;
-const { CYPRESS } = testFrameworkTypes;
+const { CYPRESS, PLAYWRIGHT } = testFrameworkTypes;
 
 export class ClientApplicationGenerator<
   Entity extends ClientEntity = ClientEntity,
@@ -118,6 +118,9 @@ export default class ClientGenerator extends ClientApplicationGenerator {
         }
         if (Array.isArray(testFrameworks) && testFrameworks.includes(CYPRESS)) {
           await this.composeWithJHipster('cypress');
+        }
+        if (Array.isArray(testFrameworks) && testFrameworks.includes(PLAYWRIGHT)) {
+          await this.composeWithJHipster('playwright');
         }
       },
     });

--- a/generators/client/prompts.spec.ts
+++ b/generators/client/prompts.spec.ts
@@ -16,7 +16,7 @@ const GENERATOR_APP = 'app';
 const { H2_DISK, MYSQL, SQL } = databaseTypes;
 const { EHCACHE } = cacheTypes;
 const { JWT } = authenticationTypes;
-const { CYPRESS } = testFrameworkTypes;
+const { CYPRESS, PLAYWRIGHT } = testFrameworkTypes;
 const { ANGULAR } = clientFrameworkTypes;
 const { MAVEN } = buildToolTypes;
 
@@ -52,6 +52,37 @@ describe('generator - client - prompts', () => {
 
       it('should write testFrameworks with cypress value to .yo-rc.json', () => {
         runResult.assertJsonFileContent('.yo-rc.json', { 'generator-jhipster': { testFrameworks: [CYPRESS] } });
+      });
+    });
+
+    describe('with playwright value', () => {
+      before(async () => {
+        await helpers
+          .runJHipster(GENERATOR_APP)
+          .withSharedApplication({ getWebappTranslation: () => 'translations' })
+          .withAnswers({
+            baseName: 'sampleMysql',
+            packageName: 'com.mycompany.myapp',
+            applicationType: APPLICATION_TYPE_MONOLITH,
+            databaseType: SQL,
+            devDatabaseType: H2_DISK,
+            prodDatabaseType: MYSQL,
+            cacheProvider: EHCACHE,
+            authenticationType: JWT,
+            enableTranslation: true,
+            nativeLanguage: 'en',
+            languages: ['en', 'fr'],
+            clientTestFrameworks: [PLAYWRIGHT],
+            buildTool: MAVEN,
+            clientFramework: ANGULAR,
+            clientTheme: 'none',
+          })
+          .withSkipWritingPriorities()
+          .withMockedGenerators(mockedComposedGenerators);
+      });
+
+      it('should write testFrameworks with playwright value to .yo-rc.json', () => {
+        runResult.assertJsonFileContent('.yo-rc.json', { 'generator-jhipster': { testFrameworks: [PLAYWRIGHT] } });
       });
     });
   });

--- a/generators/client/resources/package.json
+++ b/generators/client/resources/package.json
@@ -5,12 +5,14 @@
   "devDependencies": {
     "@cypress/code-coverage": "4.0.3",
     "@cypress/schematic": "5.0.0",
+    "@playwright/test": "1.60.0",
     "babel-loader": "10.1.1",
     "babel-plugin-istanbul": "8.0.0",
     "cypress": "15.14.2",
     "cypress-audit": "1.1.0",
     "cypress-monocart-coverage": "1.0.1",
     "eslint-plugin-cypress": "6.4.1",
+    "eslint-plugin-playwright": "2.10.2",
     "lighthouse": "13.3.0",
     "nyc": "18.0.0",
     "swagger-ui-dist": "5.32.5"

--- a/generators/generate-blueprint/internal/lookup-namespaces.spec.ts
+++ b/generators/generate-blueprint/internal/lookup-namespaces.spec.ts
@@ -98,6 +98,7 @@ describe('lookupGeneratorsNamespaces', () => {
   "languages",
   "languages:bootstrap",
   "liquibase",
+  "playwright",
   "project-name",
   "project-name:bootstrap",
   "react",

--- a/generators/playwright/command.ts
+++ b/generators/playwright/command.ts
@@ -16,12 +16,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { JHipsterCommandDefinition } from '../../lib/command/index.ts';
 
-const testFrameworkTypes = {
-  CYPRESS: 'cypress',
-  CUCUMBER: 'cucumber',
-  GATLING: 'gatling',
-  NO: 'no',
-  PLAYWRIGHT: 'playwright',
-} as const;
-export default testFrameworkTypes;
+const command = {
+  configs: {},
+} as const satisfies JHipsterCommandDefinition;
+
+export default command;

--- a/generators/playwright/files.ts
+++ b/generators/playwright/files.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { asWriteFilesSection } from '../base-application/support/task-type-inference.ts';
+import { clientRootTemplatesBlock } from '../client/support/index.ts';
+import { CLIENT_TEST_SRC_DIR } from '../generator-constants.ts';
+
+const PLAYWRIGHT_TEMPLATE_SOURCE_DIR = `${CLIENT_TEST_SRC_DIR}playwright/`;
+
+export const playwrightFiles = asWriteFilesSection({
+  common: [
+    {
+      templates: ['README.md.jhi.playwright'],
+    },
+    clientRootTemplatesBlock({
+      templates: ['playwright.config.ts'],
+    }),
+    clientRootTemplatesBlock({
+      templates: ['eslint.config.ts.jhi.playwright'],
+    }),
+  ],
+  clientTestFw: [
+    {
+      path: PLAYWRIGHT_TEMPLATE_SOURCE_DIR,
+      renameTo: (ctx, file) => `${ctx.playwrightDir}${file}`,
+      templates: ['support/selectors.ts', 'support/login.ts', 'tsconfig.json'],
+    },
+    {
+      condition: generator => !generator.authenticationTypeOauth2,
+      path: PLAYWRIGHT_TEMPLATE_SOURCE_DIR,
+      renameTo: (ctx, file) => `${ctx.playwrightDir}${file}`,
+      templates: ['e2e/account/login-page.spec.ts', 'e2e/account/logout.spec.ts'],
+    },
+  ],
+});

--- a/generators/playwright/generator.spec.ts
+++ b/generators/playwright/generator.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { before, describe, it } from 'esmocha';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { clientFrameworkTypes, testFrameworkTypes } from '../../lib/jhipster/index.ts';
+import { defaultHelpers as helpers, runResult } from '../../lib/testing/index.ts';
+import { checkEnforcements, shouldSupportFeatures, testBlueprintSupport } from '../../test/support/index.ts';
+
+import Generator from './generator.ts';
+
+const { PLAYWRIGHT } = testFrameworkTypes;
+const { ANGULAR } = clientFrameworkTypes;
+
+const generator = basename(import.meta.dirname);
+
+describe(`generator - ${generator}`, () => {
+  shouldSupportFeatures(Generator);
+  describe('blueprint support', () => testBlueprintSupport(generator, { skipSbsBlueprint: true }));
+  checkEnforcements({ client: true }, generator);
+
+  describe('with default client root', () => {
+    before(async () => {
+      await helpers.runJHipster(generator).withJHipsterConfig({
+        authenticationType: 'jwt',
+        clientFramework: ANGULAR,
+        testFrameworks: [PLAYWRIGHT],
+      });
+    });
+
+    it('contains playwright testFramework', () => {
+      runResult.assertJsonFileContent('.yo-rc.json', { 'generator-jhipster': { testFrameworks: [PLAYWRIGHT] } });
+    });
+
+    it('writes Playwright config and account smoke tests', () => {
+      runResult.assertFile([
+        'playwright.config.ts',
+        'src/test/javascript/playwright/e2e/account/login-page.spec.ts',
+        'src/test/javascript/playwright/e2e/account/logout.spec.ts',
+        'src/test/javascript/playwright/support/login.ts',
+        'src/test/javascript/playwright/support/selectors.ts',
+        'src/test/javascript/playwright/tsconfig.json',
+      ]);
+    });
+
+    it('guards the Playwright README fragment sections', () => {
+      const readmeTemplate = readFileSync(join(import.meta.dirname, 'templates/README.md.jhi.playwright.ejs'), 'utf-8');
+      assert.match(readmeTemplate, /fragment\.testingSection/);
+      assert.match(readmeTemplate, /fragment\.referenceSection/);
+    });
+
+    it('guards the Playwright tsconfig root options', () => {
+      const tsconfigTemplate = readFileSync(
+        join(import.meta.dirname, 'templates/src/test/javascript/playwright/tsconfig.json.ejs'),
+        'utf-8',
+      );
+      assert.match(tsconfigTemplate, /clientFrameworkReact/);
+      assert.match(tsconfigTemplate, /"rootDir": null/);
+      assert.match(tsconfigTemplate, /clientFrameworkAngular/);
+      assert.match(tsconfigTemplate, /playwright\/tsc/);
+    });
+
+    it('adds Playwright dependencies and scripts', () => {
+      runResult.assertJsonFileContent('package.json', {
+        devDependencies: {
+          '@playwright/test': 'PLAYWRIGHT_TEST_VERSION',
+          'eslint-plugin-playwright': 'ESLINT_PLUGIN_PLAYWRIGHT_VERSION',
+        },
+        scripts: {
+          playwright: 'playwright test --ui',
+          'e2e:playwright': 'playwright test',
+          'e2e:playwright:devserver': 'playwright test',
+          'e2e:headless': 'npm run e2e:playwright --',
+        },
+      });
+      runResult.assertFileContent('playwright.config.ts', "const devServerBaseURL = 'http://localhost:4200/';");
+      runResult.assertFileContent('playwright.config.ts', "process.env.npm_lifecycle_event === 'e2e:playwright:devserver'");
+    });
+  });
+
+  describe('with oauth2', () => {
+    before(async () => {
+      await helpers.runJHipster(generator).withJHipsterConfig({
+        authenticationType: 'oauth2',
+        clientFramework: ANGULAR,
+        testFrameworks: [PLAYWRIGHT],
+      });
+    });
+
+    it('skips the first-pass account specs', () => {
+      runResult.assertNoFile([
+        'src/test/javascript/playwright/e2e/account/login-page.spec.ts',
+        'src/test/javascript/playwright/e2e/account/logout.spec.ts',
+      ]);
+    });
+  });
+});

--- a/generators/playwright/generator.ts
+++ b/generators/playwright/generator.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { testFrameworkTypes } from '../../lib/jhipster/index.ts';
+import BaseApplicationGenerator from '../base-application/index.ts';
+import type { Source as JavaSource } from '../java/types.d.ts';
+
+import { playwrightFiles } from './files.ts';
+import type {
+  Application as PlaywrightApplication,
+  Config as PlaywrightConfig,
+  Entity as PlaywrightEntity,
+  Features as PlaywrightFeatures,
+  Options as PlaywrightOptions,
+} from './types.ts';
+
+const WAIT_TIMEOUT = 3 * 60000;
+const { CYPRESS } = testFrameworkTypes;
+
+export default class PlaywrightGenerator extends BaseApplicationGenerator<PlaywrightEntity, PlaywrightApplication, PlaywrightConfig> {
+  constructor(args?: string[], options?: PlaywrightOptions, features?: PlaywrightFeatures) {
+    super(args, options, { ...features, loadCommand: ['jhipster:server'] });
+  }
+
+  async beforeQueue() {
+    if (!this.fromBlueprint) {
+      await this.composeWithBlueprints();
+    }
+
+    if (!this.delegateToBlueprint) {
+      await this.dependsOnBootstrap('client');
+    }
+  }
+
+  get preparing() {
+    return this.asPreparingTaskGroup({
+      loadPackageJson({ application }) {
+        this.loadNodeDependenciesFromPackageJson(
+          application.nodeDependencies,
+          this.fetchFromInstalledJHipster('client', 'resources', 'package.json'),
+        );
+      },
+      prepareForTemplates({ applicationDefaults }) {
+        applicationDefaults({
+          playwrightDir: ({ clientTestDir }) => (clientTestDir ? `${clientTestDir}playwright/` : 'playwright/'),
+          playwrightTemporaryDir: ({ temporaryDir }) => (temporaryDir ? `${temporaryDir}playwright/` : '.playwright/'),
+        });
+      },
+      npmScripts({ application }) {
+        const { clientRootDir, devServerPort, devServerPortProxy: devServerPortE2e = devServerPort, testFrameworks = [] } = application;
+        const primaryE2eFramework = !testFrameworks.includes(CYPRESS);
+
+        Object.assign(application.clientPackageJsonScripts, {
+          playwright: 'playwright test --ui',
+          'e2e:playwright': 'playwright test',
+          'e2e:playwright:devserver': 'playwright test',
+          'e2e:playwright:headed': 'playwright test --headed',
+        });
+
+        if (primaryE2eFramework) {
+          Object.assign(application.clientPackageJsonScripts, {
+            e2e: 'npm run e2e:playwright:headed --',
+            'e2e:headless': 'npm run e2e:playwright --',
+          });
+
+          Object.assign(application.packageJsonScripts, {
+            'ci:e2e:run': 'concurrently -k -s first -n application,e2e -c red,blue npm:ci:e2e:server:start npm:e2e:headless',
+            'ci:e2e:dev': 'concurrently -k -s first -n application,e2e -c red,blue npm:app:start npm:e2e:headless',
+            'e2e:dev': 'concurrently -k -s first -n application,e2e -c red,blue npm:app:start npm:e2e',
+            'e2e:devserver': `concurrently -k -s first -n backend,frontend,e2e -c red,yellow,blue npm:backend:start npm:start "wait-on -t ${WAIT_TIMEOUT} http-get://127.0.0.1:${devServerPortE2e} && npm run e2e:playwright:devserver"`,
+          });
+
+          if (clientRootDir) {
+            Object.assign(application.packageJsonScripts, {
+              'e2e:headless': `npm run -w ${clientRootDir} e2e:headless`,
+              'e2e:playwright:devserver': `npm run -w ${clientRootDir} e2e:playwright:devserver`,
+            });
+          } else if (application.backendTypeJavaAny) {
+            Object.assign(application.clientPackageJsonScripts, {
+              'pree2e:headless': 'npm run ci:server:await',
+            });
+          }
+        }
+      },
+    });
+  }
+
+  get [BaseApplicationGenerator.PREPARING]() {
+    return this.delegateTasksToBlueprint(() => this.preparing);
+  }
+
+  get writing() {
+    return this.asWritingTaskGroup({
+      async writeFiles({ application }) {
+        return this.writeFiles({
+          sections: playwrightFiles,
+          context: application,
+        });
+      },
+    });
+  }
+
+  get [BaseApplicationGenerator.WRITING]() {
+    return this.delegateTasksToBlueprint(() => this.writing);
+  }
+
+  get postWriting() {
+    return this.asPostWritingTaskGroup({
+      packageJson({ application }) {
+        const clientPackageJson = this.createStorage(this.destinationPath(application.clientRootDir, 'package.json'));
+        clientPackageJson.merge({
+          devDependencies: {
+            '@playwright/test': application.nodeDependencies['@playwright/test'],
+            'eslint-plugin-playwright': application.nodeDependencies['eslint-plugin-playwright'],
+          },
+          scripts: {
+            playwright: application.clientPackageJsonScripts.playwright,
+            'e2e:playwright': application.clientPackageJsonScripts['e2e:playwright'],
+            'e2e:playwright:devserver': application.clientPackageJsonScripts['e2e:playwright:devserver'],
+            'e2e:playwright:headed': application.clientPackageJsonScripts['e2e:playwright:headed'],
+            ...(application.clientPackageJsonScripts.e2e ? { e2e: application.clientPackageJsonScripts.e2e } : {}),
+            ...(application.clientPackageJsonScripts['e2e:headless'] ?
+              { 'e2e:headless': application.clientPackageJsonScripts['e2e:headless'] }
+            : {}),
+            ...(application.clientPackageJsonScripts['pree2e:headless'] ?
+              { 'pree2e:headless': application.clientPackageJsonScripts['pree2e:headless'] }
+            : {}),
+          },
+        });
+      },
+      mavenProfile({ source }) {
+        (source as JavaSource).addMavenProfile?.({
+          id: 'e2e',
+          content: `
+            <properties>
+                <profile.e2e>,e2e</profile.e2e>
+            </properties>
+            <build>
+                <finalName>e2e</finalName>
+            </build>
+          `,
+        });
+      },
+    });
+  }
+
+  get [BaseApplicationGenerator.POST_WRITING]() {
+    return this.delegateTasksToBlueprint(() => this.postWriting);
+  }
+}

--- a/generators/playwright/index.ts
+++ b/generators/playwright/index.ts
@@ -16,12 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-const testFrameworkTypes = {
-  CYPRESS: 'cypress',
-  CUCUMBER: 'cucumber',
-  GATLING: 'gatling',
-  NO: 'no',
-  PLAYWRIGHT: 'playwright',
-} as const;
-export default testFrameworkTypes;
+export { default } from './generator.ts';
+export { default as command } from './command.ts';
+export type { Application, Config, Entity, Features, Field, Options, Relationship, Source } from './types.ts';

--- a/generators/playwright/templates/README.md.jhi.playwright.ejs
+++ b/generators/playwright/templates/README.md.jhi.playwright.ejs
@@ -1,0 +1,47 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<%#
+ This is a fragment file, it will be merged into the root template if available.
+ EJS fragments will process % delimiter tags in the template and & delimiter tags during the merge process.
+-%>
+<&_ if (fragment.testingSection) { -&>
+#### Playwright end-to-end tests
+
+This application includes a first-pass Playwright end-to-end test setup.
+
+Run the headless suite:
+
+```
+<%- nodePackageManagerCommand %> run e2e:playwright
+```
+
+Run the Playwright UI:
+
+```
+<%- nodePackageManagerCommand %> run playwright
+```
+
+The generated tests use `PLAYWRIGHT_BASE_URL` when it is set.
+Without that override, `<%- nodePackageManagerCommand %> run e2e:playwright` targets the generated backend URL and `<%- nodePackageManagerCommand %> run e2e:devserver` targets the frontend development server.
+The initial coverage focuses on account login/logout smoke flows for JWT and session authentication.
+OAuth2 and generated entity CRUD coverage are intentionally left for a later increment.
+<&_ } -&>
+<&_ if (fragment.referenceSection) { -&>
+- [Playwright](https://playwright.dev/)
+<&_ } -&>

--- a/generators/playwright/templates/eslint.config.ts.jhi.playwright.ejs
+++ b/generators/playwright/templates/eslint.config.ts.jhi.playwright.ejs
@@ -1,0 +1,37 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<&_ if (fragment.importsSection) { -&>
+import playwright from 'eslint-plugin-playwright';
+<&_ } -&>
+<&_ if (fragment.configSection) { -&>
+  {
+    files: ['<%- this.relativeDir(clientRootDir, playwrightDir) %>**/*.ts'],
+    extends: [...tseslint.configs.recommendedTypeChecked, playwright.configs['flat/recommended']],
+    languageOptions: {
+      parserOptions: {
+        project: ['./<%- this.relativeDir(clientRootDir, playwrightDir) %>tsconfig.json'],
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+    },
+  },
+<&_ } -&>

--- a/generators/playwright/templates/playwright.config.ts.ejs
+++ b/generators/playwright/templates/playwright.config.ts.ejs
@@ -1,0 +1,44 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { defineConfig, devices } from '@playwright/test';
+
+const devServerBaseURL = 'http://localhost:<%- devServerPortProxy || devServerPort %>/';
+const serverBaseURL = 'http://localhost:<%- gatewayServerPort || serverPort %>/';
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  (process.env.npm_lifecycle_event === 'e2e:playwright:devserver' ? devServerBaseURL : serverBaseURL);
+
+export default defineConfig({
+  testDir: '<%- this.relativeDir(clientRootDir, playwrightDir) %>e2e',
+  outputDir: '<%- this.relativeDir(clientRootDir, playwrightTemporaryDir) %>test-results',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { outputFolder: '<%- this.relativeDir(clientRootDir, playwrightTemporaryDir) %>report', open: 'never' }]] : 'list',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    viewport: { width: 1200, height: 720 },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/generators/playwright/templates/src/test/javascript/playwright/e2e/account/login-page.spec.ts.ejs
+++ b/generators/playwright/templates/src/test/javascript/playwright/e2e/account/login-page.spec.ts.ejs
@@ -1,0 +1,74 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { expect, type Page, test } from '@playwright/test';
+
+import { credentials } from '../../support/login';
+import {
+  accountMenuSelector,
+  errorLoginSelector,
+  loginItemSelector,
+  logoutItemSelector,
+  passwordLoginSelector,
+  submitLoginSelector,
+  titleLoginSelector,
+  usernameLoginSelector,
+} from '../../support/selectors';
+
+const authenticationUrl = '/api/<% if (authenticationTypeSession) { %>authentication<% } else { %>authenticate<% } %>';
+
+async function openLogin(page: Page) {
+  await page.goto('/');
+  await page.locator(accountMenuSelector).click();
+  await page.locator(loginItemSelector).click();
+}
+
+test.describe('login page', () => {
+  test.beforeEach(async ({ page }) => {
+    await openLogin(page);
+  });
+
+  test('greets with sign in', async ({ page }) => {
+    await expect(page.locator(titleLoginSelector)).toBeVisible();
+  });
+
+  test('errors when password is incorrect', async ({ page }) => {
+    const responsePromise = page.waitForResponse(response => response.url().includes(authenticationUrl) && response.request().method() === 'POST');
+
+    await page.locator(usernameLoginSelector).fill(credentials.username);
+    await page.locator(passwordLoginSelector).fill('bad-password');
+    await page.locator(submitLoginSelector).click();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(401);
+    await expect(page.locator(errorLoginSelector)).toBeVisible();
+  });
+
+  test('goes to home page when successfully logging in', async ({ page }) => {
+    const responsePromise = page.waitForResponse(response => response.url().includes(authenticationUrl) && response.request().method() === 'POST');
+
+    await page.locator(usernameLoginSelector).fill(credentials.username);
+    await page.locator(passwordLoginSelector).fill(credentials.password);
+    await page.locator(submitLoginSelector).click();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+    await page.locator(accountMenuSelector).click();
+    await expect(page.locator(logoutItemSelector)).toBeVisible();
+  });
+});

--- a/generators/playwright/templates/src/test/javascript/playwright/e2e/account/logout.spec.ts.ejs
+++ b/generators/playwright/templates/src/test/javascript/playwright/e2e/account/logout.spec.ts.ejs
@@ -1,0 +1,34 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { expect, test } from '@playwright/test';
+
+import { login } from '../../support/login';
+import { accountMenuSelector, loginItemSelector, logoutItemSelector, navbarSelector } from '../../support/selectors';
+
+test.describe('logout', () => {
+  test('goes to home page when successfully logging out', async ({ page }) => {
+    await login(page);
+
+    await page.locator(accountMenuSelector).click();
+    await page.locator(logoutItemSelector).click();
+
+    await page.locator(navbarSelector).locator(accountMenuSelector).click();
+    await expect(page.locator(navbarSelector).locator(loginItemSelector)).toBeVisible();
+  });
+});

--- a/generators/playwright/templates/src/test/javascript/playwright/support/login.ts.ejs
+++ b/generators/playwright/templates/src/test/javascript/playwright/support/login.ts.ejs
@@ -1,0 +1,54 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { expect, type Page } from '@playwright/test';
+
+export const credentials = {
+  adminUsername: process.env.E2E_USERNAME ?? '<%- defaultAdminUsername %>',
+  adminPassword: process.env.E2E_PASSWORD ?? '<%- defaultAdminPassword %>',
+  username: process.env.E2E_USERNAME ?? '<%- defaultUserUsername %>',
+  password: process.env.E2E_PASSWORD ?? '<%- defaultUserPassword %>',
+};
+
+export async function login(page: Page, username = credentials.username, password = credentials.password) {
+  await page.goto('/');
+<%_ if (authenticationTypeSession) { _%>
+  const response = await page.request.post('/api/authentication', {
+    form: { username, password },
+  });
+<%_ } else { _%>
+  const response = await page.request.post('/api/authenticate', {
+    data: { username, password },
+  });
+<%_ } _%>
+  expect(response.ok()).toBeTruthy();
+<%_ if (authenticationTypeJwt) { _%>
+  const { id_token: token } = await response.json();
+  await page.evaluate(
+    ([storageName, tokenValue]) => {
+  <%_ if (clientFrameworkVue) { _%>
+      sessionStorage.setItem(storageName, tokenValue);
+  <%_ } else { _%>
+      sessionStorage.setItem(storageName, JSON.stringify(tokenValue));
+  <%_ } _%>
+    },
+    ['<%- jhiPrefixDashed %>-authenticationToken', token],
+  );
+<%_ } _%>
+  await page.goto('/');
+}

--- a/generators/playwright/templates/src/test/javascript/playwright/support/selectors.ts.ejs
+++ b/generators/playwright/templates/src/test/javascript/playwright/support/selectors.ts.ejs
@@ -1,0 +1,28 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+export const navbarSelector = '[data-cy="navbar"]';
+export const accountMenuSelector = '[data-cy="accountMenu"]';
+export const loginItemSelector = '[data-cy="login"]';
+export const logoutItemSelector = '[data-cy="logout"]';
+
+export const titleLoginSelector = '[data-cy="loginTitle"]';
+export const errorLoginSelector = '[data-cy="loginError"]';
+export const usernameLoginSelector = '[data-cy="username"]';
+export const passwordLoginSelector = '[data-cy="password"]';
+export const submitLoginSelector = '[data-cy="submit"]';

--- a/generators/playwright/templates/src/test/javascript/playwright/tsconfig.json.ejs
+++ b/generators/playwright/templates/src/test/javascript/playwright/tsconfig.json.ejs
@@ -1,0 +1,42 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+{
+<%_ if (clientFrameworkVue) { _%>
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+<%_ } else { _%>
+  "extends": "<%- this.relativeDir(playwrightDir, clientRootDir) %>tsconfig.json",
+<%_ } _%>
+  "compilerOptions": {
+<%_ if (clientFrameworkVue || clientFrameworkReact) { _%>
+    "ignoreDeprecations": "6.0",
+<%_ } _%>
+    "baseUrl": "./",
+    "sourceMap": false,
+<%_ if (clientFrameworkReact) { _%>
+    "outDir": null,
+    "rootDir": null,
+<%_ } _%>
+<%_ if (clientFrameworkAngular) { _%>
+    "outDir": "<%- this.relativeDir(playwrightDir, temporaryDir) %>playwright/tsc",
+<%_ } _%>
+    "target": "es2018",
+    "types": ["@playwright/test", "node"]
+  },
+  "include": ["./<%- this.relativeDir(playwrightDir, clientRootDir) %>playwright.config.ts", "./**/*.ts"]
+}

--- a/generators/playwright/types.d.ts
+++ b/generators/playwright/types.d.ts
@@ -1,0 +1,24 @@
+import type { CommandTypeMap } from '../../lib/command/index.ts';
+import type {
+  Application as JavascriptApplication,
+  Config as JavascriptConfig,
+  Entity as JavascriptEntity,
+  Options as JavascriptOptions,
+} from '../client/types.ts';
+
+export type { Features, Field, Relationship, Source } from '../client/types.ts';
+import type command from './command.ts';
+
+type Command = CommandTypeMap<typeof command>;
+
+export type Config = JavascriptConfig & Command['Config'];
+
+export type Options = JavascriptOptions & Command['Options'];
+
+export type Entity = JavascriptEntity;
+
+export type Application<E extends Entity = Entity> = JavascriptApplication<E> &
+  Command['Application'] & {
+    playwrightDir: string;
+    playwrightTemporaryDir: string;
+  };

--- a/generators/types.d.ts
+++ b/generators/types.d.ts
@@ -75,6 +75,8 @@ type GeneratorsByNamespace = {
   'jhipster:common:bootstrap': import('./common/generators/bootstrap/generator.ts').default;
   cypress: import('./cypress/generator.ts').default;
   'jhipster:cypress': import('./cypress/generator.ts').default;
+  playwright: import('./playwright/generator.ts').default;
+  'jhipster:playwright': import('./playwright/generator.ts').default;
   docker: import('./docker/generator.ts').default;
   'jhipster:docker': import('./docker/generator.ts').default;
   'docker-compose': import('./docker-compose/generator.ts').default;

--- a/lib/jhipster/application-options.ts
+++ b/lib/jhipster/application-options.ts
@@ -45,7 +45,7 @@ const { CAFFEINE, EHCACHE, HAZELCAST, INFINISPAN, MEMCACHED, REDIS } = cacheType
 
 const NO_CACHE_PROVIDER = cacheTypes.NO;
 
-const { CYPRESS, CUCUMBER, GATLING } = testFrameworkTypes;
+const { CYPRESS, CUCUMBER, GATLING, PLAYWRIGHT } = testFrameworkTypes;
 const { ANGULAR, REACT, VUE, SVELTE, NO } = clientFrameworkTypes;
 const { ELASTICSEARCH } = searchEngineTypes;
 
@@ -220,6 +220,7 @@ export const jhipsterOptionValues = {
     [CYPRESS]: CYPRESS,
     [CUCUMBER]: CUCUMBER,
     [GATLING]: GATLING,
+    [PLAYWRIGHT]: PLAYWRIGHT,
   },
   [optionNames.WEBSOCKET]: {
     [SPRING_WEBSOCKET]: SPRING_WEBSOCKET,

--- a/lib/types/command-all.d.ts
+++ b/lib/types/command-all.d.ts
@@ -13,6 +13,7 @@ import type { Config as JdlBootstrapConfig, Options as JdlBootstrapOptions } fro
 import type { Config as JdlConfig, Options as JdlOptions } from '../../generators/jdl/types.d.ts';
 import type { Config as LanguagesConfig, Options as LanguagesOptions } from '../../generators/languages/types.d.ts';
 import type { Config as LiquibaseConfig, Options as LiquibaseOptions } from '../../generators/liquibase/types.d.ts';
+import type { Config as PlaywrightConfig, Options as PlaywrightOptions } from '../../generators/playwright/types.d.ts';
 import type { Config as ProjectNameConfig, Options as ProjectNameOptions } from '../../generators/project-name/types.d.ts';
 import type { Config as ServerConfig, Options as ServerOptions } from '../../generators/server/types.d.ts';
 import type {
@@ -37,6 +38,7 @@ export type ConfigAll = Simplify<
     JdlConfig &
     LanguagesConfig &
     LiquibaseConfig &
+    PlaywrightConfig &
     ProjectNameConfig &
     ServerConfig &
     SpringBootConfig &
@@ -61,6 +63,7 @@ export type OptionsAll = Simplify<
     JdlOptions &
     LanguagesOptions &
     LiquibaseOptions &
+    PlaywrightOptions &
     ProjectNameOptions &
     ServerOptions &
     SpringBootOptions &


### PR DESCRIPTION
## Summary

Contributes to #13755 (`$$ bug-bounty $$`, `$500`) by adding a first-pass Playwright e2e implementation to generator-jhipster.

This PR adds:
- `playwright` as a selectable client e2e test framework alongside Cypress
- a new `jhipster:playwright` generator
- generated Playwright config, npm scripts, TypeScript config, ESLint fragment, and README notes
- generated JWT/session account login and logout smoke specs using Playwright locators/API helpers
- focused generator coverage for emitted files, package scripts/dependencies, OAuth2 scoping, namespace lookup, prompt, and composition plumbing

## Validation

Passed locally on Windows:
- `npm run check-types`
- `npm run eslint -- generators/playwright generators/client/command.ts generators/client/generator.ts generators/client/generator.spec.ts generators/client/prompts.spec.ts lib/jhipster/test-framework-types.ts lib/jhipster/application-options.ts lib/types/command-all.d.ts generators/types.d.ts`
- `npx esmocha generators/playwright/generator.spec.ts generators/generate-blueprint/internal/lookup-namespaces.spec.ts --forbid-only`
- `npm run build`
- `npm run prettier:check -- generators/playwright generators/client/command.ts generators/client/generator.ts generators/client/generator.spec.ts generators/client/prompts.spec.ts lib/jhipster/test-framework-types.ts lib/jhipster/application-options.ts lib/types/command-all.d.ts generators/types.d.ts .blueprint/github-build-matrix/support/git-changes.ts generators/generate-blueprint/internal/lookup-namespaces.spec.ts`
- `git diff --check`

Notes:
- `generators/client/prompts.spec.ts` and the client composition spec currently hit the existing Windows ESM loader path issue (`Received protocol 'c:'`) before reaching the Playwright assertions. The new Playwright generator spec and typecheck cover the added behavior directly.

## Scope

Intentionally in scope for this first increment:
- generator selection/composition
- runnable Playwright project setup
- account login/logout smoke coverage for JWT and session apps
- lint/type/test coverage for the generator output

Intentionally out of scope for this increment:
- OAuth2 browser flow generation
- generated entity CRUD Playwright specs
- replacing or removing Cypress
- CI provider-specific Playwright wiring