### PR TITLE
Add gold sponsors section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Support this project by becoming a sponsor! [Become a sponsor](https://opencolle
 
 **Thank you to our sponsors!**
 
+### Gold sponsors
+
+[![GoldSponsors][gold-sponsors-image]][gold-sponsors-url]
+
 ### Bronze sponsors
 
 [![BronzeSponsors][bronze-sponsors-image]][bronze-sponsors-url]
@@ -128,6 +132,8 @@ Additional builds at [hipster-labs/jhipster-daily-builds](https://github.com/hip
 [backers-url]: https://opencollective.com/generator-jhipster
 [bronze-sponsors-image]: https://opencollective.com/generator-jhipster/tiers/bronze-sponsor.svg?avatarHeight=120&width=890
 [bronze-sponsors-url]: https://opencollective.com/generator-jhipster
+[gold-sponsors-image]: https://opencollective.com/generator-jhipster/tiers/gold-sponsor.svg?avatarHeight=180&width=890
+[gold-sponsors-url]: https://opencollective.com/generator-jhipster
 [issue-template]: https://github.com/jhipster/generator-jhipster/issues/new?template=BUG_REPORT.md
 [feature-template]: https://github.com/jhipster/generator-jhipster/issues/new?template=FEATURE_REQUEST.md
 [npmcharts-image]: https://img.shields.io/npm/dm/generator-jhipster.svg?label=Downloads&style=flat


### PR DESCRIPTION
## What

Gold sponsors (e.g. [CodeRabbit](https://opencollective.com/coderabbit)) were not visible in the README. The **Sponsors** section only rendered the **bronze** tier and backers — there was no gold sponsor section at all.

## Change

Add a **Gold sponsors** section above the bronze one, rendered from the OpenCollective gold-sponsor tier SVG:

`https://opencollective.com/generator-jhipster/tiers/gold-sponsor.svg?avatarHeight=180&width=890`

A larger `avatarHeight` (180 vs bronze's 120) is used to reflect gold being the top sponsorship tier.

The gold-sponsor tier SVG already exists on OpenCollective and includes the current gold sponsors, so no other change is required.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
