### PR TITLE
fix: switch Vue microfrontends to @module-federation/vite@1.0.0 (Fixes #27489)

### DIFF
--- a/generators/vue/__snapshots__/generator.spec.ts.snap
+++ b/generators/vue/__snapshots__/generator.spec.ts.snap
@@ -1752,12 +1752,12 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "cacheProviderRedis": false,
   "camelizedBaseName": "jhipster",
   "capitalizedBaseName": "Jhipster",
-  "clientBundler": "webpack",
+  "clientBundler": "vite",
   "clientBundlerAny": true,
   "clientBundlerEsbuild": false,
-  "clientBundlerName": "Webpack",
-  "clientBundlerVite": false,
-  "clientBundlerWebpack": true,
+  "clientBundlerName": "Vite",
+  "clientBundlerVite": true,
+  "clientBundlerWebpack": false,
   "clientDistDir": "dist/",
   "clientFramework": "vue",
   "clientFrameworkAngular": false,
@@ -1833,8 +1833,8 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "devDatabaseTypeMysql": false,
   "devDatabaseTypeOracle": false,
   "devDatabaseTypePostgresql": true,
-  "devServerPort": 9060,
-  "devServerPortProxy": 9000,
+  "devServerPort": 9000,
+  "devServerPortProxy": undefined,
   "dockerApplicationEnvironment": {},
   "dockerContainers": Any<Object>,
   "dockerServices": [],
@@ -2467,27 +2467,6 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
   "clientRoot/vitest.config.ts": {
     "stateCleared": "modified",
   },
-  "clientRoot/webpack/config.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/package.json": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/vue.utils.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.common.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.dev.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.microfrontend.js": {
-    "stateCleared": "modified",
-  },
-  "clientRoot/webpack/webpack.prod.js": {
-    "stateCleared": "modified",
-  },
   "package.json": {
     "stateCleared": "modified",
   },
@@ -2504,6 +2483,16 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
         "Entity[Microservice]",
         "Entity[EntityWithCustomId]",
       ],
