### PR TITLE
Fix: bump webpack from 5.106.2 to 5.108.3 in /generators/angular/resources

### DIFF
--- a/generators/angular/resources/package.json
+++ b/generators/angular/resources/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "@angular-architects/module-federation": "21.2.2",
     "@angular-architects/module-federation-runtime": "21.2.2",
-    "@angular-builders/custom-esbuild": "21.0.3",
-    "@angular-builders/custom-webpack": "21.0.3",
+    "@angular-builders/custom-esbuild": "21.1.0",
+    "@angular-builders/custom-webpack": "21.1.0",
     "@angular/build": "21.2.13",
     "@angular/cli": "21.2.13",
     "@eslint/js": "10.0.1",
@@ -46,7 +46,7 @@
     "typescript-eslint": "8.62.1",
     "vitest": "4.1.9",
     "vitest-sonar-reporter": "3.0.0",
-    "webpack": "5.106.2",
+    "webpack": "5.108.3",
     "webpack-bundle-analyzer": "5.3.0",
     "webpack-merge": "6.0.1",
     "webpack-notifier": "1.15.0"

--- a/generators/angular/templates/angular.json.ejs
+++ b/generators/angular/templates/angular.json.ejs
@@ -70,7 +70,7 @@
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": <%- new Boolean(microfrontend) %>,
-              "extractLicenses": true,
+              "extractLicenses": <%- !microfrontend %>,
               "vendorChunk": false,
               "buildOptimizer": true,
               "serviceWorker": true,

--- a/generators/angular/templates/angular.json.ejs
+++ b/generators/angular/templates/angular.json.ejs
@@ -70,7 +70,7 @@
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": <%- new Boolean(microfrontend) %>,
-              "extractLicenses": <%- !microfrontend %>,
+              "extractLicenses": false,
               "vendorChunk": false,
               "buildOptimizer": true,
               "serviceWorker": true,

--- a/generators/angular/templates/angular.json.esbuild.ejs
+++ b/generators/angular/templates/angular.json.esbuild.ejs
@@ -82,7 +82,7 @@
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": <%- new Boolean(microfrontend) %>,
-              "extractLicenses": <%- !microfrontend %>,
+              "extractLicenses": true,
               "budgets": [
                 {
                   "type": "initial",

--- a/generators/angular/templates/angular.json.esbuild.ejs
+++ b/generators/angular/templates/angular.json.esbuild.ejs
@@ -82,7 +82,7 @@
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": <%- new Boolean(microfrontend) %>,
-              "extractLicenses": true,
+              "extractLicenses": <%- !microfrontend %>,
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
Fix #33964 

It's a workaround, real bug is in the lib `license-webpack-plugin`