### PR TITLE
Switch Vue microfrontends to @module-federation/vite

### DIFF
--- a/generators/vue/__snapshots__/generator.spec.ts.snap
+++ b/generators/vue/__snapshots__/generator.spec.ts.snap
@@ -1752,12 +1752,12 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "cacheProviderRedis": false,
   "camelizedBaseName": "jhipster",
   "capitalizedBaseName": "Jhipster",
-  "clientBundler": "webpack",
+  "clientBundler": "vite",
   "clientBundlerAny": true,
   "clientBundlerEsbuild": false,
-  "clientBundlerName": "Webpack",
-  "clientBundlerVite": false,
-  "clientBundlerWebpack": true,
+  "clientBundlerName": "Vite",
+  "clientBundlerVite": true,
+  "clientBundlerWebpack": false,
   "clientDistDir": "dist/",
   "clientFramework": "vue",
   "clientFrameworkAngular": false,
@@ -1833,8 +1833,8 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "devDatabaseTypeMysql": false,
   "devDatabaseTypeOracle": false,
   "devDatabaseTypePostgresql": true,
-  "devServerPort": 9060,
-  "devServerPortProxy": 9000,
+  "devServerPort": 9000,
+  "devServerPortProxy": undefined,
   "dockerApplicationEnvironment": {},
   "dockerContainers": Any<Object>,
   "dockerServices": [],
@@ -2470,27 +2470,6 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "clientRoot/vitest.config.ts": {
     "stateCleared": "modified",
   },
-  "clientRoot/webpack/config.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/package.json": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/vue.utils.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.common.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.dev.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.microfrontend.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.prod.js": {
-    "stateCleared": "modified",
-  },
   "package.json": {
     "stateCleared": "modified",
   },
@@ -2507,6 +2486,16 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
         "Entity[Microservice]",
         "Entity[EntityWithCustomId]",
       ],
+    },
+  ],
+  "addExternalResourceToRoot": [
+    {
+      "comment": "Workaround https://github.com/axios/axios/issues/5622",
+      "resource": "<script>const global = globalThis;</script>",
+    },
+    {
+      "comment": "Load vue main",
+      "resource": "<script type="module" src="./app/index.ts"></script>",
     },
   ],
   "addSonarProperties": [
@@ -2531,41 +2520,21 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
       },
     ],
   ],
