### PR TITLE
generate-blueprint: only run tsc in typescript blueprint

### DIFF
--- a/generators/generate-blueprint/generators/standalone/generator.ts
+++ b/generators/generate-blueprint/generators/standalone/generator.ts
@@ -152,7 +152,7 @@ export default class StandaloneBlueprintGenerator extends GenerateBlueprintBaseG
         }
       },
       packageJson({ application }) {
-        const { jhipsterPackageJson } = application;
+        const { javascriptBlueprint, jhipsterPackageJson } = application;
         const mainDependencies: Record<string, string> = {
           ...jhipsterPackageJson.dependencies,
           ...jhipsterPackageJson.devDependencies,
@@ -169,7 +169,7 @@ export default class StandaloneBlueprintGenerator extends GenerateBlueprintBaseG
             ejslint: 'ejslint generators/**/*.ejs',
             lint: 'eslint',
             'lint-fix': 'npm run ejslint && npm run lint -- --fix',
-            pretest: 'npm run prettier-check && npm run lint && tsc',
+            pretest: `npm run prettier-check && npm run lint${javascriptBlueprint ? '' : ' && tsc'}`,
             test: 'vitest run',
             'update-snapshot': 'vitest run --update',
             vitest: 'vitest',


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/33923
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
