### PR TITLE
Switch Vue microfrontends from @originjs/vite-plugin-federation to @module-federation/vite (Fix #27489)

### DIFF
--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -360,7 +360,7 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
         if (clientBundlerVite) {
           source.mergeClientPackageJson!({
             devDependencies: {
-              '@originjs/vite-plugin-federation': '1.3.6',
+              '@module-federation/vite': '1.0.0',
             },
           });
         } else if (clientBundlerWebpack) {

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@module-federation/enhanced": "2.4.0",
+    "@module-federation/vite": "1.0.0",
     "@pinia/testing": "1.0.3",
     "@tsconfig/node18": "18.2.6",
     "@types/node": "22.19.19",

--- a/generators/vue/templates/vite.config.ts.ejs
+++ b/generators/vue/templates/vite.config.ts.ejs
@@ -29,7 +29,7 @@ import {
 import vue from '@vitejs/plugin-vue';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 <%_ if (microfrontend && clientBundlerVite) { _%>
-import federation from "@originjs/vite-plugin-federation";
+import { ModuleFederationPlugin } from '@module-federation/vite';
 
   <%_ if (applicationTypeGateway) { _%>
 const sharedAppVersion = '0.0.0';
@@ -130,7 +130,7 @@ config = mergeConfig(config, {
     target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
   },
   plugins: [
-    federation({
+    ModuleFederationPlugin({
       name: '<%- lowercaseBaseName %>',
   <%_ if (applicationTypeGateway) { _%>
       remotes: {
@@ -145,11 +145,12 @@ config = mergeConfig(config, {
         './entities-menu': './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/entities/entities-menu.vue',
       },
   <%_ } _%>
+      filename: 'remoteEntry.js',
+      shareScope: 'default',
       shared: {
         '@vuelidate/core': {},
         '@vuelidate/validators': {},
         axios: {},
-        // 'bootstrap-vue': {},
         vue: {
           packagePath: 'vue/dist/vue.esm-bundler.js',
         },


### PR DESCRIPTION
This PR replaces `@originjs/vite-plugin-federation` with the official `@module-federation/vite` plugin (v1.0.0) for Vue microfrontend builds. Fixes #27489.

## Changes

- **generator.ts** — `addMicrofrontendDependencies()` now adds `@module-federation/vite: 1.0.0` instead of `@originjs/vite-plugin-federation: 1.3.6`
- **vite.config.ts.ejs** — imports `ModuleFederationPlugin` from `@module-federation/vite`, with `filename` and `shareScope` config for full compatibility with the existing `@module-federation/runtime`
- **resources/package.json** — adds `@module-federation/vite: 1.0.0` to canonical dependencies

## Compatibility

- Uses the same runtime (`@module-federation/enhanced/runtime`) as the existing webpack microfrontend path — `loadRemote` and `registerRemotes` in main.ts, router, navbar, and translation service work unchanged
- The `module-federation.config.cjs` shared config is unaffected

## $100 bug bounty claim per https://www.jhipster.tech/bug-bounties/