### PR TITLE
add moduleFederationName property without dashes

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/app.routes.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/app.routes.ts.ejs
@@ -69,8 +69,8 @@ const routes: Routes = [
 <%_ if (applicationTypeGateway && microfrontend) { _%>
   <%_ for (const remote of microfrontends) { _%>
   {
-    path: '<%- remote.lowercaseBaseName %>',
-    loadChildren: () => loadEntityRoutes('<%- remote.lowercaseBaseName %>'),
+    path: '<%- remote.moduleFederationName %>',
+    loadChildren: () => loadEntityRoutes('<%- remote.moduleFederationName %>'),
   },
   <%_ } _%>
 <%_ } _%>

--- a/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.html.ejs
@@ -64,12 +64,12 @@
             <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
 <%_ if (applicationTypeGateway && microfrontend) { _%>
   <%_ for (const remote of microfrontends) { _%>
-          @if (<%- remote.lowercaseBaseName %>EntityNavbarItems().length === 0) {
+          @if (<%- remote.moduleFederationName %>EntityNavbarItems().length === 0) {
             <li>
-              <span class="dropdown-item">Failed to load <%- remote.lowercaseBaseName %> entities</span>
+              <span class="dropdown-item">Failed to load <%- remote.moduleFederationName %> entities</span>
             </li>
           }
-          @for (entityNavbarItem of <%- remote.lowercaseBaseName %>EntityNavbarItems(); track $index) {
+          @for (entityNavbarItem of <%- remote.moduleFederationName %>EntityNavbarItems(); track $index) {
             <li>
               <a
                 class="dropdown-item"

--- a/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.ts.ejs
@@ -79,7 +79,7 @@ export default class Navbar implements OnInit {
   readonly account = inject(AccountService).account;
 <%_ if (applicationTypeGateway && microfrontend) { _%>
   <%_ for (const remote of microfrontends) { _%>
-  <%- remote.lowercaseBaseName %>EntityNavbarItems = signal<NavbarItem[]>([]);
+  <%- remote.moduleFederationName %>EntityNavbarItems = signal<NavbarItem[]>([]);
   <%_ } _%>
 <%_ } _%>
 
@@ -151,22 +151,22 @@ export default class Navbar implements OnInit {
   loadMicrofrontendsEntities(): void {
     // Lazy load microfrontend entities.
   <%_ for (const remote of microfrontends) { _%>
-    loadNavbarItems('<%- remote.lowercaseBaseName %>').then(
+    loadNavbarItems('<%- remote.moduleFederationName %>').then(
       async items => {
-        this.<%- remote.lowercaseBaseName %>EntityNavbarItems.set(items);
+        this.<%- remote.moduleFederationName %>EntityNavbarItems.set(items);
     <%_ if (enableTranslation && applicationTypeGateway) { _%>
         try {
-          const LazyTranslationModule = await loadTranslationModule('<%- remote.lowercaseBaseName %>');
+          const LazyTranslationModule = await loadTranslationModule('<%- remote.moduleFederationName %>');
           createNgModule(LazyTranslationModule, this.injector);
         } catch (error) {
           // eslint-disable-next-line no-console
-          console.log('Error loading <%- remote.lowercaseBaseName %> translation module', error);
+          console.log('Error loading <%- remote.moduleFederationName %> translation module', error);
         }
     <%_ } _%>
       },
       (error: unknown) => {
         // eslint-disable-next-line no-console
-        console.log('Error loading <%- remote.lowercaseBaseName %> entities', error);
+        console.log('Error loading <%- remote.moduleFederationName %> entities', error);
       }
     );
   <%_ } _%>

--- a/generators/base-application/generators/bootstrap/generator.ts
+++ b/generators/base-application/generators/bootstrap/generator.ts
@@ -133,6 +133,7 @@ export default class BootstrapBaseApplicationGenerator extends BaseApplicationGe
             const { baseName } = microfrontend;
             mutateData(microfrontend, {
               lowercaseBaseName: baseName.toLowerCase(),
+              moduleFederationName: ({ lowercaseBaseName }) => lowercaseBaseName.replaceAll('-', '_'),
               capitalizedBaseName: upperFirst(baseName),
               endpointPrefix: `services/${baseName.toLowerCase()}`,
             });

--- a/generators/base-application/types.d.ts
+++ b/generators/base-application/types.d.ts
@@ -32,7 +32,13 @@ type MicroservicesArchitectureApplication = {
 };
 
 type GatewayApplication = MicroservicesArchitectureApplication & {
-  microfrontends: { baseName: string; lowercaseBaseName?: string; capitalizedBaseName?: string; endpointPrefix?: string }[];
+  microfrontends: {
+    baseName: string;
+    lowercaseBaseName: string;
+    moduleFederationName: string;
+    capitalizedBaseName: string;
+    endpointPrefix: string;
+  }[];
 };
 
 /*

--- a/generators/react/templates/src/main/webapp/app/routes.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/routes.tsx.ejs
@@ -56,8 +56,8 @@ const Admin = React.lazy(() => import(/* webpackChunkName: "administration" */ '
 
   <%_ for (const remote of microfrontends) { _%>
 const <%- remote.capitalizedBaseName %>Routes = React.lazy(() => importRemote<any>({
-  url: `./services/<%- remote.lowercaseBaseName %>`,
-  scope: '<%- remote.lowercaseBaseName %>',
+  url: `./services/<%- remote.moduleFederationName %>`,
+  scope: '<%- remote.moduleFederationName %>',
   module: './entities-routes',
 }).catch(() => import('app/shared/error/error-loading')));
 
@@ -111,7 +111,7 @@ const AppRoutes = () => {
 <%_ if (applicationTypeGateway && microfrontend) { _%>
   <%_ for (const remote of microfrontends) { _%>
           <Route
-            path="<%- remote.lowercaseBaseName %>/*"
+            path="<%- remote.moduleFederationName %>/*"
             element={
               <PrivateRoute hasAnyAuthorities={[Authority.USER]}>
                 <<%- remote.capitalizedBaseName %>Routes />

--- a/generators/react/templates/src/main/webapp/app/shared/layout/menus/entities.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/shared/layout/menus/entities.tsx.ejs
@@ -29,8 +29,8 @@ const EntitiesMenuItems = React.lazy(() => import('app/entities/menu').catch(() 
   <%_ if (applicationTypeGateway) { _%>
     <%_ for (const remote of microfrontends) { _%>
 const <%- remote.capitalizedBaseName %>EntitiesMenuItems = React.lazy(async () => importRemote<any>({
-  url: `./services/<%- remote.lowercaseBaseName %>`,
-  scope: '<%- remote.lowercaseBaseName %>',
+  url: `./services/<%- remote.moduleFederationName %>`,
+  scope: '<%- remote.moduleFederationName %>',
   module: './entities-menu',
 }).catch(() => import('app/shared/error/error-loading')));
 

--- a/generators/react/templates/src/main/webapp/app/typings.d.ts.ejs
+++ b/generators/react/templates/src/main/webapp/app/typings.d.ts.ejs
@@ -40,12 +40,12 @@ declare module '*.css' {
 <%_ if (applicationTypeGateway && microfrontend) { _%>
   <%_ for (const remote of microfrontends) { _%>
 
-declare module '@<%- remote.lowercaseBaseName %>/entities-routes' {
+declare module '@<%- remote.moduleFederationName %>/entities-routes' {
   const _default: () => import('react').React.JSX.Element;
   export default _default;
 }
 
-declare module '@<%- remote.lowercaseBaseName %>/entities-menu' {
+declare module '@<%- remote.moduleFederationName %>/entities-menu' {
   const _default: () => import('react').React.JSX.Element;
   export default _default;
 }

--- a/generators/vue/templates/module-federation.config.cjs.ejs
+++ b/generators/vue/templates/module-federation.config.cjs.ejs
@@ -33,7 +33,7 @@ const shareDependencies = ({ skipList = [] } = {}) =>
 
 /** @type {import('@module-federation/runtime').Options} */
 module.exports = {
-  name: '<%- lowercaseBaseName %>',
+  name: '<%- lowercaseBaseName.replaceAll('-', '_') %>',
 <%_ if (applicationTypeMicroservice) { _%>
   exposes: {
     './entities-router': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/router/entities.ts',

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -26,8 +26,8 @@ export default defineComponent({
     'entities-menu': EntitiesMenu,
 <%_ if (applicationTypeGateway && microfrontend) { _%>
   <%_ for (const remote of microfrontends) { _%>
-    '<%- remote.lowercaseBaseName %>-menu': defineAsyncComponent(() => {
-      return loadRemote<any>('<%- remote.lowercaseBaseName %>/entities-menu')
+    '<%- remote.moduleFederationName %>-menu': defineAsyncComponent(() => {
+      return loadRemote<any>('<%- remote.moduleFederationName %>/entities-menu')
         .catch(() => import('@/core/error/error-loading.vue'));
     }),
   <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/declarations.d.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/declarations.d.ts.ejs
@@ -25,17 +25,3 @@ declare const APP_VERSION: string;
 <%_ if (enableTranslation) { _%>
 declare const I18N_HASH: string;
 <%_ } _%>
-<%_ if (applicationTypeGateway && microfrontend) { _%>
-  <%_ for (const remote of microfrontends) { _%>
-
-declare module '@<%- remote.lowercaseBaseName %>/entities-router' {
-  const _default: unknown;
-  export default _default;
-}
-
-declare module '@<%- remote.lowercaseBaseName %>/entities-menu' {
-  const _default: unknown;
-  export default _default;
-}
-  <%_ } _%>
-<%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -39,7 +39,7 @@ init({
   remotes: [
   <%_ for (const remote of microfrontends) { _%>
     {
-      name: '<%- remote.lowercaseBaseName %>',
+      name: '<%- remote.moduleFederationName %>',
       entry: '/<%- remote.endpointPrefix %>/remoteEntry.js',
     },
   <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
@@ -12,7 +12,7 @@ import admin from '@/router/admin';
 import entities from '@/router/entities';
 import pages from '@/router/pages';
 
-export const createRouter = () =>   createVueRouter({
+export const createRouter = () => createVueRouter({
   history: createWebHistory(),
   routes: [
     {
@@ -46,12 +46,12 @@ const router = createRouter();
 <%_ if (applicationTypeGateway && microfrontend) { _%>
 export const lazyRoutes = Promise.all([
   <%_ for (const remote of microfrontends) { _%>
-  loadRemote<any>('<%- remote.lowercaseBaseName %>/entities-router')
-    .then(<%- remote.lowercaseBaseName %>Router => {
-      router.addRoute(<%- remote.lowercaseBaseName %>Router.default as RouteRecordRaw);
-      return <%- remote.lowercaseBaseName %>Router.default;
+  loadRemote<any>('<%- remote.moduleFederationName %>/entities-router')
+    .then(<%- remote.moduleFederationName %>Router => {
+      router.addRoute(<%- remote.moduleFederationName %>Router.default as RouteRecordRaw);
+      return <%- remote.moduleFederationName %>Router.default;
     }).catch(error => {
-      console.log(`Error loading <%- remote.lowercaseBaseName %> menus. Make sure it's up. ${error}`);
+      console.log(`Error loading <%- remote.moduleFederationName %> menus. Make sure it's up. ${error}`);
     }),
   <%_ } _%>
 ]);


### PR DESCRIPTION
Module federation is not compatible with names with dashes
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
