### PR TITLE
Handle OAuth logout when end_session_endpoint is missing

### DIFF
--- a/generators/spring-boot/generators/oauth2/templates/src/main/java/_package_/web/rest/LogoutResource_imperative.java.ejs
+++ b/generators/spring-boot/generators/oauth2/templates/src/main/java/_package_/web/rest/LogoutResource_imperative.java.ejs
@@ -62,12 +62,17 @@ public class LogoutResource {
         ClientRegistration clientRegistration = registrationRepository.findByRegistrationId(
             oAuth2AuthenticationToken.getAuthorizedClientRegistrationId()
         );
-        logoutUrl
-            .append(clientRegistration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString())
-            .append("?id_token_hint=")
-            .append(oidcUser.getIdToken().getTokenValue())
-            .append("&post_logout_redirect_uri=")
-            .append(originUrl);
+        Object endSessionEndpoint = clientRegistration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint");
+        if (endSessionEndpoint == null) {
+            logoutUrl.append("/");
+        } else {
+            logoutUrl
+                .append(endSessionEndpoint.toString())
+                .append("?id_token_hint=")
+                .append(oidcUser.getIdToken().getTokenValue())
+                .append("&post_logout_redirect_uri=")
+                .append(originUrl);
+        }
 
         request.getSession().invalidate();
         return ResponseEntity.ok().body(Map.of("logoutUrl", logoutUrl.toString()));

--- a/generators/spring-boot/generators/oauth2/templates/src/main/java/_package_/web/rest/LogoutResource_reactive.java.ejs
+++ b/generators/spring-boot/generators/oauth2/templates/src/main/java/_package_/web/rest/LogoutResource_reactive.java.ejs
@@ -71,11 +71,19 @@ public class LogoutResource {
     private Map<String, String> prepareLogoutUri(ServerHttpRequest request, ClientRegistration clientRegistration, OidcIdToken idToken) {
         StringBuilder logoutUrl = new StringBuilder();
 
-        logoutUrl.append(clientRegistration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint").toString());
+        Object endSessionEndpoint = clientRegistration.getProviderDetails().getConfigurationMetadata().get("end_session_endpoint");
+        if (endSessionEndpoint == null) {
+            logoutUrl.append("/");
+        } else {
+            String originUrl = request.getHeaders().getOrigin();
 
-        String originUrl = request.getHeaders().getOrigin();
-
-        logoutUrl.append("?id_token_hint=").append(idToken.getTokenValue()).append("&post_logout_redirect_uri=").append(originUrl);
+            logoutUrl
+                .append(endSessionEndpoint.toString())
+                .append("?id_token_hint=")
+                .append(idToken.getTokenValue())
+                .append("&post_logout_redirect_uri=")
+                .append(originUrl);
+        }
 
         return Map.of("logoutUrl", logoutUrl.toString());
     }

--- a/generators/spring-boot/generators/oauth2/templates/src/test/java/_package_/config/TestSecurityConfiguration.java.ejs
+++ b/generators/spring-boot/generators/oauth2/templates/src/test/java/_package_/config/TestSecurityConfiguration.java.ejs
@@ -46,6 +46,8 @@ import org.springframework.context.annotation.Import;
 <%_ } _%>
 public class TestSecurityConfiguration {
 
+    private static final String NO_END_SESSION_ENDPOINT_REGISTRATION_ID = "oidc-no-end-session-endpoint";
+
     @Bean
     ClientRegistration clientRegistration() {
         return clientRegistrationBuilder().build();
@@ -53,7 +55,13 @@ public class TestSecurityConfiguration {
 
     @Bean
     <%- reactivePrefix %>ClientRegistrationRepository clientRegistrationRepository(ClientRegistration clientRegistration) {
-        return new InMemory<%- reactivePrefix %>ClientRegistrationRepository(clientRegistration);
+        return new InMemory<%- reactivePrefix %>ClientRegistrationRepository(
+            clientRegistration,
+            ClientRegistration.withClientRegistration(clientRegistration)
+                .registrationId(NO_END_SESSION_ENDPOINT_REGISTRATION_ID)
+                .providerConfigurationMetadata(Map.of())
+                .build()
+        );
     }
 
     private ClientRegistration.Builder clientRegistrationBuilder() {

--- a/generators/spring-boot/generators/oauth2/templates/src/test/java/_package_/web/rest/LogoutResourceIT.java.ejs
+++ b/generators/spring-boot/generators/oauth2/templates/src/test/java/_package_/web/rest/LogoutResourceIT.java.ejs
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.<%- reactive ? 'Reactive' : '' %>OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.<%- reactive ? 'Reactive' : '' %>ClientRegistrationRepository;
@@ -59,6 +60,8 @@ import java.util.Map;
  */
 @IntegrationTest
 class LogoutResourceIT {
+
+    private static final String NO_END_SESSION_ENDPOINT_REGISTRATION_ID = "oidc-no-end-session-endpoint";
 
     @Autowired
     private <%- reactive ? 'Reactive' : '' %>ClientRegistrationRepository registrations;
@@ -125,6 +128,53 @@ class LogoutResourceIT {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.logoutUrl").value(logoutUrl));
+<%_ } _%>
+    }
+
+    @Test
+    void getLogoutInformationWithoutEndSessionEndpoint() <%- reactive ? '' : 'throws Exception ' %>{
+        final String ORIGIN_URL = "http://localhost:8080";
+        OAuth2AuthenticationToken authentication = authenticationToken(claims);
+        OAuth2AuthenticationToken authenticationWithoutEndSessionEndpoint = new OAuth2AuthenticationToken(
+            authentication.getPrincipal(),
+            authentication.getAuthorities(),
+            NO_END_SESSION_ENDPOINT_REGISTRATION_ID
+        );
+        ClientRegistration clientRegistrationWithoutEndSessionEndpoint = ClientRegistration.withClientRegistration(clientRegistration)
+            .registrationId(NO_END_SESSION_ENDPOINT_REGISTRATION_ID)
+            .providerConfigurationMetadata(Map.of())
+            .build();
+<%_ if (reactive) { _%>
+        this.webTestClient.mutateWith(csrf())
+            .mutateWith(
+                mockAuthentication(
+                    registerAuthenticationToken(
+                        authorizedClientService,
+                        clientRegistrationWithoutEndSessionEndpoint,
+                        authenticationWithoutEndSessionEndpoint
+                    )
+                )
+            )
+            .post().uri("http://localhost:8080/api/logout").header(HttpHeaders.ORIGIN, ORIGIN_URL).exchange()
+            .expectStatus().isOk()
+            .expectHeader().contentType(MediaType.APPLICATION_JSON_VALUE)
+            .expectBody()
+            .jsonPath("$.logoutUrl").isEqualTo("/");
+<%_ } else { _%>
+        SecurityContextHolder
+            .getContext()
+            .setAuthentication(
+                registerAuthenticationToken(
+                    authorizedClientService,
+                    clientRegistrationWithoutEndSessionEndpoint,
+                    authenticationWithoutEndSessionEndpoint
+                )
+            );
+
+        restLogoutMockMvc.perform(post("http://localhost:8080/api/logout").header(HttpHeaders.ORIGIN, ORIGIN_URL))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.logoutUrl").value("/"));
 <%_ } _%>
     }
 }


### PR DESCRIPTION
## Summary

Prevent NullPointerException during OAuth logout when the provider metadata does not expose end_session_endpoint.

## Root Cause

Generated logout resources assume end_session_endpoint is always present and call:

clientRegistration.getProviderDetails()
    .getConfigurationMetadata()
    .get("end_session_endpoint")
    .toString();

When the metadata entry is absent, logout fails with a NullPointerException.

## Changes

- Added null checks around end_session_endpoint lookup
- Preserved existing RP-initiated logout behavior
- Added fallback to local logout when provider logout metadata is unavailable
- Added test coverage for missing metadata scenario

## Testing

- Existing logout behavior remains unchanged when end_session_endpoint exists
- Added tests verifying successful logout when metadata is missing