### PR TITLE
generate-blueprint: pass JHI_JWT_SECRET_KEY to improve compare-sample

### DIFF
--- a/generators/generate-blueprint/generators/standalone/templates/.github/workflows/samples.yml.ejs
+++ b/generators/generate-blueprint/generators/standalone/templates/.github/workflows/samples.yml.ejs
@@ -57,6 +57,8 @@ jobs:
       - run: npm install
         working-directory: ${{ github.workspace }}/generator-jhipster-<%- baseName %>
       - run: <%- blueprintCliName %> generate-sample ${{ matrix.sample }} --skip-jhipster-dependencies --skip-install ${{ matrix.extra-args }}
+        env:
+          JHI_JWT_SECRET_KEY: ${{ matrix.jwt-secret-key }}
       - uses: <%- githubActions['jhipster/actions/compare-sample'] %>
         id: compare
         if: >-
@@ -65,6 +67,8 @@ jobs:
         with:
           generator-path: generator-jhipster-<%- baseName %>
           cmd: <%- blueprintCliName %> generate-sample ${{ matrix.sample }} --skip-jhipster-dependencies --skip-install ${{ matrix.extra-args }}
+        env:
+          JHI_JWT_SECRET_KEY: ${{ matrix.jwt-secret-key }}
       - run: npm run ci:backend:test
         if: steps.compare.outputs.equals != 'true'
         id: backend


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/33923
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
