### PR TITLE
cypress: add cypress-terminal-report

### DIFF
--- a/generators/cypress/generator.ts
+++ b/generators/cypress/generator.ts
@@ -253,6 +253,7 @@ export default class CypressGenerator extends BaseApplicationGenerator<CypressEn
         clientPackageJson.merge({
           devDependencies: {
             cypress: application.nodeDependencies.cypress,
+            'cypress-terminal-report': null,
             'eslint-plugin-cypress': application.nodeDependencies['eslint-plugin-cypress'],
           },
         });

--- a/generators/cypress/resources/package.json
+++ b/generators/cypress/resources/package.json
@@ -7,6 +7,7 @@
     "cypress": "15.15.0",
     "cypress-audit": "1.1.0",
     "cypress-monocart-coverage": "1.0.1",
+    "cypress-terminal-report": "7.3.3",
     "eslint-plugin-cypress": "6.4.1",
     "lighthouse": "13.3.0",
     "nyc": "18.0.0"

--- a/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
@@ -28,6 +28,7 @@
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
+import installLogsPrinter from "cypress-terminal-report/src/installLogsPrinter";
 <%_ if (cypressAudit) { _%>
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { pa11y, prepareAudit } from 'cypress-audit';
@@ -36,6 +37,7 @@ const VALID_CATEGORIES = new Set(['performance', 'accessibility', 'best-practice
 <%_ } _%>
 
 export default <% if (cypressCoverage) { %>async <% } %>(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
+  installLogsPrinter(on);
   on('before:browser:launch', (browser, launchOptions) => {
 <%_ if (cypressAudit) { _%>
     prepareAudit(launchOptions);

--- a/generators/cypress/templates/src/test/javascript/cypress/support/index.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/support/index.ts.ejs
@@ -51,3 +51,6 @@ import './management';
 <%_ if (authenticationTypeOauth2) { _%>
 import './oauth2';
 <%_ } _%>
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
+
+installLogsCollector()


### PR DESCRIPTION
It prints cypress logs on error. See https://www.npmjs.com/package/cypress-terminal-report
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
