### PR TITLE
Add Vinyl to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "jiti": "2.7.0",
         "jsdoc": "4.0.5",
         "rimraf": "6.1.3",
+        "vinyl": "3.0.1",
         "yeoman-test": "11.6.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "jiti": "2.7.0",
     "jsdoc": "4.0.5",
     "rimraf": "6.1.3",
+    "vinyl": "3.0.1",
     "yeoman-test": "11.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
`vinyl` is imported as a type but only resolved transitively; declare it explicitly so it doesn't break when transitive deps change

https://github.com/search?q=repo%3Ajhipster%2Fgenerator-jhipster+vinyl&type=code