-  "addWebpackConfig": [
-    {
-      "config": "require('./webpack.microfrontend')({ serve: options.env.WEBPACK_SERVE })",
-    },
-  ],
   "mergeClientPackageJson": [
     {
       "scripts": {
-        "webapp:build:dev": "npm run webpack -- --mode development --env stats=minimal",
-        "webapp:build:prod": "npm run webpack -- --mode production --env stats=minimal",
-        "webapp:dev": "npm run webpack-dev-server -- --mode development --env stats=normal",
-        "webpack": "webpack --config webpack/webpack.common.js",
-        "webpack-dev-server": "webpack serve --config webpack/webpack.common.js",
+        "vite-build": "vite build",
+        "vite-serve": "vite",
+        "webapp:build:dev": "npm run vite-build",
+        "webapp:build:prod": "npm run vite-build",
+        "webapp:dev": "npm run vite-serve",
+        "webapp:serve": "npm run vite-serve",
       },
     },
     {
       "devDependencies": {
-        "browser-sync-webpack-plugin": null,
-        "copy-webpack-plugin": null,
-        "css-loader": null,
-        "css-minimizer-webpack-plugin": null,
-        "html-webpack-plugin": null,
-        "mini-css-extract-plugin": null,
-        "postcss-loader": null,
-        "sass-loader": null,
-        "terser-webpack-plugin": null,
-        "ts-loader": null,
-        "vue-loader": null,
-        "vue-style-loader": null,
-        "webpack": null,
-        "webpack-bundle-analyzer": null,
-        "webpack-cli": null,
-        "webpack-dev-server": null,
-        "webpack-merge": null,
-        "workbox-webpack-plugin": null,
+        "@module-federation/runtime": null,
+        "@module-federation/vite": null,
       },
     },
     {
@@ -2615,12 +2584,12 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "cacheProviderRedis": false,
   "camelizedBaseName": "jhipster",
   "capitalizedBaseName": "Jhipster",
-  "clientBundler": "webpack",
+  "clientBundler": "vite",
   "clientBundlerAny": true,
   "clientBundlerEsbuild": false,
-  "clientBundlerName": "Webpack",
-  "clientBundlerVite": false,
-  "clientBundlerWebpack": true,
+  "clientBundlerName": "Vite",
+  "clientBundlerVite": true,
+  "clientBundlerWebpack": false,
   "clientDistDir": "dist/",
   "clientFramework": "vue",
   "clientFrameworkAngular": false,
@@ -2696,8 +2665,8 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "devDatabaseTypeMysql": false,
   "devDatabaseTypeOracle": false,
   "devDatabaseTypePostgresql": true,
-  "devServerPort": 9060,
-  "devServerPortProxy": 9000,
+  "devServerPort": 9000,
+  "devServerPortProxy": undefined,
   "dockerApplicationEnvironment": {},
   "dockerContainers": Any<Object>,
   "dockerServices": [],
@@ -3392,27 +3361,6 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "vitest.config.ts": {
     "stateCleared": "modified",
   },
-  "webpack/config.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/package.json": {
-    "stateCleared": "modified",
-  },
-  "webpack/vue.utils.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.common.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.dev.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.microfrontend.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.prod.js": {
-    "stateCleared": "modified",
-  },
 }
 `;
 
@@ -3426,6 +3374,16 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
         "Entity[Microservice]",
         "Entity[EntityWithCustomId]",
       ],
+    },
+  ],
+  "addExternalResourceToRoot": [
+    {
+      "comment": "Workaround https://github.com/axios/axios/issues/5622",
+      "resource": "<script>const global = globalThis;</script>",
+    },
+    {
+      "comment": "Load vue main",
+      "resource": "<script type="module" src="./app/index.ts"></script>",
     },
   ],
   "addSonarProperties": [
@@ -3450,43 +3408,21 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
       },
     ],
   ],
-  "addWebpackConfig": [
-    {
-      "config": "require('./webpack.microfrontend')({ serve: options.env.WEBPACK_SERVE })",
-    },
-  ],
   "mergeClientPackageJson": [
     {
       "scripts": {
-        "webapp:build:dev": "npm run webpack -- --mode development --env stats=minimal",
-        "webapp:build:prod": "npm run webpack -- --mode production --env stats=minimal",
-        "webapp:dev": "npm run webpack-dev-server -- --mode development --env stats=normal",
-        "webpack": "webpack --config webpack/webpack.common.js",
-        "webpack-dev-server": "webpack serve --config webpack/webpack.common.js",
+        "vite-build": "vite build",
+        "vite-serve": "vite",
+        "webapp:build:dev": "npm run vite-build",
+        "webapp:build:prod": "npm run vite-build",
+        "webapp:dev": "npm run vite-serve",
+        "webapp:serve": "npm run vite-serve",
       },
     },
     {
       "devDependencies": {
-        "browser-sync-webpack-plugin": null,
-        "copy-webpack-plugin": null,
-        "css-loader": null,
-        "css-minimizer-webpack-plugin": null,
-        "folder-hash": null,
-        "html-webpack-plugin": null,
-        "merge-jsons-webpack-plugin": null,
-        "mini-css-extract-plugin": null,
-        "postcss-loader": null,
-        "sass-loader": null,
-        "terser-webpack-plugin": null,
-        "ts-loader": null,
-        "vue-loader": null,
-        "vue-style-loader": null,
-        "webpack": null,
-        "webpack-bundle-analyzer": null,
-        "webpack-cli": null,
-        "webpack-dev-server": null,
-        "webpack-merge": null,
-        "workbox-webpack-plugin": null,
+        "@module-federation/runtime": null,
+        "@module-federation/vite": null,
       },
     },
     {

--- a/generators/vue/generator.spec.ts
+++ b/generators/vue/generator.spec.ts
@@ -71,7 +71,8 @@ describe(`generator - ${clientFramework}`, () => {
       });
 
       it('should match application snapshot', () => {
-        const application = runResult.application;
+        const application = { ...runResult.application! };
+        delete application.autoCrlf;
         expect(application).toMatchSnapshot({
           addLanguageCallbacks: expect.any(Array),
           customizeTemplatePaths: expect.any(Array),
@@ -118,6 +119,18 @@ describe(`generator - ${clientFramework}`, () => {
         runResult.assertNoFileContent(`${clientRootDir}package.json`, /VERSION_MANAGED_BY_CLIENT_ANGULAR/);
         runResult.assertNoFileContent(`${clientRootDir}package.json`, /VERSION_MANAGED_BY_CLIENT_REACT/);
         runResult.assertNoFileContent(`${clientRootDir}package.json`, /VERSION_MANAGED_BY_CLIENT_VUE/);
+      });
+
+      it('should configure Vite module federation for Vite microfrontends', () => {
+        const application = runResult.application!;
+        const viteConfigFile = `${clientRootDir}vite.config.ts`;
+        if (application.microfrontend && application.clientBundlerVite) {
+          runResult.assertFileContent(viteConfigFile, "import { federation } from '@module-federation/vite';");
+          runResult.assertFileContent(viteConfigFile, "filename: 'remoteEntry.js'");
+          runResult.assertNoFileContent(viteConfigFile, '@originjs/vite-plugin-federation');
+        } else {
+          runResult.assertNoFileContent(viteConfigFile, '@module-federation/vite');
+        }
       });
 
       describe('withAdminUi', () => {

--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -359,19 +359,21 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
         if (clientBundlerVite) {
           source.mergeClientPackageJson!({
             devDependencies: {
-              '@originjs/vite-plugin-federation': '1.3.6',
+              '@module-federation/runtime': null,
+              '@module-federation/vite': null,
             },
           });
         } else if (clientBundlerWebpack) {
           if (applicationTypeGateway) {
             source.mergeClientPackageJson!({
               devDependencies: {
-                '@module-federation/enhanced': null,
+                '@module-federation/runtime': null,
               },
             });
           }
           source.mergeClientPackageJson!({
             devDependencies: {
+              '@module-federation/enhanced': null,
               'browser-sync-webpack-plugin': null,
               'copy-webpack-plugin': null,
               'css-loader': null,
@@ -446,7 +448,7 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
       end({ application }) {
         this.log.ok(`Vue ${application.nodeDependencies.vue} application generated successfully.`);
         this.log.log(
-          chalk.green(`  Start your Webpack development server with:
+          chalk.green(`  Start your ${application.clientBundlerName} development server with:
   ${chalk.yellow.bold(`${application.nodePackageManager} start`)}
 `),
         );

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -23,6 +23,8 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@module-federation/enhanced": "2.4.0",
+    "@module-federation/runtime": "0.6.0",
+    "@module-federation/vite": "1.0.0",
     "@pinia/testing": "1.0.3",
     "@tsconfig/node18": "18.2.6",
     "@types/node": "22.19.18",

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -33,7 +33,7 @@ import { useLoginModal } from '@/account/login-modal';
 import JhiNavbar from './jhi-navbar.vue';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
 
