### PR TITLE
from-issue: Inefficient regular expression

### DIFF
--- a/generators/info/support/extract-info.spec.ts
+++ b/generators/info/support/extract-info.spec.ts
@@ -215,6 +215,19 @@ describe('extract-info', () => {
 `);
     });
 
+    it('should reject empty .jhipster json filename', () => {
+      const data = {
+        yoRcBlank: true,
+        files: [{ filename: '.jhipster/.json', content: '{}', type: 'json' as const }],
+      };
+      expect(filterData(data)).toMatchInlineSnapshot(`
+{
+  "files": [],
+  "yoRcBlank": true,
+}
+`);
+    });
+
     it('should filter out non-matching files', () => {
       const data = {
         yoRcBlank: true,

--- a/generators/info/support/extract-info.ts
+++ b/generators/info/support/extract-info.ts
@@ -23,7 +23,7 @@ export const filterData = ({ files, ...data }: InfoData): InfoData => {
       file =>
         // Forbid any package.json file for security reasons.
         path.basename(file.filename).toLowerCase() !== 'package.json' &&
-        (file.filename === '.yo-rc.json' || file.filename.endsWith('.jdl') || file.filename.match(/\.jhipster\/\w+\.json$/)),
+        (file.filename === '.yo-rc.json' || file.filename.endsWith('.jdl') || /\.jhipster\/\w+\.json$/.test(file.filename)),
     ),
   };
 };

--- a/generators/info/support/extract-info.ts
+++ b/generators/info/support/extract-info.ts
@@ -23,7 +23,7 @@ export const filterData = ({ files, ...data }: InfoData): InfoData => {
       file =>
         // Forbid any package.json file for security reasons.
         path.basename(file.filename).toLowerCase() !== 'package.json' &&
-        (file.filename === '.yo-rc.json' || file.filename.endsWith('.jdl') || file.filename.match(/\.jhipster\/(\w*)+\.json$/)),
+        (file.filename === '.yo-rc.json' || file.filename.endsWith('.jdl') || file.filename.match(/\.jhipster\/\w+\.json$/)),
     ),
   };
 };


### PR DESCRIPTION
Potential fix for [https://github.com/jhipster/generator-jhipster/security/code-scanning/78](https://github.com/jhipster/generator-jhipster/security/code-scanning/78)

The best fix is to remove the ambiguous nested quantification while preserving intended matching behavior. Here, `(\w*)+` is equivalent to `\w*` in terms of accepted strings, but much less safe for backtracking. In this context, we want `.jhipster/<name>.json` with at least one word character in `<name>`, so replacing with `\w+` is both safe and semantically appropriate.

Edit **`generators/info/support/extract-info.ts`**, specifically the regex in `filterData` (line 26 in the snippet). Replace:

- `file.filename.match(/\.jhipster\/(\w*)+\.json$/)`

with:

- `file.filename.match(/\.jhipster\/\w+\.json$/)`

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
