### PR TITLE
jdl: Inefficient regular expression

### DIFF
--- a/lib/jdl/core/parsing/validator.spec.ts
+++ b/lib/jdl/core/parsing/validator.spec.ts
@@ -2263,6 +2263,12 @@ describe('jdl - JDLSyntaxValidatorVisitor', () => {
             }
             deployment {
               ${type} "gcr.io.192.120.0.0.io"
+            }
+            deployment {
+              ${type} "https://example.com"
+            }
+            deployment {
+              ${type} "example.com:5000/test"
             }`,
                 jdlRuntime,
               ),
@@ -2285,14 +2291,12 @@ describe('jdl - JDLSyntaxValidatorVisitor', () => {
               expect(() =>
                 parse(
                   `
-                deployment {
-                  ${type} "test 123"
+               deployment {
+                 ${type} "test 123"
               }`,
                   jdlRuntime,
                 ),
-              ).toThrow(
-                String.raw`The ${type} property name must match: /^"((?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+|[a-zA-Z0-9]+)"$/`,
-              );
+              ).toThrow(new RegExp(`^The ${type} property name must match: `));
             });
           });
           describe('such as not a name', () => {

--- a/lib/jdl/core/parsing/validator.ts
+++ b/lib/jdl/core/parsing/validator.ts
@@ -40,7 +40,7 @@ const ENUM_PROP_VALUE_PATTERN = /^[A-Za-z]\w*$/;
 const METHOD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-_]*$/;
 
 // const PASSWORD_PATTERN = /^(.+)$/;
-const REPONAME_PATTERN = /^"((?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+|[a-zA-Z0-9]+)"$/;
+const REPONAME_PATTERN = /^"((?:http(s)?:\/\/)?[\w-]+(?:\.[\w-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+|[a-zA-Z0-9]+)"$/;
 const KUBERNETES_STORAGE_CLASS_NAME = /^"[A-Za-z]*"$/;
 const PATH_PATTERN = /^"([^/]+).*"$/;
 

--- a/lib/jdl/core/parsing/validator.ts
+++ b/lib/jdl/core/parsing/validator.ts
@@ -40,7 +40,7 @@ const ENUM_PROP_VALUE_PATTERN = /^[A-Za-z]\w*$/;
 const METHOD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-_]*$/;
 
 // const PASSWORD_PATTERN = /^(.+)$/;
-const REPONAME_PATTERN = /^"((?:http(s)?:\/\/)?[\w-]+(?:\.[\w-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+|[a-zA-Z0-9]+)"$/;
+const REPONAME_PATTERN = /^"((?:https?:\/\/)?(?:[\w-]+\.)+[\w-]+(?:[:/?#][\w\-._~:/?#[\]@!$&'()*+,;=]*)?|[a-zA-Z0-9]+)"$/;
 const KUBERNETES_STORAGE_CLASS_NAME = /^"[A-Za-z]*"$/;
 const PATH_PATTERN = /^"([^/]+).*"$/;
 


### PR DESCRIPTION
Potential fix for <a href="https://github.com/jhipster/generator-jhipster/security/code-scanning/75">https://github.com/jhipster/generator-jhipster/security/code-scanning/75</a>

Best general fix: remove ambiguous overlap between repeated parts and ensure the optional suffix after the host starts with a real URL separator instead of being freely consumed by the host-matching portion.

For this file, the targeted fix updates `REPONAME_PATTERN` in `lib/jdl/core/parsing/validator.ts` so the host is matched as explicit dot-separated labels and any optional remainder only begins after `:`, `/`, `?`, or `#`.

This keeps the existing accepted forms used by deployment settings, including plain alphanumeric names, dotted hosts, HTTPS URLs, and host/path combinations, while removing the backtracking hotspot in the original expression.

The change also updates `lib/jdl/core/parsing/validator.spec.ts` to cover the accepted URL forms and avoid coupling the test to the exact regex string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._