### PR TITLE
fix(angular): make AlertService own alert state as signal to fix runt…

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/core/util/alert.service.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/alert.service.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { inject, Injectable, SecurityContext } from '@angular/core';
+import { inject, Injectable, SecurityContext, signal } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 <%_ if (enableTranslation) { _%>
 import { TranslateService } from '@ngx-translate/core';
@@ -37,7 +37,7 @@ export interface AlertModel {
   timeout?: number;
   toast?: boolean;
   position?: string;
-  close?: (alerts: AlertModel[]) => void;
+  close?: (alerts?: AlertModel[]) => void;
 }
 
 @Injectable({
@@ -50,7 +50,8 @@ export class AlertService {
 
   // unique id for each alert. Starts from 0.
   private alertId = 0;
-  private alerts: AlertModel[] = [];
+  private alertsSignal = signal<AlertModel[]>([]);
+  readonly alerts = this.alertsSignal.asReadonly();
 
   private readonly sanitizer = inject(DomSanitizer);
 <%_ if (enableTranslation) { _%>
@@ -58,24 +59,16 @@ export class AlertService {
 <%_ } _%>
 
   clear(): void {
-    this.alerts = [];
-  }
-
-  get(): AlertModel[] {
-    return this.alerts;
+    this.alertsSignal.set([]);
   }
 
   /**
    * Adds alert to alerts array and returns added alert.
    * @param alertToAdd Alert to add. If `timeout`, `toast` or `position` is missing then applying default value.
-<%_ if (enableTranslation) { _%>
    *                   If `translateKey` is available then it's translation else `message` is used for showing.
-<%_ } _%>
-   * @param extAlerts  If missing then adding `alert` to `AlertService` internal array and alerts can be retrieved by `get()`.
-   *                   Else adding `alert` to `extAlerts`.
    * @returns  Added alert
    */
-  addAlert(alertToAdd: Omit<AlertModel, 'id'>, extAlerts?: AlertModel[]): AlertModel {
+  addAlert(alertToAdd: Omit<AlertModel, 'id'>): AlertModel {
     const alert: AlertModel = { ...alertToAdd, id: this.alertId++ };
 
 <%_ if (enableTranslation) { _%>
@@ -93,25 +86,21 @@ export class AlertService {
     alert.timeout ??= this.timeout;
     alert.toast ??= this.toast;
     alert.position ??= this.position;
-    alert.close = (alertsArray: AlertModel[]) => this.closeAlert(alert.id, alertsArray);
+    alert.close = () => this.closeAlert(alert.id);
 
-    (extAlerts ?? this.alerts).push(alert);
+    this.alertsSignal.update(alerts => [...alerts, alert]);
 
     if (alert.timeout > 0) {
       setTimeout(() => {
-        this.closeAlert(alert.id, extAlerts ?? this.alerts);
+        this.closeAlert(alert.id);
       }, alert.timeout);
     }
 
     return alert;
   }
 
-  private closeAlert(alertId: number, extAlerts?: AlertModel[]): void {
-    const alerts = extAlerts ?? this.alerts;
-    const alertIndex = alerts.map(alert => alert.id).indexOf(alertId);
-    // if found alert then remove
-    if (alertIndex >= 0) {
-      alerts.splice(alertIndex, 1);
-    }
+  closeAlert(alertId: number): void {
+    this.alertsSignal.update(alerts => alerts.filter(alert => alert.id !== alertId));
   }
+}
 }

--- a/generators/angular/templates/src/main/webapp/app/shared/alert/alert-error.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/alert/alert-error.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, ChangeDetectionStrategy, inject, OnDestroy, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, OnDestroy } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Subscription } from 'rxjs';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
@@ -36,7 +36,7 @@ import { getMessageFromHeaders } from 'app/shared/jhipster/headers';
   imports: [NgbAlert],
 })
 export class AlertError implements OnDestroy {
-  readonly alerts = signal<AlertModel[]>([]);
+  readonly alerts = this.alertService.alerts;
   errorListener: Subscription;
   httpErrorListener: Subscription;
 
@@ -71,11 +71,11 @@ export class AlertError implements OnDestroy {
   }
 
   close(alert: AlertModel): void {
-    alert.close?.(this.alerts());
+    alert.close?.();
   }
 
   private addErrorAlert(message?: string<%- enableTranslation ? ', translationKey?: string, translationParams?: Record<string, unknown>' : '' %>): void {
-    this.alertService.addAlert({ type: 'danger', message<%- enableTranslation ? ', translationKey, translationParams' : '' %> }, this.alerts());
+    this.alertService.addAlert({ type: 'danger', message<%- enableTranslation ? ', translationKey, translationParams' : '' %> });
   }
 
   private handleHttpError(response: EventWithContent<unknown> | string): void {

--- a/generators/angular/templates/src/main/webapp/app/shared/alert/alert.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/alert/alert.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, ChangeDetectionStrategy, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, OnDestroy } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 
 import { AlertService, AlertModel } from 'app/core/util/alert.service';
@@ -27,14 +27,10 @@ import { AlertService, AlertModel } from 'app/core/util/alert.service';
   templateUrl: './alert.html',
   imports: [NgbAlert],
 })
-export class Alert implements OnInit, OnDestroy {
-  readonly alerts = signal<AlertModel[]>([]);
+export class Alert implements OnDestroy {
+  readonly alerts = this.alertService.alerts;
 
   private readonly alertService = inject(AlertService);
-
-  ngOnInit(): void {
-    this.alerts.set(this.alertService.get());
-  }
 
   setClasses(alert: AlertModel): Record<string, boolean> {
     const classes = { 'jhi-toast': Boolean(alert.toast) };
@@ -49,6 +45,6 @@ export class Alert implements OnInit, OnDestroy {
   }
 
   close(alert: AlertModel): void {
-    alert.close?.(this.alerts());
+    alert.close?.();
   }
 }


### PR DESCRIPTION
Fixes #33070

## Problem
The generated Angular alert templates mixed signal-based components
with in-place array mutation in AlertService. This caused:
1. Runtime alerts (post-init) not rendering in `jhi-alert`
2. Multiple error alerts not auto-dismissing correctly

## Fix
- AlertService now owns alert state in a `signal<AlertModel[]>`
- Alerts are updated immutably (`update`, `filter`) — no `push`/`splice`
- `Alert` component reads directly from `alertService.alerts` (live signal)
- `AlertError` no longer passes an array snapshot to `addAlert`
- Timeout dismissal always operates on the current signal state

## Testing
- [ ] Verified runtime `addAlert()` calls render in `jhi-alert`
- [ ] Verified multiple error alerts all auto-dismiss correctly