### PR TITLE
Fix SecurityUtils.getCurrentUserJWT for Jwt credentials

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
@@ -139,12 +139,21 @@ public final class SecurityUtils {
   <%_ if (reactive) { _%>
         return ReactiveSecurityContextHolder.getContext()
             .map(SecurityContext::getAuthentication)
+            .flatMap(authentication -> Mono.justOrEmpty(extractCredentials(authentication)));
   <%_ } else { _%>
         SecurityContext securityContext = SecurityContextHolder.getContext();
         return Optional.ofNullable(securityContext.getAuthentication())
+            .map(SecurityUtils::extractCredentials);
   <%_ } _%>
-            .filter(authentication -> authentication.getCredentials() instanceof String)
-            .map(authentication -> (String) authentication.getCredentials());
+    }
+
+    private static String extractCredentials(Authentication authentication) {
+        if (authentication.getCredentials() instanceof String token) {
+            return token;
+        } else if (authentication.getCredentials() instanceof Jwt jwt) {
+            return jwt.getTokenValue();
+        }
+        return null;
     }
   <%_ if (user) { _%>
 

--- a/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_imperative.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_imperative.java.ejs
@@ -137,6 +137,21 @@ class SecurityUtilsUnitTest {
         Optional<String> jwt = SecurityUtils.getCurrentUserJWT();
         assertThat(jwt).contains("token");
     }
+
+    @Test
+    void testGetCurrentUserJWTFromJwtCredentials() {
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        var now = Instant.now();
+        var jwt = Jwt.withTokenValue("token")
+            .issuedAt(now)
+            .expiresAt(now.plusSeconds(60))
+            .header("Test", "test")
+            .build();
+        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken("admin", jwt));
+        SecurityContextHolder.setContext(securityContext);
+        Optional<String> currentUserJwt = SecurityUtils.getCurrentUserJWT();
+        assertThat(currentUserJwt).contains("token");
+    }
   <%_ if (user) { _%>
 
     @Test

--- a/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_reactive.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_reactive.java.ejs
@@ -70,6 +70,22 @@ class SecurityUtilsUnitTest {
         assertThat(jwt).isEqualTo("token");
     }
 
+    @Test
+    void testGetCurrentUserJWTFromJwtCredentials() {
+        var now = Instant.now();
+        var jwt = Jwt.withTokenValue("token")
+            .issuedAt(now)
+            .expiresAt(now.plusSeconds(60))
+            .header("Test", "test")
+            .build();
+
+        String currentUserJwt = SecurityUtils.getCurrentUserJWT()
+            .contextWrite(ReactiveSecurityContextHolder.withAuthentication(new UsernamePasswordAuthenticationToken("admin", jwt)))
+            .block();
+
+        assertThat(currentUserJwt).isEqualTo("token");
+    }
+
   <%_ if (user) { _%>
     @Test
     void testGetCurrentUserId() {


### PR DESCRIPTION
Fixes #32399.

`SecurityUtils.getCurrentUserJWT()` only handled `String` credentials.
In Spring Security JWT authentication, credentials can be a `Jwt` instance, so the method returned an empty value.

This change supports both:
- `String` credentials
- `Jwt` credentials via `jwt.getTokenValue()`

Added regression tests for imperative and reactive templates.

Verification:
- `npm ci`
- `npx -p node@24 -c "npm run check-types"`
- `npx -p node@24 -c "npm run build"`