### PR TITLE
fix(reactive): avoid negative BigDecimal scale in generated entities

### DIFF
--- a/generators/spring-boot/generators/data-relational/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.spring_data_reactive.ejs
+++ b/generators/spring-boot/generators/data-relational/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.jhi.spring_data_reactive.ejs
@@ -40,7 +40,7 @@ import org.springframework.data.relational.core.mapping.Table;
   <%_ if (field.fieldTypeBigDecimal) { _%>
 <&_ if (fragment.field<%- field.fieldNameCapitalized %>CustomSetSection) { -&>
     public void <%- field.propertyConsumerName %>(<%- field.javaFieldType %> <%- field.fieldName %>) {
-        this.<%- field.fieldName %> = <%- field.fieldName %> != null ? <%- field.fieldName %>.stripTrailingZeros() : null;
+        this.<%- field.fieldName %> = <%- field.fieldName %>;
     }
 <&_ } -&>
   <%_ } _%>


### PR DESCRIPTION
## Summary

Reactive entities generated by JHipster normalize `BigDecimal` values using `stripTrailingZeros()`.

For values such as `new BigDecimal(100)`, this produces `1E+2` with a negative scale (`-2`).

While testing the `ng-webflux-psql-default` sample, persistence operations failed with:

```text
JdbcSQLSyntaxErrorException:
Scale or fractional seconds precision ("-2")
```

The failure originated from generated reactive entity setters:

```java
this.field = field != null ? field.stripTrailingZeros() : null;
```

This change removes the `stripTrailingZeros()` call and preserves the original `BigDecimal` value.

## Reproduce

1. Generate the `ng-webflux-psql-default` sample.
2. Run the integration tests.
3. Observe failures related to negative BigDecimal scale (`-2`) when persisting values such as `100`.

After this change, the negative-scale persistence failure disappears and the generated sample progresses past the original BigDecimal persistence error.

## Testing

* Generated `ng-webflux-psql-default`
* Reproduced the failure
* Confirmed the BigDecimal negative-scale persistence failure disappears after removing `stripTrailingZeros()`