+    },
+  ],
+  "addExternalResourceToRoot": [
+    {
+      "comment": "Workaround https://github.com/axios/axios/issues/5622",
+      "resource": "<script>const global = globalThis;</script>",
+    },
+    {
+      "comment": "Load vue main",
+      "resource": "<script type="module" src="./app/index.ts"></script>",
     },
   ],
   "addSonarProperties": [
@@ -2528,42 +2517,21 @@ exports[`generator - vue microservice-jwt-skipUserManagement(false)-withAdminUi(
       },
     ],
   ],
-  "addWebpackConfig": [
-    {
-      "config": "require('./webpack.microfrontend')({ serve: options.env.WEBPACK_SERVE })",
-    },
-  ],
   "mergeClientPackageJson": [
     {
       "scripts": {
-        "webapp:build:dev": "npm run webpack -- --mode development --env stats=minimal",
-        "webapp:build:prod": "npm run webpack -- --mode production --env stats=minimal",
-        "webapp:dev": "npm run webpack-dev-server -- --mode development --env stats=normal",
-        "webpack": "webpack --config webpack/webpack.common.js",
-        "webpack-dev-server": "webpack serve --config webpack/webpack.common.js",
+        "vite-build": "vite build",
+        "vite-serve": "vite",
+        "webapp:build:dev": "npm run vite-build",
+        "webapp:build:prod": "npm run vite-build",
+        "webapp:dev": "npm run vite-serve",
+        "webapp:serve": "npm run vite-serve",
       },
     },
     {
       "devDependencies": {
-        "@module-federation/enhanced": null,
-        "browser-sync-webpack-plugin": null,
-        "copy-webpack-plugin": null,
-        "css-loader": null,
-        "css-minimizer-webpack-plugin": null,
-        "html-webpack-plugin": null,
-        "mini-css-extract-plugin": null,
-        "postcss-loader": null,
-        "sass-loader": null,
-        "terser-webpack-plugin": null,
-        "ts-loader": null,
-        "vue-loader": null,
-        "vue-style-loader": null,
-        "webpack": null,
-        "webpack-bundle-analyzer": null,
-        "webpack-cli": null,
-        "webpack-dev-server": null,
-        "webpack-merge": null,
-        "workbox-webpack-plugin": null,
+        "@module-federation/runtime": null,
+        "@module-federation/vite": null,
       },
     },
     {
@@ -2613,12 +2581,12 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "cacheProviderRedis": false,
   "camelizedBaseName": "jhipster",
   "capitalizedBaseName": "Jhipster",
-  "clientBundler": "webpack",
+  "clientBundler": "vite",
   "clientBundlerAny": true,
   "clientBundlerEsbuild": false,
-  "clientBundlerName": "Webpack",
-  "clientBundlerVite": false,
-  "clientBundlerWebpack": true,
+  "clientBundlerName": "Vite",
+  "clientBundlerVite": true,
+  "clientBundlerWebpack": false,
   "clientDistDir": "dist/",
   "clientFramework": "vue",
   "clientFrameworkAngular": false,
@@ -2694,8 +2662,8 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "devDatabaseTypeMysql": false,
   "devDatabaseTypeOracle": false,
   "devDatabaseTypePostgresql": true,
-  "devServerPort": 9060,
-  "devServerPortProxy": 9000,
+  "devServerPort": 9000,
+  "devServerPortProxy": undefined,
   "dockerApplicationEnvironment": {},
   "dockerContainers": Any<Object>,
   "dockerServices": [],
@@ -3387,27 +3355,6 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
   "vitest.config.ts": {
     "stateCleared": "modified",
   },
-  "webpack/config.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/package.json": {
-    "stateCleared": "modified",
-  },
-  "webpack/vue.utils.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.common.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.dev.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.microfrontend.js": {
-    "stateCleared": "modified",
-  },
-  "webpack/webpack.prod.js": {
-    "stateCleared": "modified",
-  },
 }
 `;
 
@@ -3421,6 +3368,16 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
         "Entity[Microservice]",
         "Entity[EntityWithCustomId]",
       ],
+    },
+  ],
+  "addExternalResourceToRoot": [
+    {
+      "comment": "Workaround https://github.com/axios/axios/issues/5622",
+      "resource": "<script>const global = globalThis;</script>",
+    },
+    {
+      "comment": "Load vue main",
+      "resource": "<script type="module" src="./app/index.ts"></script>",
     },
   ],
   "addSonarProperties": [
@@ -3445,42 +3402,21 @@ exports[`generator - vue microservice-oauth2-withAdminUi(true)-skipJhipsterDepen
       },
     ],
   ],
-  "addWebpackConfig": [
-    {
-      "config": "require('./webpack.microfrontend')({ serve: options.env.WEBPACK_SERVE })",
-    },
-  ],
   "mergeClientPackageJson": [
     {
       "scripts": {
-        "webapp:build:dev": "npm run webpack -- --mode development --env stats=minimal",
-        "webapp:build:prod": "npm run webpack -- --mode production --env stats=minimal",
-        "webapp:dev": "npm run webpack-dev-server -- --mode development --env stats=normal",
-        "webpack": "webpack --config webpack/webpack.common.js",
-        "webpack-dev-server": "webpack serve --config webpack/webpack.common.js",
+        "vite-build": "vite build",
+        "vite-serve": "vite",
+        "webapp:build:dev": "npm run vite-build",
+        "webapp:build:prod": "npm run vite-build",
+        "webapp:dev": "npm run vite-serve",
+        "webapp:serve": "npm run vite-serve",
       },
     },
     {
       "devDependencies": {
-        "@module-federation/enhanced": null,
-        "browser-sync-webpack-plugin": null,
-        "copy-webpack-plugin": null,
-        "css-loader": null,
-        "css-minimizer-webpack-plugin": null,
-        "html-webpack-plugin": null,
-        "mini-css-extract-plugin": null,
-        "postcss-loader": null,
-        "sass-loader": null,
-        "terser-webpack-plugin": null,
-        "ts-loader": null,
-        "vue-loader": null,
-        "vue-style-loader": null,
-        "webpack": null,
-        "webpack-bundle-analyzer": null,
-        "webpack-cli": null,
-        "webpack-dev-server": null,
-        "webpack-merge": null,
-        "workbox-webpack-plugin": null,
+        "@module-federation/runtime": null,
+        "@module-federation/vite": null,
       },
     },
     {

--- a/generators/vue/generator.ts
+++ b/generators/vue/generator.ts
@@ -360,7 +360,8 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
         if (clientBundlerVite) {
           source.mergeClientPackageJson!({
             devDependencies: {
-              '@originjs/vite-plugin-federation': '1.3.6',
+              '@module-federation/runtime': null,
+              '@module-federation/vite': null,
             },
           });
         } else if (clientBundlerWebpack) {
@@ -435,7 +436,7 @@ const ${entityAngularName}Update = () => import('@/entities/${entityFolderName}/
       end({ application }) {
         this.log.ok(`Vue ${application.nodeDependencies.vue} application generated successfully.`);
         this.log.log(
-          chalk.green(`  Start your Webpack development server with:
+          chalk.green(`  Start your ${application.clientBundlerName} development server with:
   ${chalk.yellow.bold(`${application.nodePackageManager} start`)}
 `),
         );

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -23,6 +23,8 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@module-federation/enhanced": "2.4.0",
+    "@module-federation/runtime": "0.6.0",
+    "@module-federation/vite": "1.0.0",
     "@pinia/testing": "1.0.3",
     "@tsconfig/node18": "18.2.6",
     "@types/node": "22.19.19",

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -33,7 +33,7 @@ import { useLoginModal } from '@/account/login-modal';
 import JhiNavbar from './jhi-navbar.vue';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
 
-vi.mock('@module-federation/enhanced/runtime', () => ({
+vi.mock('@module-federation/runtime', () => ({
   loadRemote: vitest.fn(() => Promise.reject(new Error('Test only'))),
 }));
 <%_ } _%>

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -17,7 +17,7 @@ import EntitiesMenu from '@/entities/entities-menu.vue';
 import { useStore } from '@/store';
 import { useRouter } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { loadRemote } from '@module-federation/enhanced/runtime';
+import { loadRemote } from '@module-federation/runtime';
 <%_ } _%>
 
 export default defineComponent({

--- a/generators/vue/templates/src/main/webapp/app/locale/translation.service.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/locale/translation.service.ts.ejs
@@ -1,5 +1,5 @@
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { loadRemote } from '@module-federation/enhanced/runtime';
+import { loadRemote } from '@module-federation/runtime';
 <%_ } _%>
 import axios from 'axios';
 import { type Composer } from 'vue-i18n';

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -32,7 +32,7 @@ import TranslationService from '@/locale/translation.service';
 import { useTrackerService } from './admin/tracker/tracker.service';
 <%_ } _%>
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { registerRemotes } from '@module-federation/enhanced/runtime';
+import { registerRemotes } from '@module-federation/runtime';
 
 registerRemotes([
   <%_ for (const remote of microfrontends) { _%>

--- a/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/router/index.ts.ejs
@@ -1,6 +1,6 @@
 import { createRouter as createVueRouter, createWebHistory<% if (applicationTypeGateway && microfrontend) { %>, type RouteRecordRaw<% } %> } from 'vue-router';
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-import { loadRemote } from '@module-federation/enhanced/runtime';
+import { loadRemote } from '@module-federation/runtime';
 <%_ } _%>
 
 const Home = () => import('@/core/home/home.vue');

--- a/generators/vue/templates/vite.config.ts.ejs
+++ b/generators/vue/templates/vite.config.ts.ejs
@@ -29,11 +29,7 @@ import {
 import vue from '@vitejs/plugin-vue';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 <%_ if (microfrontend && clientBundlerVite) { _%>
-import federation from "@originjs/vite-plugin-federation";
-
-  <%_ if (applicationTypeGateway) { _%>
-const sharedAppVersion = '0.0.0';
-  <%_ } _%>
+import { federation } from '@module-federation/vite';
 <%_ } _%>
 
 const { getAbsoluteFSPath } = await import('swagger-ui-dist');
@@ -132,10 +128,15 @@ config = mergeConfig(config, {
   plugins: [
     federation({
       name: '<%- lowercaseBaseName %>',
+      filename: 'remoteEntry.js',
   <%_ if (applicationTypeGateway) { _%>
       remotes: {
     <%_ for (const remote of microfrontends) { _%>
-        '@<%- remote.lowercaseBaseName %>': `/<%- remote.endpointPrefix %>/assets/remoteEntry.js`,
+        '<%- remote.lowercaseBaseName %>': {
+          type: 'module',
+          name: '<%- remote.lowercaseBaseName %>',
+          entry: '/<%- remote.endpointPrefix %>/remoteEntry.js',
+        },
     <%_ } _%>
       },
   <%_ } _%>
@@ -146,34 +147,13 @@ config = mergeConfig(config, {
       },
   <%_ } _%>
       shared: {
-        '@vuelidate/core': {},
-        '@vuelidate/validators': {},
-        axios: {},
-        // 'bootstrap-vue': {},
-        vue: {
-          packagePath: 'vue/dist/vue.esm-bundler.js',
-        },
-        'vue-i18n': {},
-        'vue-router': {},
-        pinia: {},
-        '@/shared/jhipster/constants': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/jhipster/constants',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/shared/alert/alert.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/shared/alert/alert.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
-        '@/locale/translation.service': {
-          packagePath: './<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/locale/translation.service',
-  <%_ if (applicationTypeGateway) { _%>
-          version: sharedAppVersion,
-  <%_ } _%>
-        },
+        '@vuelidate/core': { singleton: true },
+        '@vuelidate/validators': { singleton: true },
+        axios: { singleton: true },
+        vue: { singleton: true },
+        'vue-i18n': { singleton: true },
+        'vue-router': { singleton: true },
+        pinia: { singleton: true },
       },
     }),
   ],

--- a/lib/jhipster/default-application-options.ts
+++ b/lib/jhipster/default-application-options.ts
@@ -125,7 +125,7 @@ function getConfigForClientApplication(options: ApplicationDefaults = {}): Appli
   }
   switch (clientFramework) {
     case 'vue': {
-      options.clientBundler ??= options.microfrontend || options.applicationType === 'microservice' ? 'webpack' : 'vite';
+      options.clientBundler ??= 'vite';
       options.devServerPort ??= options.clientBundler === 'webpack' ? 9060 : 9000;
       break;
     }


### PR DESCRIPTION
## Summary

Fixes #27489

`@module-federation/vite@1.0.0` is now stable and addresses the blockers from the earlier attempt (#27493): it supports custom `cacheDir` and custom `outDir`, making it viable for JHipster's Maven (`target/`) and Gradle (`build/`) setups.

## Changes

### Core switch
- **`generators/vue/generator.ts`** — `addMicrofrontendDependencies` for Vite now adds `@module-federation/vite` and `@module-federation/runtime` (replaces `@originjs/vite-plugin-federation`)
- **`lib/jhipster/default-application-options.ts`** — Vue `clientBundler` now defaults to `'vite'` for all application types (previously forced to webpack for microfrontend/microservice apps)

### Template updates
- **`vite.config.ts.ejs`** — uses named `{ federation }` import from `@module-federation/vite`; remotes are now object-format (`{ type, name, entry }`); adds `filename: 'remoteEntry.js'`; shared packages use `{ singleton: true }` (removes manual `packagePath`/`version` workarounds)
- **`main.ts.ejs`**, **`router/index.ts.ejs`**, **`jhi-navbar.component.ts.ejs`**, **`jhi-navbar.component.spec.ts.ejs`**, **`translation.service.ts.ejs`** — `@module-federation/enhanced/runtime` → `@module-federation/runtime`

### Resource updates
- **`resources/package.json`** — adds `@module-federation/runtime@0.6.0` and `@module-federation/vite@1.0.0`

### Test snapshot updates
- **`generators/vue/__snapshots__/generator.spec.ts.snap`** — 6 snapshots regenerated; all microservice/gateway samples now correctly show `clientBundler: "vite"`, `devServerPort: 9000`, webpack files removed

## Acceptance criteria checked

- [x] `@module-federation/vite@1.0.0` used as the Vite microfrontend plugin
- [x] `@module-federation/runtime` used for runtime imports (not `@module-federation/enhanced/runtime`)
- [x] Default bundler for Vue apps (including microfrontend/microservice) is now Vite
- [x] Snapshot tests updated and all 932 tests pass

## Testing

```bash
npm run check-types      # no type errors
npm run lint             # no lint warnings
node node_modules/esmocha/dist/bin.cjs --no-insight --no-parallel -- generators/vue/generator.spec.ts
# 932 passing, 6 snapshots updated
```

> **AI disclosure:** This PR was prepared with AI assistance. All changes have been reviewed for correctness against the module federation v1.0.0 API and tested locally.