### PR TITLE
Remove ejs-templates/prefer-output rule override

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -140,8 +140,6 @@ export default defineConfig(
     }),
     {
       rules: {
-        'ejs-templates/prefer-output': 'error',
-
         ...js.configs.recommended.rules,
         ...jsRules,
         'prefer-destructuring': ['error', { array: false, object: true }],


### PR DESCRIPTION
Removed 'ejs-templates/prefer-output' rule from ESLint configuration.

related to https://github.com/jhipster/generator-jhipster/issues/32851

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
