### PR TITLE
Add angular-eslint to angular group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,7 @@ updates:
           - '@angular-devkit/*'
           - '@fortawesome/angular-fontawesome'
           - '@ng-bootstrap/*'
+          - 'angular-eslint'
           - 'ngx-cookie-service'
           - 'ngx-infinite-scroll'
           - 'typescript'


### PR DESCRIPTION
angular-eslint has a more restrictive dependency now.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
