### PR TITLE
Improve AccountResource security, validation, and exception mapping

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
@@ -342,6 +342,8 @@ public class AccountResource {
         return userService.completePasswordReset(keyAndPassword.getNewPassword(), keyAndPassword.getKey())
             .switchIfEmpty(
                 Mono.defer(() -> {
+                    // Dummy hash to prevent reset-key enumeration via response-time timing attack:
+                    // mirrors the bcrypt cost of a successful path so both branches take equal time.
                     passwordEncoder.encode(keyAndPassword.getNewPassword());
                     return Mono.error(new AccountResourceException("No user was found for this reset key"));
                 })
@@ -352,6 +354,8 @@ public class AccountResource {
             userService.completePasswordReset(keyAndPassword.getNewPassword(), keyAndPassword.getKey());
 
         if (!user.isPresent()) {
+            // Dummy hash to prevent reset-key enumeration via response-time timing attack:
+            // mirrors the bcrypt cost of a successful path so both branches take equal time.
             passwordEncoder.encode(keyAndPassword.getNewPassword());
             throw new AccountResourceException("No user was found for this reset key");
         }

--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
@@ -48,6 +48,7 @@ import org.springframework.web.bind.annotation.*;
 <%_ if (reactive) { _%>
 import java.util.Objects;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 <%_ } else { _%>
 import java.util.*;
 <%_ } _%>
@@ -67,7 +68,7 @@ import java.net.URLDecoder;
 @Validated
 public class AccountResource {
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Account resource request invalid")
     private static class AccountResourceException extends RuntimeException {
         private AccountResourceException(String message) {
             super(message);
@@ -341,12 +342,15 @@ public class AccountResource {
 <%_ if (reactive) { _%>
         return userService.completePasswordReset(keyAndPassword.getNewPassword(), keyAndPassword.getKey())
             .switchIfEmpty(
-                Mono.defer(() -> {
-                    // Dummy hash to prevent reset-key enumeration via response-time timing attack:
-                    // mirrors the bcrypt cost of a successful path so both branches take equal time.
-                    passwordEncoder.encode(keyAndPassword.getNewPassword());
-                    return Mono.error(new AccountResourceException("No user was found for this reset key"));
-                })
+                Mono.defer(() ->
+                    Mono.fromRunnable(() -> {
+                        // Dummy hash to prevent reset-key enumeration via response-time timing attack:
+                        // mirrors the bcrypt cost of a successful path so both branches take equal time.
+                        passwordEncoder.encode(keyAndPassword.getNewPassword());
+                    })
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .then(Mono.error(new AccountResourceException("No user was found for this reset key")))
+                )
             )
             .then();
 <%_ } else { _%>

--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 <%_ if (reactive) { _%>
 import java.util.Objects;
@@ -50,6 +51,8 @@ import reactor.core.publisher.Mono;
 import java.util.*;
 <%_ } _%>
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
 <%_ if (authenticationTypeSession && !reactive) { _%>
 import java.nio.charset.StandardCharsets;
 import java.net.URLDecoder;
@@ -60,8 +63,10 @@ import java.net.URLDecoder;
  */
 @RestController
 @RequestMapping("/api")
+@Validated
 public class AccountResource {
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     private static class AccountResourceException extends RuntimeException {
         private AccountResourceException(String message) {
             super(message);
@@ -101,6 +106,7 @@ public class AccountResource {
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
     public <%- reactive ? 'Mono<Void>' : 'void' %> registerAccount(@Valid @RequestBody ManagedUserVM managedUserVM) {
+        LOG.debug("REST request to register account");
         if (isPasswordLengthInvalid(managedUserVM.getPassword())) {
             throw new InvalidPasswordException();
         }
@@ -122,6 +128,7 @@ public class AccountResource {
      */
     @GetMapping("/activate")
     public <%- reactive ? 'Mono<Void>' : 'void' %> activateAccount(@RequestParam(value = "key") String key) {
+        LOG.debug("REST request to activate account");
 <%_ if (reactive) { _%>
         return userService.activateRegistration(key)
             .switchIfEmpty(Mono.error(new AccountResourceException("No user was found for this activation key")))
@@ -156,6 +163,7 @@ public class AccountResource {
      */
     @GetMapping("/account")
     public <%- wrapMono(user.adminUserDto) %> getAccount() {
+        LOG.debug("REST request to get account");
         return userService.getUserWithAuthorities()
             .map(<%- user.adminUserDto %>::new)
 <%_ if (reactive) { _%>
@@ -175,6 +183,7 @@ public class AccountResource {
     @PostMapping("/account")
 <%_ if (reactive) { _%>
     public Mono<Void> saveAccount(@Valid @RequestBody <%- user.adminUserDto %> userDTO) {
+        LOG.debug("REST request to save account");
         return SecurityUtils.getCurrentUserLogin()
             .switchIfEmpty(Mono.error(new AccountResourceException("Current user login not found")))
             .flatMap(userLogin -> userRepository.findOneByEmailIgnoreCase(userDTO.getEmail())
@@ -191,6 +200,7 @@ public class AccountResource {
                     userDTO.getLangKey()<%- user.hasImageField ? ', userDTO.getImageUrl()' : '' %>));
 <%_ } else { _%>
     public void saveAccount(@Valid @RequestBody <%- user.adminUserDto %> userDTO) {
+        LOG.debug("REST request to save account");
         String userLogin = SecurityUtils.getCurrentUserLogin().orElseThrow(() -> new AccountResourceException("Current user login not found"));
         Optional<<%- user.persistClass %>> existingUser = userRepository.findOneByEmailIgnoreCase(userDTO.getEmail());
         if (existingUser.isPresent() && (!existingUser.orElseThrow().getLogin().equalsIgnoreCase(userLogin))) {
@@ -213,6 +223,7 @@ public class AccountResource {
      */
     @PostMapping(path = "/account/change-password")
     public <%- reactive ? 'Mono<Void>' : 'void' %> changePassword(@RequestBody PasswordChangeDTO passwordChangeDto) {
+        LOG.debug("REST request to change password");
         if (isPasswordLengthInvalid(passwordChangeDto.getNewPassword())) {
             throw new InvalidPasswordException();
         }
@@ -228,6 +239,7 @@ public class AccountResource {
      */
     @GetMapping("/account/sessions")
     public List<PersistentToken> getCurrentSessions() {
+        LOG.debug("REST request to get current sessions");
         return persistentTokenRepository.findByUser(
             userRepository
                 .findOneByLogin(
@@ -278,7 +290,8 @@ public class AccountResource {
      */
     @PostMapping(path = "/account/reset-password/init")
 <%_ if (reactive) { _%>
-    public Mono<Void> requestPasswordReset(@RequestBody String mail) {
+    public Mono<Void> requestPasswordReset(@RequestBody @Email @Size(min = 5, max = 254) String mail) {
+        LOG.debug("REST request to request password reset");
         return userService
             .requestPasswordReset(mail)
             .doOnSuccess(user -> {
@@ -292,7 +305,8 @@ public class AccountResource {
             })
             .then();
 <%_ } else { _%>
-    public void requestPasswordReset(@RequestBody String mail) {
+    public void requestPasswordReset(@RequestBody @Email @Size(min = 5, max = 254) String mail) {
+        LOG.debug("REST request to request password reset");
         Optional<<%- user.persistClass %>> user = userService.requestPasswordReset(mail);
         if (user.isPresent()) {
             mailService.sendPasswordResetMail(user.orElseThrow());

--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/AccountResource.java.ejs
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 <%_ if (reactive) { _%>
@@ -80,16 +81,23 @@ public class AccountResource {
     private final UserService userService;
 
     private final MailService mailService;
+
+    private final PasswordEncoder passwordEncoder;
 <%_ if (authenticationTypeSession && !reactive) { _%>
 
     private final PersistentTokenRepository persistentTokenRepository;
 <%_ } _%>
 
-    public AccountResource(UserRepository userRepository, UserService userService, MailService mailService<%- authenticationTypeSession && !reactive ? ', PersistentTokenRepository persistentTokenRepository' : '' %>) {
-
+    public AccountResource(
+        UserRepository userRepository,
+        UserService userService,
+        MailService mailService,
+        PasswordEncoder passwordEncoder<%- authenticationTypeSession && !reactive ? ', PersistentTokenRepository persistentTokenRepository' : '' %>
+    ) {
         this.userRepository = userRepository;
         this.userService = userService;
         this.mailService = mailService;
+        this.passwordEncoder = passwordEncoder;
 <%_ if (authenticationTypeSession && !reactive) { _%>
         this.persistentTokenRepository = persistentTokenRepository;
 <%_ } _%>
@@ -332,13 +340,19 @@ public class AccountResource {
         }
 <%_ if (reactive) { _%>
         return userService.completePasswordReset(keyAndPassword.getNewPassword(), keyAndPassword.getKey())
-            .switchIfEmpty(Mono.error(new AccountResourceException("No user was found for this reset key")))
+            .switchIfEmpty(
+                Mono.defer(() -> {
+                    passwordEncoder.encode(keyAndPassword.getNewPassword());
+                    return Mono.error(new AccountResourceException("No user was found for this reset key"));
+                })
+            )
             .then();
 <%_ } else { _%>
         Optional<<%- user.persistClass %>> user =
             userService.completePasswordReset(keyAndPassword.getNewPassword(), keyAndPassword.getKey());
 
         if (!user.isPresent()) {
+            passwordEncoder.encode(keyAndPassword.getNewPassword());
             throw new AccountResourceException("No user was found for this reset key");
         }
 <%_ } _%>

--- a/generators/spring-boot/templates/src/main/java/_package_/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/web/rest/errors/ExceptionTranslator.java.ejs
@@ -79,6 +79,7 @@ import reactor.core.publisher.Mono;
 <%_ if (!reactive) { _%>
 import jakarta.servlet.http.HttpServletRequest;
 <%_ } _%>
+import jakarta.validation.ConstraintViolationException;
 import java.net.URI;
 import java.util.List;
 import java.util.Collection;
@@ -265,12 +266,12 @@ _%>
     }
 
     private URI getMappedType(Throwable err) {
-        if (err instanceof MethodArgumentNotValidException) return ErrorConstants.CONSTRAINT_VIOLATION_TYPE;
+        if (err instanceof MethodArgumentNotValidException || err instanceof ConstraintViolationException) return ErrorConstants.CONSTRAINT_VIOLATION_TYPE;
         return ErrorConstants.DEFAULT_TYPE;
     }
 
     private String getMappedMessageKey(Throwable err) {
-        if (err instanceof MethodArgumentNotValidException) {
+        if (err instanceof MethodArgumentNotValidException || err instanceof ConstraintViolationException) {
             return ErrorConstants.ERR_VALIDATION;
 <%_ if (!databaseTypeNo && !databaseTypeCassandra) { _%>
         } else if (err instanceof ConcurrencyFailureException
@@ -286,7 +287,7 @@ _%>
     }
 
     private String getCustomizedTitle(Throwable err) {
-        if (err instanceof MethodArgumentNotValidException) return "Method argument not valid";
+        if (err instanceof MethodArgumentNotValidException || err instanceof ConstraintViolationException) return "Method argument not valid";
         return null;
     }
 
@@ -312,6 +313,7 @@ _%>
 <%_ if (reactive) { _%>
         if (err instanceof UsernameNotFoundException) return HttpStatus.UNAUTHORIZED;
 <%_ } _%>
+        if (err instanceof ConstraintViolationException) return HttpStatus.BAD_REQUEST;
         return null;
     }
 

--- a/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
@@ -713,10 +713,10 @@ class AccountResourceIT {
 <%_ if (reactive) { _%>
         accountWebTestClient.get().uri("/api/activate?key=wrongActivationKey")
             .exchange()
-            .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            .expectStatus().isBadRequest();
 <%_ } else { _%>
         restAccountMockMvc.perform(get("/api/activate?key=wrongActivationKey"))
-            .andExpect(status().isInternalServerError());
+            .andExpect(status().isBadRequest());
 <%_ } _%>
     }
 
@@ -1364,6 +1364,42 @@ class AccountResourceIT {
     }
 
     @Test
+<%_ if (reactive) { _%>
+    void testRequestPasswordResetInvalidEmail() {
+        accountWebTestClient.post().uri("/api/account/reset-password/init")
+            .bodyValue("invalid-email")
+            .exchange()
+            .expectStatus().isBadRequest();
+    }
+<%_ } else { _%>
+    void testRequestPasswordResetInvalidEmail() <%- reactive ? '' : 'throws Exception ' %>{
+        restAccountMockMvc.perform(
+            post("/api/account/reset-password/init")
+                .content("invalid-email")<% if (authenticationUsesCsrf) { %>
+                .with(csrf())<% } %>)
+            .andExpect(status().isBadRequest());
+    }
+<%_ } _%>
+
+    @Test
+<%_ if (reactive) { _%>
+    void testRequestPasswordResetTooLongEmail() {
+        accountWebTestClient.post().uri("/api/account/reset-password/init")
+            .bodyValue(RandomStringUtils.insecure().nextAlphanumeric(255))
+            .exchange()
+            .expectStatus().isBadRequest();
+    }
+<%_ } else { _%>
+    void testRequestPasswordResetTooLongEmail() <%- reactive ? '' : 'throws Exception ' %>{
+        restAccountMockMvc.perform(
+            post("/api/account/reset-password/init")
+                .content(RandomStringUtils.insecure().nextAlphanumeric(255))<% if (authenticationUsesCsrf) { %>
+                .with(csrf())<% } %>)
+            .andExpect(status().isBadRequest());
+    }
+<%_ } _%>
+
+    @Test
 <%_ if (databaseTypeSql && !reactive) { _%>
     @Transactional
 <%_ } _%>
@@ -1465,14 +1501,14 @@ class AccountResourceIT {
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(om.writeValueAsBytes(keyAndPassword))
             .exchange()
-            .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            .expectStatus().isBadRequest();
 <%_ } else { _%>
         restAccountMockMvc.perform(
             post("/api/account/reset-password/finish")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsBytes(keyAndPassword))<% if (authenticationUsesCsrf) { %>
                 .with(csrf())<% } %>)
-            .andExpect(status().isInternalServerError());
+            .andExpect(status().isBadRequest());
 <%_ } _%>
     }
 }

--- a/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/web/rest/AccountResourceIT.java.ejs
@@ -1385,7 +1385,7 @@ class AccountResourceIT {
 <%_ if (reactive) { _%>
     void testRequestPasswordResetTooLongEmail() {
         accountWebTestClient.post().uri("/api/account/reset-password/init")
-            .bodyValue(RandomStringUtils.insecure().nextAlphanumeric(255))
+            .bodyValue("a".repeat(250) + "@x.co")
             .exchange()
             .expectStatus().isBadRequest();
     }
@@ -1393,7 +1393,7 @@ class AccountResourceIT {
     void testRequestPasswordResetTooLongEmail() <%- reactive ? '' : 'throws Exception ' %>{
         restAccountMockMvc.perform(
             post("/api/account/reset-password/init")
-                .content(RandomStringUtils.insecure().nextAlphanumeric(255))<% if (authenticationUsesCsrf) { %>
+                .content("a".repeat(250) + "@x.co")<% if (authenticationUsesCsrf) { %>
                 .with(csrf())<% } %>)
             .andExpect(status().isBadRequest());
     }


### PR DESCRIPTION
### Problem

The AccountResource password reset and activation flows had several issues:

* Missing validation on email input accepted through request bodies.
* Client-side activation/reset errors were mapped to HTTP 500 responses.
* Limited request traceability due to missing endpoint-level logging.
* Potential differences in execution flow that could expose unnecessary information during password reset operations.

### Solution

* Added method-level validation support using `@Validated`.
* Added `@Email` and `@Size` constraints for password reset email input.
* Mapped `AccountResourceException` to `400 Bad Request` using `@ResponseStatus`.
* Added debug-level logging at REST endpoint entry points.
* Updated and extended integration tests to cover validation and error handling scenarios.

### Testing

* Added integration tests for invalid email formats.
* Added integration tests for oversized email inputs.
* Updated activation and reset-key tests to verify HTTP 400 responses.
* Verified successful local build and test execution.


