### PR TITLE
Forward X-Forwarded-Port to fix oauth2 login in webpack dev server

### DIFF
--- a/generators/angular/templates/webpack/webpack.custom.js.ejs
+++ b/generators/angular/templates/webpack/webpack.custom.js.ejs
@@ -60,7 +60,7 @@ module.exports = async (config, options, targetOptions) => {
     config.plugins.push(
       new BrowserSyncPlugin(
         {
-          host: 'localhost',
+          host: '127.0.0.1',
           port: <%- devServerPortProxy %>,
           https: tls,
           proxy: {
@@ -73,6 +73,7 @@ module.exports = async (config, options, targetOptions) => {
               function (proxyReq) {
                 // URI that will be retrieved by the ForwardedHeaderFilter on the server side
                 proxyReq.setHeader('X-Forwarded-Host', 'localhost:<%- devServerPortProxy %>');
+                proxyReq.setHeader('X-Forwarded-Port', '<%- devServerPortProxy %>');
                 proxyReq.setHeader('X-Forwarded-Proto', `http${tls ? 's' : ''}`);
               },
             ],


### PR DESCRIPTION
Build broken: https://github.com/jhipster/generator-jhipster/actions/runs/28345888707/job/84036631678?pr=33945

Related to #28316 