### PR TITLE
Sonar: Use assertDoesNotThrow() instead of try/catch and fail() in the catch block

### DIFF
--- a/generators/spring-boot/templates/src/test/java/_package_/service/MailServiceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/service/MailServiceIT.java.ejs
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -210,11 +211,7 @@ class MailServiceIT {
     @Test
     void testSendEmailWithException() {
         doThrow(MailSendException.class).when(javaMailSender).send(any(MimeMessage.class));
-        try {
-            mailService.sendEmail("john.doe@example.com", "testSubject", "testContent", false, false);
-        } catch (Exception e) {
-            fail("Exception shouldn't have been thrown");
-        }
+        assertDoesNotThrow(() -> mailService.sendEmail("john.doe@example.com", "testSubject", "testContent", false, false));
     }
 
     @Test


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=jhipster-sample-application&open=AZ68yYLc3tnZRkZ2nktH
