### PR TITLE
heroku: URL substring sanitization

### DIFF
--- a/generators/heroku/generator.ts
+++ b/generators/heroku/generator.ts
@@ -556,13 +556,25 @@ export default class HerokuGenerator extends BaseSimpleApplicationGenerator<Hero
     return child;
   }
 
+  private stderrContainsVerifyAccountUrl(stderr: string): boolean {
+    const urlMatches = stderr.match(/https?:\/\/[^\s)]+/g) ?? [];
+    return urlMatches.some(urlText => {
+      try {
+        const parsed = new URL(urlText);
+        return parsed.host === 'heroku.com' && (parsed.pathname === '/verify' || parsed.pathname === '/verify/');
+      } catch {
+        return false;
+      }
+    });
+  }
+
   checkAddOnReturn({ addOn, stdout, stderr }: { addOn: string; stdout: string; stderr: string }) {
     if (stdout) {
       this.log.ok(`Created ${addOn} add-on`);
       this.log.ok(stdout);
     } else if (stderr) {
       const verifyAccountUrl = 'https://heroku.com/verify';
-      if (stderr.includes(verifyAccountUrl)) {
+      if (this.stderrContainsVerifyAccountUrl(stderr)) {
         this.log.error(`Account must be verified to use addons. Please go to: ${verifyAccountUrl}`);
         throw new Error(stderr);
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/jhipster/generator-jhipster/security/code-scanning/21](https://github.com/jhipster/generator-jhipster/security/code-scanning/21)

Use URL parsing on extracted URL-like tokens from `stderr`, then compare parsed host/path to expected values rather than doing raw substring matching.

Best minimal fix in `generators/heroku/generator.ts`:
- Add a small helper method in `HerokuGenerator` that scans text for `http(s)` URLs, parses each with `new URL(...)`, and returns true only when it finds `host === 'heroku.com'` and `pathname === '/verify'` (optionally allowing trailing slash).
- Replace `stderr.includes(verifyAccountUrl)` with this helper call.
- Keep existing behavior/messages unchanged.

No new dependency is required; use the built-in `URL` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