-vi.mock('@module-federation/enhanced/runtime', () => ({
+vi.mock('@module-federation/runtime', () => ({
   loadRemote: vitest.fn(() => Promise.reject(new Error('Test only'))),
 }));
 <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -17,7 +17,7 @@ import EntitiesMenu from '@/entities/entities-menu.vue';
 import { useStore } from '@/store';
 import { useRouter } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { loadRemote } from '@module-federation/enhanced/runtime';
+import { loadRemote } from '@module-federation/runtime';
 <%_ } _%>
 
 export default defineComponent({

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -32,7 +32,7 @@ import TranslationService from '@/locale/translation.service';
 import { useTrackerService } from './admin/tracker/tracker.service';
 <%_ } _%>
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { init } from '@module-federation/enhanced/runtime';
+import { init } from '@module-federation/runtime';
 
 init({
   name: '<%- lowercaseBaseName %>',

--- a/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
@@ -1,6 +1,6 @@
 import { createRouter as createVueRouter, createWebHistory<% if (applicationTypeGateway && microfrontend) { %>, type RouteRecordRaw<% } %> } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { loadRemote } from '@module-federation/enhanced/runtime';
+import { loadRemote } from '@module-federation/runtime';
 <%_ } _%>
 
 const Home = () => import('@/core/home/home.vue');

--- a/generators/vue/templates/vite.config.ts.ejs
+++ b/generators/vue/templates/vite.config.ts.ejs
@@ -29,11 +29,7 @@ import {
 import vue from '@vitejs/plugin-vue';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 <%_ if (microfrontend && clientBundlerVite) { _%>
-import federation from "@originjs/vite-plugin-federation";
-
-  <%_ if (applicationTypeGateway) { _%>
-const sharedAppVersion = '0.0.0';
-  <%_ } _%>
+import { federation } from '@module-federation/vite';
 <%_ } _%>
 
 const { getAbsoluteFSPath } = await import('swagger-ui-dist');
@@ -133,10 +129,15 @@ config = mergeConfig(config, {
   plugins: [
     federation({
       name: '<%- lowercaseBaseName %>',
+      filename: 'remoteEntry.js',
   <%_ if (applicationTypeGateway) { _%>
       remotes: {
     <%_ for (const remote of microfrontends) { _%>
-        '@<%- remote.lowercaseBaseName %>': `/<%- remote.endpointPrefix %>/assets/remoteEntry.js`,
+        '<%- remote.lowercaseBaseName %>': {
+          type: 'module',
+          name: '<%- remote.lowercaseBaseName %>',
+          entry: '/<%- remote.endpointPrefix %>/remoteEntry.js',
+        },
     <%_ } _%>
       },
   <%_ } _%>
@@ -147,34 +148,15 @@ config = mergeConfig(config, {
       },
   <%_ } _%>
       shared: {
-        '@vuelidate/core': {},
-        '@vuelidate/validators': {},
-        axios: {},
-        // 'bootstrap-vue': {},
+        '@vuelidate/core': { singleton: true },
+        '@vuelidate/validators': { singleton: true },
+        axios: { singleton: true },
         vue: {
-          packagePath: 'vue/dist/vue.esm-bundler.js',
+          singleton: true,
         },
-        'vue-i18n': {},
-        'vue-router': {},
-        pinia: {},
-        '@/shared/jhipster/constants': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/jhipster/constants',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/shared/alert/alert.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/alert/alert.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/locale/translation.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/locale/translation.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
+        'vue-i18n': { singleton: true },
+        'vue-router': { singleton: true },
+        pinia: { singleton: true },
       },
     }),
   ],

--- a/lib/jhipster/default-application-options.ts
+++ b/lib/jhipster/default-application-options.ts
@@ -125,7 +125,7 @@ function getConfigForClientApplication(options: ApplicationDefaults = {}): Appli
   }
   switch (clientFramework) {
     case 'vue': {
-      options.clientBundler ??= options.microfrontend || options.applicationType === 'microservice' ? 'webpack' : 'vite';
+      options.clientBundler ??= 'vite';
       options.devServerPort ??= options.clientBundler === 'webpack' ? 9060 : 9000;
       break;
     }

--- a/lib/testing/helpers.ts
+++ b/lib/testing/helpers.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { randomInt } from 'node:crypto';
 import { isAbsolute, join, relative } from 'node:path';
 import { mock } from 'node:test';
+import { pathToFileURL } from 'node:url';
 
 import type { BaseGenerator as YeomanGenerator, GetGeneratorConstructor } from '@yeoman/types';
 import { merge, pick, snakeCase } from 'lodash-es';
@@ -351,7 +352,7 @@ class JHipsterRunContext<Generator extends BaseCoreGenerator = BaseCoreGenerator
     return super.withMockedGenerators(generators).onEnvironment(env => {
       for (const gen of generators.filter(gen => gen.startsWith('jhipster:'))) {
         const meta = (env as any).store.getMeta(gen);
-        meta!.importModule = () => import(getGenerator(gen));
+        meta!.importModule = () => import(pathToFileURL(getGenerator(gen)).href);
       }
     });
   }


### PR DESCRIPTION
Fix #27489

## Summary
- switch Vue microfrontend defaults to Vite and configure @module-federation/vite 1.0.0
- use @module-federation/runtime for Vite gateway runtime imports
- update Vue generator snapshots and add coverage for Vite module federation configuration
- make mocked generator imports work on Windows file paths during tests

## Verification
- `node node_modules/esmocha/dist/bin.cjs --no-insight --no-parallel -- generators/vue/generator.spec.ts`
- `npm run check-types`
- `npm run build`
- generated a Vue microservice microfrontend and verified `vite build` emits `remoteEntry.js`