### PR TITLE
Angular: remove leftover jest conditionals now that vitest is the only test framework

### DIFF
--- a/generators/angular/templates/eslint.config.ts.jhi.angular.ejs
+++ b/generators/angular/templates/eslint.config.ts.jhi.angular.ejs
@@ -22,7 +22,7 @@ import eslint from '@eslint/js';
 import angular from 'angular-eslint';
 <&_ } -&>
 <&_ if (fragment.configSection) { -&>
-  { ignores: ['<%- this.relativeDir(clientRootDir, clientDistDir) %>', '<%- temporaryDir %>', '<%- this.relativeDir(clientRootDir, clientSrcDir) %>swagger-ui/'<%- clientTestFrameworkVitest ? ', \'dist/\'' : '' %>] },
+  { ignores: ['<%- this.relativeDir(clientRootDir, clientDistDir) %>', '<%- temporaryDir %>', '<%- this.relativeDir(clientRootDir, clientSrcDir) %>swagger-ui/', 'dist/'] },
   eslint.configs.recommended,
   {
     files: ['**/*.{js,cjs,mjs}'],

--- a/generators/angular/templates/src/main/webapp/app/account/activate/activate.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/activate/activate.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/account/activate/activate.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/activate/activate.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed, inject } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 <%_ if (enableTranslation) { _%>
@@ -52,7 +50,7 @@ describe('Activate', () => {
   });
 
   it('calls activate.get with the key from params', inject([ActivateService], (service: ActivateService) => {
-    <%- clientTestFramework %>.spyOn(service, 'get').mockReturnValue(of());
+    vitest.spyOn(service, 'get').mockReturnValue(of());
 
     comp.ngOnInit();
 
@@ -60,7 +58,7 @@ describe('Activate', () => {
   }));
 
   it('should set success to true upon successful activation', inject([ActivateService], (service: ActivateService) => {
-    <%- clientTestFramework %>.spyOn(service, 'get').mockReturnValue(of({}));
+    vitest.spyOn(service, 'get').mockReturnValue(of({}));
 
     comp.ngOnInit();
 
@@ -69,7 +67,7 @@ describe('Activate', () => {
   }));
 
   it('should set error to true upon activation failure', inject([ActivateService], (service: ActivateService) => {
-    <%- clientTestFramework %>.spyOn(service, 'get').mockReturnValue(throwError(Error));
+    vitest.spyOn(service, 'get').mockReturnValue(throwError(Error));
 
     comp.ngOnInit();
 

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/finish/password-reset-finish.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ElementRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
@@ -61,7 +59,7 @@ describe('PasswordResetFinish', () => {
 
   it('sets focus after the view has been initialized', () => {
     const node = {
-      focus: <%- clientTestFramework %>.fn(),
+      focus: vitest.fn(),
     };
     comp.newPassword = signal(new ElementRef(node));
 
@@ -82,7 +80,7 @@ describe('PasswordResetFinish', () => {
   });
 
   it('should update success to true after resetting password', inject([PasswordResetFinishService], (service: PasswordResetFinishService) => {
-    <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(of({}));
+    vitest.spyOn(service, 'save').mockReturnValue(of({}));
     comp.passwordForm.patchValue({
       newPassword: 'password',
       confirmPassword: 'password',
@@ -95,7 +93,7 @@ describe('PasswordResetFinish', () => {
   }));
 
   it('should notify of generic error', inject([PasswordResetFinishService], (service: PasswordResetFinishService) => {
-    <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(throwError(Error));
+    vitest.spyOn(service, 'save').mockReturnValue(throwError(Error));
     comp.passwordForm.patchValue({
       newPassword: 'password',
       confirmPassword: 'password',

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password-reset/init/password-reset-init.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ElementRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
@@ -47,7 +45,7 @@ describe('PasswordResetInit', () => {
 
   it('sets focus after the view has been initialized', () => {
     const node = {
-      focus: <%- clientTestFramework %>.fn(),
+      focus: vitest.fn(),
     };
     comp.email = signal(new ElementRef(node));
 
@@ -57,7 +55,7 @@ describe('PasswordResetInit', () => {
   });
 
   it('notifies of success upon successful requestReset', () => {
-    <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(of({}));
+    vitest.spyOn(service, 'save').mockReturnValue(of({}));
     comp.resetRequestForm.patchValue({
       email: 'user@domain.com',
     });
@@ -70,7 +68,7 @@ describe('PasswordResetInit', () => {
 
   it('no notification of success upon error response', () => {
     const err = { status: 503, data: 'something else' };
-    <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(throwError(() => err));
+    vitest.spyOn(service, 'save').mockReturnValue(throwError(() => err));
     comp.resetRequestForm.patchValue({
       email: 'user@domain.com',
     });

--- a/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
 import { provideTranslateService } from '@ngx-translate/core';

--- a/generators/angular/templates/src/main/webapp/app/account/password/password.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password.service.spec.ts.ejs
@@ -1,6 +1,4 @@
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/account/password/password.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
@@ -40,7 +38,7 @@ describe('Password', () => {
         {
           provide: AccountService,
           useValue: {
-            isAuthenticated: <%- clientTestFramework %>.fn(),
+            isAuthenticated: vitest.fn(),
           },
         },
       ],
@@ -74,7 +72,7 @@ describe('Password', () => {
       newPassword: 'myPassword',
     };
 
-    <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(of(new HttpResponse({ body: true })));
+    vitest.spyOn(service, 'save').mockReturnValue(of(new HttpResponse({ body: true })));
 
     comp.passwordForm.patchValue({
       currentPassword: passwordValues.currentPassword,
@@ -91,7 +89,7 @@ describe('Password', () => {
 
   it('should set success to true upon success', () => {
     // GIVEN
-    <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(of(new HttpResponse({ body: true })));
+    vitest.spyOn(service, 'save').mockReturnValue(of(new HttpResponse({ body: true })));
     comp.passwordForm.patchValue({
       newPassword: 'myPassword',
       confirmPassword: 'myPassword',
@@ -108,7 +106,7 @@ describe('Password', () => {
 
   it('should notify of error if change password fails', () => {
     // GIVEN
-    <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(throwError(Error));
+    vitest.spyOn(service, 'save').mockReturnValue(throwError(Error));
     comp.passwordForm.patchValue({
       newPassword: 'myPassword',
       confirmPassword: 'myPassword',

--- a/generators/angular/templates/src/main/webapp/app/account/register/register.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/register/register.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/account/register/register.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/register/register.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
@@ -68,9 +66,9 @@ describe('Register', () => {
   it('should update success to true after creating an account', inject(
     [RegisterService<%- enableTranslation ? ', TranslateService' : '' %>],
     (service: RegisterService<%- enableTranslation ? ', mockTranslateService: TranslateService' : '' %>) => {
-      <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(of({}));
+      vitest.spyOn(service, 'save').mockReturnValue(of({}));
 <%_ if (enableTranslation) { _%>
-      <%- clientTestFramework %>.spyOn(mockTranslateService, 'getCurrentLang').mockReturnValue('<%- nativeLanguage %>');
+      vitest.spyOn(mockTranslateService, 'getCurrentLang').mockReturnValue('<%- nativeLanguage %>');
 <%_ } _%>
       comp.registerForm.patchValue({
         password: 'password',
@@ -96,7 +94,7 @@ describe('Register', () => {
     [RegisterService],
     (service: RegisterService) => {
       const err = { status: 400, error: { type: LOGIN_ALREADY_USED_TYPE } };
-      <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(throwError(() => err));
+      vitest.spyOn(service, 'save').mockReturnValue(throwError(() => err));
       comp.registerForm.patchValue({
         password: 'password',
         confirmPassword: 'password',
@@ -114,7 +112,7 @@ describe('Register', () => {
     [RegisterService],
     (service: RegisterService) => {
       const err = { status: 400, error: { type: EMAIL_ALREADY_USED_TYPE } };
-      <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(throwError(() => err));
+      vitest.spyOn(service, 'save').mockReturnValue(throwError(() => err));
       comp.registerForm.patchValue({
         password: 'password',
         confirmPassword: 'password',
@@ -132,7 +130,7 @@ describe('Register', () => {
     [RegisterService],
     (service: RegisterService) => {
       const err = { status: 503 };
-      <%- clientTestFramework %>.spyOn(service, 'save').mockReturnValue(throwError(() => err));
+      vitest.spyOn(service, 'save').mockReturnValue(throwError(() => err));
       comp.registerForm.patchValue({
         password: 'password',
         confirmPassword: 'password',

--- a/generators/angular/templates/src/main/webapp/app/account/sessions/sessions.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/sessions/sessions.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 
@@ -62,8 +60,8 @@ describe('Sessions', () => {
   it('should define its initial state', inject(
     [AccountService, SessionsService],
     (mockAccountService: AccountService, service: SessionsService) => {
-      mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(account));
-      <%- clientTestFramework %>.spyOn(service, 'findAll').mockReturnValue(of(sessions));
+      mockAccountService.identity = vitest.fn(() => of(account));
+      vitest.spyOn(service, 'findAll').mockReturnValue(of(sessions));
 
       comp.ngOnInit();
 
@@ -79,9 +77,9 @@ describe('Sessions', () => {
   it('should call delete on Sessions to invalidate a session', inject(
     [AccountService, SessionsService],
     (mockAccountService: AccountService, service: SessionsService) => {
-      mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(account));
-      <%- clientTestFramework %>.spyOn(service, 'findAll').mockReturnValue(of(sessions));
-      <%- clientTestFramework %>.spyOn(service, 'delete').mockReturnValue(of({}));
+      mockAccountService.identity = vitest.fn(() => of(account));
+      vitest.spyOn(service, 'findAll').mockReturnValue(of(sessions));
+      vitest.spyOn(service, 'delete').mockReturnValue(of({}));
 
       comp.ngOnInit();
       comp.invalidate('xyz');
@@ -93,9 +91,9 @@ describe('Sessions', () => {
   it('should call delete on Sessions and notify of error', inject(
     [AccountService, SessionsService],
     (mockAccountService: AccountService, service: SessionsService) => {
-      mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(account));
-      <%- clientTestFramework %>.spyOn(service, 'findAll').mockReturnValue(of(sessions));
-      <%- clientTestFramework %>.spyOn(service, 'delete').mockReturnValue(throwError(Error));
+      mockAccountService.identity = vitest.fn(() => of(account));
+      vitest.spyOn(service, 'findAll').mockReturnValue(of(sessions));
+      vitest.spyOn(service, 'delete').mockReturnValue(throwError(Error));
 
       comp.ngOnInit();
       comp.invalidate('xyz');
@@ -108,9 +106,9 @@ describe('Sessions', () => {
   it('should call notify of success upon session invalidation', inject(
     [AccountService, SessionsService],
     (mockAccountService: AccountService, service: SessionsService) => {
-      mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(account));
-      <%- clientTestFramework %>.spyOn(service, 'findAll').mockReturnValue(of(sessions));
-      <%- clientTestFramework %>.spyOn(service, 'delete').mockReturnValue(of({}));
+      mockAccountService.identity = vitest.fn(() => of(account));
+      vitest.spyOn(service, 'findAll').mockReturnValue(of(sessions));
+      vitest.spyOn(service, 'delete').mockReturnValue(of({}));
 
       comp.ngOnInit();
       comp.invalidate('xyz');

--- a/generators/angular/templates/src/main/webapp/app/account/settings/settings.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/settings/settings.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 <%_ if (enableTranslation) { _%>
@@ -55,7 +53,7 @@ describe('Settings', () => {
         {
           provide: AccountService,
           useValue: {
-            authenticate: <%- clientTestFramework %>.fn(),
+            authenticate: vitest.fn(),
           },
         },
       ],
@@ -66,12 +64,12 @@ describe('Settings', () => {
     fixture = TestBed.createComponent(Settings);
     comp = fixture.componentInstance;
     mockAccountService = TestBed.inject(AccountService);
-    mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(account));
+    mockAccountService.identity = vitest.fn(() => of(account));
   });
 
   it('should send the current identity upon save', () => {
     // GIVEN
-    mockAccountService.save = <%- clientTestFramework %>.fn(() => of({}));
+    mockAccountService.save = vitest.fn(() => of({}));
     const settingsFormValues = {
       firstName: 'John',
       lastName: 'Doe',
@@ -94,7 +92,7 @@ describe('Settings', () => {
 
   it('should notify of success upon successful save', () => {
     // GIVEN
-    mockAccountService.save = <%- clientTestFramework %>.fn(() => of({}));
+    mockAccountService.save = vitest.fn(() => of({}));
 
     // WHEN
     comp.ngOnInit();
@@ -106,7 +104,7 @@ describe('Settings', () => {
 
   it('should notify of error upon failed save', () => {
     // GIVEN
-    mockAccountService.save = <%- clientTestFramework %>.fn(() => throwError(Error));
+    mockAccountService.save = vitest.fn(() => throwError(Error));
 
     // WHEN
     comp.ngOnInit();

--- a/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/configuration/configuration.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
@@ -66,8 +64,8 @@ describe('Configuration', () => {
           },
         },
       ];
-      <%- clientTestFramework %>.spyOn(service, 'getBeans').mockReturnValue(of(beans));
-      <%- clientTestFramework %>.spyOn(service, 'getPropertySources').mockReturnValue(of(propertySources));
+      vitest.spyOn(service, 'getBeans').mockReturnValue(of(beans));
+      vitest.spyOn(service, 'getPropertySources').mockReturnValue(of(propertySources));
 
       // WHEN
       comp.ngOnInit();

--- a/generators/angular/templates/src/main/webapp/app/admin/health/health.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/health/health.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/admin/health/health.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/health/health.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 <%_ if (enableTranslation) { _%>
@@ -62,7 +60,7 @@ describe('Health', () => {
     it('should call refresh on init', () => {
       // GIVEN
       const health: HealthModel = { status: 'UP', components: { mail: { status: 'UP', details: { mailDetail: 'mail' } } } };
-      <%- clientTestFramework %>.spyOn(service, 'checkHealth').mockReturnValue(of(health));
+      vitest.spyOn(service, 'checkHealth').mockReturnValue(of(health));
 
       // WHEN
       comp.ngOnInit();
@@ -75,7 +73,7 @@ describe('Health', () => {
     it('should handle a 503 on refreshing health data', () => {
       // GIVEN
       const health: HealthModel = { status: 'DOWN', components: { mail: { status: 'DOWN' } } };
-      <%- clientTestFramework %>.spyOn(service, 'checkHealth').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 503, error: health })));
+      vitest.spyOn(service, 'checkHealth').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 503, error: health })));
 
       // WHEN
       comp.refresh();

--- a/generators/angular/templates/src/main/webapp/app/admin/health/modal/health-modal.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/health/modal/health-modal.spec.ts.ejs
@@ -1,6 +1,4 @@
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
@@ -98,7 +96,7 @@ describe('HealthModal', () => {
   describe('dismiss', () => {
     it('should call dismiss when dismiss modal is called', () => {
       // GIVEN
-      const spy = <%- clientTestFramework %>.spyOn(mockActiveModal, 'dismiss');
+      const spy = vitest.spyOn(mockActiveModal, 'dismiss');
 
       // WHEN
       comp.dismiss();

--- a/generators/angular/templates/src/main/webapp/app/admin/logs/logs.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/logs/logs.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/admin/logs/logs.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/logs/logs.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of } from 'rxjs';
@@ -60,7 +58,7 @@ describe('Logs', () => {
     it('should call load all on init', () => {
       // GIVEN
       const log = new Log('main', 'WARN');
-      <%- clientTestFramework %>.spyOn(service, 'findAll').mockReturnValue(
+      vitest.spyOn(service, 'findAll').mockReturnValue(
         of({
           loggers: {
             main: {
@@ -83,8 +81,8 @@ describe('Logs', () => {
     it('should change log level correctly', () => {
       // GIVEN
       const log = new Log('main', 'ERROR');
-      <%- clientTestFramework %>.spyOn(service, 'changeLevel').mockReturnValue(of({}));
-      <%- clientTestFramework %>.spyOn(service, 'findAll').mockReturnValue(
+      vitest.spyOn(service, 'changeLevel').mockReturnValue(of({}));
+      vitest.spyOn(service, 'findAll').mockReturnValue(
         of({
           loggers: {
             main: {

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 <%_ if (enableTranslation) { _%>
@@ -320,7 +318,7 @@ describe('MetricsModalThreads', () => {
   describe('dismiss', () => {
     it('should call dismiss function for modal on dismiss', () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(mockActiveModal, 'dismiss');
+      vitest.spyOn(mockActiveModal, 'dismiss');
 
       // WHEN
       comp.dismiss();

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/admin/metrics/metrics.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
 import { provideTranslateService } from '@ngx-translate/core';
@@ -65,8 +63,8 @@ describe('Metrics', () => {
       } as unknown as MetricsModel;
       const threadDump = { threads: [{ threadName: 'thread 1' } as Thread] };
 
-      <%- clientTestFramework %>.spyOn(service, 'getMetrics').mockReturnValue(of(metrics));
-      <%- clientTestFramework %>.spyOn(service, 'threadDump').mockReturnValue(of(threadDump));
+      vitest.spyOn(service, 'getMetrics').mockReturnValue(of(metrics));
+      vitest.spyOn(service, 'threadDump').mockReturnValue(of(threadDump));
 
       // WHEN
       comp.ngOnInit();

--- a/generators/angular/templates/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { Mock, afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
@@ -49,7 +47,7 @@ function accountWithAuthorities(authorities: string[]): Account {
   };
 }
 
-const mockFn = (value: string | null): Mock => <%- clientTestFramework %>.fn(() => value);
+const mockFn = (value: string | null): Mock => vitest.fn(() => value);
 
 describe('Account Service', () => {
   let service: AccountService;
@@ -73,8 +71,8 @@ describe('Account Service', () => {
         {
           provide: StateStorageService,
           useValue: {
-            clearUrl: <%- clientTestFramework %>.fn(),
-            getUrl: <%- clientTestFramework %>.fn(),
+            clearUrl: vitest.fn(),
+            getUrl: vitest.fn(),
           },
         },
       ],
@@ -87,11 +85,11 @@ describe('Account Service', () => {
     httpMock = TestBed.inject(HttpTestingController);
     mockStorageService = TestBed.inject(StateStorageService);
     mockRouter = TestBed.inject(Router);
-    <%- clientTestFramework %>.spyOn(mockRouter, 'navigateByUrl');
+    vitest.spyOn(mockRouter, 'navigateByUrl');
 <%_ if (enableTranslation) { _%>
 
     mockTranslateService = TestBed.inject(TranslateService);
-    <%- clientTestFramework %>.spyOn(mockTranslateService, 'use');
+    vitest.spyOn(mockTranslateService, 'use');
 <%_ } _%>
   });
 

--- a/generators/angular/templates/src/main/webapp/app/core/auth/auth-jwt.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/auth/auth-jwt.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 <%_ if (authenticationTypeJwt) { _%>
@@ -64,7 +62,7 @@ describe('Auth JWT', () => {
   describe('Login', () => {
     it('should clear session storage and save in local storage when rememberMe is true', () => {
       // GIVEN
-      mockStorageService.storeAuthenticationToken = <%- clientTestFramework %>.fn();
+      mockStorageService.storeAuthenticationToken = vitest.fn();
 
       // WHEN
       service.login({ username: 'John', password: '123', rememberMe: true }).subscribe();
@@ -77,7 +75,7 @@ describe('Auth JWT', () => {
 
     it('should clear local storage and save in session storage when rememberMe is false', () => {
       // GIVEN
-      mockStorageService.storeAuthenticationToken = <%- clientTestFramework %>.fn();
+      mockStorageService.storeAuthenticationToken = vitest.fn();
 
       // WHEN
       service.login({ username: 'John', password: '123', rememberMe: false }).subscribe();
@@ -92,7 +90,7 @@ describe('Auth JWT', () => {
   describe('Logout', () => {
     it('should clear storage', () => {
       // GIVEN
-      mockStorageService.clearAuthenticationToken = <%- clientTestFramework %>.fn();
+      mockStorageService.clearAuthenticationToken = vitest.fn();
 
       // WHEN
       service.logout().subscribe();

--- a/generators/angular/templates/src/main/webapp/app/core/config/application-config.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/config/application-config.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 
 import { ApplicationConfigService } from './application-config.service';

--- a/generators/angular/templates/src/main/webapp/app/core/util/alert.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/alert.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { inject, TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
 import { TranslateService, MissingTranslationHandler, provideTranslateService } from '@ngx-translate/core';
@@ -52,7 +50,7 @@ describe('Alert Service Test', () => {
     translateService = TestBed.inject(TranslateService);
     translateService.setFallbackLang('en');
 <%_ } _%>
-    <%- clientTestFramework %>.useFakeTimers();
+    vitest.useFakeTimers();
     extAlerts = [];
   });
 
@@ -186,7 +184,7 @@ describe('Alert Service Test', () => {
 
     expect(service.get()).toHaveLength(1);
 
-    <%- clientTestFramework %>.advanceTimersByTime(6000);
+    vitest.advanceTimersByTime(6000);
 
     expect(service.get()).toHaveLength(0);
   });

--- a/generators/angular/templates/src/main/webapp/app/core/util/data-util.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/data-util.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 
 import { DataUtils } from './data-util.service';
@@ -42,8 +40,8 @@ describe('Data Utils Service Test', () => {
   describe('openFile', () => {
     it('should open the file in the new window', () => {
       const newWindow = { ...window };
-      window.open = <%- clientTestFramework %>.fn(() => newWindow);
-      window.URL.createObjectURL = <%- clientTestFramework %>.fn();
+      window.open = vitest.fn(() => newWindow);
+      window.URL.createObjectURL = vitest.fn();
       // 'JHipster' in base64 is 'SkhpcHN0ZXI='
       const data = 'SkhpcHN0ZXI=';
       const contentType = 'text/plain';

--- a/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/event-manager.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 
 import { EventManager, EventWithContent } from './event-manager.service';

--- a/generators/angular/templates/src/main/webapp/app/core/util/operators.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/operators.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { filterNaN, isPresent } from './operators';
 
 describe('Operators Test', () => {

--- a/generators/angular/templates/src/main/webapp/app/core/util/parse-links.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/core/util/parse-links.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 
 import { ParseLinks } from './parse-links.service';

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/delete/_entityFile_-delete-dialog.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/delete/_entityFile_-delete-dialog.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const tsKeyId = primaryKey.tsSampleValues[0]; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
@@ -48,8 +46,8 @@ describe('<%- entityAngularName %> Management Delete Component', () => {
   describe('confirmDelete', () => {
     it('should call delete service on confirmDelete', () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(service, 'delete').mockReturnValue(of(undefined));
-      <%- clientTestFramework %>.spyOn(mockActiveModal, 'close');
+      vitest.spyOn(service, 'delete').mockReturnValue(of(undefined));
+      vitest.spyOn(mockActiveModal, 'close');
 
       // WHEN
       comp.confirmDelete(<%- tsKeyId %>);
@@ -61,9 +59,9 @@ describe('<%- entityAngularName %> Management Delete Component', () => {
 
     it('should not call delete service on clear', () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(service, 'delete');
-      <%- clientTestFramework %>.spyOn(mockActiveModal, 'close');
-      <%- clientTestFramework %>.spyOn(mockActiveModal, 'dismiss');
+      vitest.spyOn(service, 'delete');
+      vitest.spyOn(mockActiveModal, 'close');
+      vitest.spyOn(mockActiveModal, 'dismiss');
 
       // WHEN
       comp.cancel();

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/detail/_entityFile_-detail.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/detail/_entityFile_-detail.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const testEntity = tsPrimaryKeySamples[0]; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
@@ -66,7 +64,7 @@ describe('<%- entityAngularName %> Management Detail Component', () => {
     library.addIcons(faPencilAlt);
 <%_ if (anyFieldIsBlobDerived) { _%>
     dataUtils = TestBed.inject(DataUtils);
-    <%- clientTestFramework %>.spyOn(window, 'open').mockImplementation(() => null);
+    vitest.spyOn(window, 'open').mockImplementation(() => null);
 <%_ } _%>
   });
 
@@ -87,7 +85,7 @@ describe('<%- entityAngularName %> Management Detail Component', () => {
 
   describe('PreviousState', () => {
     it('should navigate to previous state', () => {
-      <%- clientTestFramework %>.spyOn(globalThis.history, 'back');
+      vitest.spyOn(globalThis.history, 'back');
       comp.previousState();
       expect(globalThis.history.back).toHaveBeenCalled();
     });
@@ -97,7 +95,7 @@ describe('<%- entityAngularName %> Management Detail Component', () => {
   describe('byteSize', () => {
     it('should call byteSize from DataUtils', () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(dataUtils, 'byteSize');
+      vitest.spyOn(dataUtils, 'byteSize');
       const fakeBase64 = 'fake base64';
 
       // WHEN
@@ -111,15 +109,11 @@ describe('<%- entityAngularName %> Management Detail Component', () => {
   describe('openFile', () => {
     it('should call openFile from DataUtils', () => {
       const newWindow = { ...window };
-  <%_ if (clientTestFrameworkVitest) { _%>
       vitest.stubGlobal('open', vitest.fn(() => newWindow));
-  <%_ } else { _%>
-      window.open = <%- clientTestFramework %>.fn(() => newWindow);
-  <%_ } _%>
-      window.onload = <%- clientTestFramework %>.fn(() => newWindow) as any;
-      window.URL.createObjectURL = <%- clientTestFramework %>.fn() as any;
+      window.onload = vitest.fn(() => newWindow) as any;
+      window.URL.createObjectURL = vitest.fn() as any;
       // GIVEN
-      <%- clientTestFramework %>.spyOn(dataUtils, 'openFile');
+      vitest.spyOn(dataUtils, 'openFile');
       const fakeContentType = 'fake content type';
       const fakeBase64 = 'fake base64';
 

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.spec.ts.ejs
@@ -20,9 +20,7 @@
     const testEntityPrimaryKey = tsPrimaryKeySamples[0];
     const testEntityPrimaryKey2 = tsPrimaryKeySamples[1];
 _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { MockInstance, afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import {
   ComponentFixture, TestBed,
@@ -103,7 +101,7 @@ describe('<%- entityAngularName %> Management Component', () => {
         fixture = TestBed.createComponent(<%- entityAngularName %>);
         comp = fixture.componentInstance;
         service = TestBed.inject(<%- entityAngularName %>Service);
-        routerNavigateSpy = <%- clientTestFramework %>.spyOn(comp.router, 'navigate');
+        routerNavigateSpy = vitest.spyOn(comp.router, 'navigate');
 
     const library = TestBed.inject(FaIconLibrary);
     library.addIcons(faEye, faPencilAlt, faPlus<%- searchEngineAny ? ', faSearch' : '' %>, faSort, faSortDown, faSortUp, faSync, faTimes);
@@ -182,7 +180,7 @@ describe('<%- entityAngularName %> Management Component', () => {
     describe('track<%- primaryKey.nameCapitalized %>', () => {
         it('should forward to <%- entityInstance %>Service', () => {
             const entity = <%- tsPrimaryKeySamples[0] %>;
-            <%- clientTestFramework %>.spyOn(service, 'get<%- entityAngularName %>Identifier');
+            vitest.spyOn(service, 'get<%- entityAngularName %>Identifier');
             const <%- primaryKey.name %> = comp.track<%- primaryKey.nameCapitalized %>(entity);
             expect(service.get<%- entityAngularName %>Identifier).toHaveBeenCalledWith(entity);
             expect(<%- primaryKey.name %>).toBe(entity.<%- primaryKey.name %>);
@@ -273,12 +271,12 @@ describe('<%- entityAngularName %> Management Component', () => {
       // NgbModal is not a singleton using TestBed.inject.
       // ngbModal = TestBed.inject(NgbModal);
       ngbModal = (comp as any).modalService;
-      <%- clientTestFramework %>.spyOn(ngbModal, 'open').mockReturnValue(deleteModalMock);
+      vitest.spyOn(ngbModal, 'open').mockReturnValue(deleteModalMock);
     });
 
     it('on confirm should call load', inject([], () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(comp, 'load');
+      vitest.spyOn(comp, 'load');
 
       // WHEN
       comp.delete(sampleWithRequiredData);
@@ -291,7 +289,7 @@ describe('<%- entityAngularName %> Management Component', () => {
 
     it('on dismiss should call load', inject([], () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(comp, 'load');
+      vitest.spyOn(comp, 'load');
 
       // WHEN
       comp.delete(sampleWithRequiredData);

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/route/_entityFile_-routing-resolve.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/route/_entityFile_-routing-resolve.service.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const tsKeyId = primaryKey.tsSampleValues[0]; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
@@ -50,7 +48,7 @@ describe('<%- entityAngularName %> routing resolve service', () => {
       ],
     });
     mockRouter = TestBed.inject(Router);
-    <%- clientTestFramework %>.spyOn(mockRouter, 'navigate');
+    vitest.spyOn(mockRouter, 'navigate');
     mockActivatedRouteSnapshot = TestBed.inject(ActivatedRoute).snapshot;
     service = TestBed.inject(<%- entityAngularName %>Service);
   });
@@ -58,7 +56,7 @@ describe('<%- entityAngularName %> routing resolve service', () => {
   describe('resolve', () => {
     it('should return I<%- entityAngularName %> returned by find', async () => {
       // GIVEN
-      service.find = <%- clientTestFramework %>.fn(<%- primaryKey.name %> => of({ <%- primaryKey.name %> }));
+      service.find = vitest.fn(<%- primaryKey.name %> => of({ <%- primaryKey.name %> }));
       mockActivatedRouteSnapshot.params = { <%- primaryKey.name %>: <%- tsKeyId %> };
 
       // WHEN
@@ -78,7 +76,7 @@ describe('<%- entityAngularName %> routing resolve service', () => {
 
     it('should return null if id is not provided', async () => {
       // GIVEN
-      service.find = <%- clientTestFramework %>.fn();
+      service.find = vitest.fn();
       mockActivatedRouteSnapshot.params = {};
 
       // WHEN
@@ -98,7 +96,7 @@ describe('<%- entityAngularName %> routing resolve service', () => {
 
     it('should route to 404 page if data not found in server', async () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(service, 'find').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' })));
+      vitest.spyOn(service, 'find').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' })));
       mockActivatedRouteSnapshot.params = { <%- primaryKey.name %>: <%- tsKeyId %> };
 
       // WHEN
@@ -112,7 +110,7 @@ describe('<%- entityAngularName %> routing resolve service', () => {
 
     it('should route to error page if server returns an error other than 404', async () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(service, 'find').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Internal Server Error' })));
+      vitest.spyOn(service, 'find').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Internal Server Error' })));
       mockActivatedRouteSnapshot.params = { <%- primaryKey.name %>: <%- tsKeyId %> };
 
       // WHEN

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/service/_entityFile_.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/service/_entityFile_.service.spec.ts.ejs
@@ -20,9 +20,7 @@
     const requiresRestTypeConversion = !builtInUserManagement && anyFieldIsDateDerived || builtInUserManagement && !userManagement.skipClient;
     const entityRestName = requiresRestTypeConversion ? `Rest${entityAngularName}` : `I${entityAngularName}`;
 _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-form.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-form.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 
 import { sampleWithRequiredData, sampleWithNewData } from '../<%- entityFileName %>.test-samples';

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-update.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/update/_entityFile_-update.spec.ts.ejs
@@ -23,9 +23,7 @@
     const testEntityPrimaryKey0 = tsPrimaryKeySamples[0];
     const testEntityPrimaryKey1 = tsPrimaryKeySamples[1];
 _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { HttpResponse } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -103,14 +101,14 @@ describe('<%- entityAngularName %> Management Update Component', () => {
     <%_ } _%>
 
                 const <%- otherEntity.entityInstance %>Collection: I<%- otherEntity.entityAngularName %>[] = [<%- otherEntity.tsPrimaryKeySamples[0] %>];
-                <%- clientTestFramework %>.spyOn(<%- otherEntity.entityInstance %>Service, 'query').mockReturnValue(of(new HttpResponse({ body: <%- otherEntity.entityInstance %>Collection })));
+                vitest.spyOn(<%- otherEntity.entityInstance %>Service, 'query').mockReturnValue(of(new HttpResponse({ body: <%- otherEntity.entityInstance %>Collection })));
                 const additional<%- otherEntity.entityAngularNamePlural %> = [
     <%_ for (const relationship of relationshipsWithCustomSharedOptions) { _%>
                     <%- relationship.collection ? '...' : '' %><%- relationship.propertyName %>,
     <%_ } _%>
                 ];
                 const expectedCollection: I<%- otherEntity.entityAngularName %>[] = [...additional<%- otherEntity.entityAngularNamePlural %>, ...<%- otherEntity.entityInstance %>Collection];
-                <%- clientTestFramework %>.spyOn(<%- otherEntity.entityInstance %>Service, 'add<%- otherEntity.entityAngularName %>ToCollectionIfMissing').mockReturnValue(expectedCollection);
+                vitest.spyOn(<%- otherEntity.entityInstance %>Service, 'add<%- otherEntity.entityAngularName %>ToCollectionIfMissing').mockReturnValue(expectedCollection);
 
                 activatedRoute.data = of({ <%- entityInstance %> });
                 comp.ngOnInit();
@@ -132,9 +130,9 @@ describe('<%- entityAngularName %> Management Update Component', () => {
                 <%- entityInstance %>.<%- relationship.propertyName %> = <%- relationship.propertyName %>;
 
                 const <%- relationship.propertyName %>Collection: I<%- otherEntity.entityAngularName %>[] = [<%- otherEntity.tsPrimaryKeySamples[0] %>];
-                <%- clientTestFramework %>.spyOn(<%- otherEntity.entityInstance %>Service, 'query').mockReturnValue(of(new HttpResponse({ body: <%- relationship.propertyName %>Collection })));
+                vitest.spyOn(<%- otherEntity.entityInstance %>Service, 'query').mockReturnValue(of(new HttpResponse({ body: <%- relationship.propertyName %>Collection })));
                 const expectedCollection: I<%- otherEntity.entityAngularName %>[] = [<%- relationship.propertyName %>, ...<%- relationship.propertyName %>Collection];
-                <%- clientTestFramework %>.spyOn(<%- otherEntity.entityInstance %>Service, 'add<%- otherEntity.entityAngularName %>ToCollectionIfMissing').mockReturnValue(expectedCollection);
+                vitest.spyOn(<%- otherEntity.entityInstance %>Service, 'add<%- otherEntity.entityAngularName %>ToCollectionIfMissing').mockReturnValue(expectedCollection);
 
                 activatedRoute.data = of({ <%- entityInstance %> });
                 comp.ngOnInit();
@@ -176,9 +174,9 @@ describe('<%- entityAngularName %> Management Update Component', () => {
             // GIVEN
             const saveSubject = new Subject<I<%- entityAngularName %>>();
             const <%- entityInstance %> = <%- testEntityPrimaryKey0 %>;
-            <%- clientTestFramework %>.spyOn(<%- entityInstance %>FormService, 'get<%- entityAngularName %>').mockReturnValue(<%- entityInstance %>);
-            <%- clientTestFramework %>.spyOn(<%- entityInstance %>Service, 'update').mockReturnValue(saveSubject);
-            <%- clientTestFramework %>.spyOn(comp, 'previousState');
+            vitest.spyOn(<%- entityInstance %>FormService, 'get<%- entityAngularName %>').mockReturnValue(<%- entityInstance %>);
+            vitest.spyOn(<%- entityInstance %>Service, 'update').mockReturnValue(saveSubject);
+            vitest.spyOn(comp, 'previousState');
             activatedRoute.data = of({ <%- entityInstance %> });
             comp.ngOnInit();
 
@@ -200,9 +198,9 @@ describe('<%- entityAngularName %> Management Update Component', () => {
             // GIVEN
             const saveSubject = new Subject<I<%- entityAngularName %>>();
             const <%- entityInstance %> = <%- testEntityPrimaryKey0 %>;
-            <%- clientTestFramework %>.spyOn(<%- entityInstance %>FormService, 'get<%- entityAngularName %>').mockReturnValue({ <%- primaryKey.name %>: null });
-            <%- clientTestFramework %>.spyOn(<%- entityInstance %>Service, 'create').mockReturnValue(saveSubject);
-            <%- clientTestFramework %>.spyOn(comp, 'previousState');
+            vitest.spyOn(<%- entityInstance %>FormService, 'get<%- entityAngularName %>').mockReturnValue({ <%- primaryKey.name %>: null });
+            vitest.spyOn(<%- entityInstance %>Service, 'create').mockReturnValue(saveSubject);
+            vitest.spyOn(comp, 'previousState');
             activatedRoute.data = of({ <%- entityInstance %>: null });
             comp.ngOnInit();
 
@@ -224,8 +222,8 @@ describe('<%- entityAngularName %> Management Update Component', () => {
             // GIVEN
             const saveSubject = new Subject<I<%- entityAngularName %>>();
             const <%- entityInstance %> = <%- testEntityPrimaryKey0 %>;
-            <%- clientTestFramework %>.spyOn(<%- entityInstance %>Service, 'update').mockReturnValue(saveSubject);
-            <%- clientTestFramework %>.spyOn(comp, 'previousState');
+            vitest.spyOn(<%- entityInstance %>Service, 'update').mockReturnValue(saveSubject);
+            vitest.spyOn(comp, 'previousState');
             activatedRoute.data = of({ <%- entityInstance %> });
             comp.ngOnInit();
 
@@ -252,7 +250,7 @@ describe('<%- entityAngularName %> Management Update Component', () => {
             it('should forward to <%- otherEntity.entityInstance %>Service', () => {
                 const entity = <%- otherEntity.tsPrimaryKeySamples[0] %>;
                 const entity2 = <%- otherEntity.tsPrimaryKeySamples[1] %>;
-                <%- clientTestFramework %>.spyOn(<%- otherEntity.entityInstance %>Service, 'compare<%- otherEntity.entityAngularName %>');
+                vitest.spyOn(<%- otherEntity.entityInstance %>Service, 'compare<%- otherEntity.entityAngularName %>');
                 comp.compare<%- otherEntity.entityAngularName %>(entity, entity2);
                 expect(<%- otherEntity.entityInstance %>Service.compare<%- otherEntity.entityAngularName %>).toHaveBeenCalledWith(entity, entity2);
             });

--- a/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/detail/user-management-detail.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/detail/user-management-detail.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const tsKeyId = user.primaryKey.tsSampleValues[0]; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';

--- a/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/list/user-management.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/list/user-management.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const tsKeyId = user.primaryKey.tsSampleValues[0]; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
@@ -68,15 +66,15 @@ describe('User Management Component', () => {
     comp = fixture.componentInstance;
     service = TestBed.inject(UserManagementService);
     mockAccountService = TestBed.inject(AccountService);
-    mockAccountService.isAuthenticated = <%- clientTestFramework %>.fn(() => false);
-    mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(null));
+    mockAccountService.isAuthenticated = vitest.fn(() => false);
+    mockAccountService.identity = vitest.fn(() => of(null));
   });
 
   describe('OnInit', () => {
     it('should call load all on init', inject([], () => {
       // GIVEN
       const headers = new HttpHeaders().append('link', 'link;link');
-      <%- clientTestFramework %>.spyOn(service, 'query').mockReturnValue(
+      vitest.spyOn(service, 'query').mockReturnValue(
         of(
           new HttpResponse({
             body: [{ id: <%- tsKeyId %> } as IUserManagement],
@@ -99,7 +97,7 @@ describe('User Management Component', () => {
       // GIVEN
       const headers = new HttpHeaders().append('link', 'link;link');
       const user = { id: <%- tsKeyId %> } as IUserManagement;
-      <%- clientTestFramework %>.spyOn(service, 'query').mockReturnValue(
+      vitest.spyOn(service, 'query').mockReturnValue(
         of(
           new HttpResponse({
             body: [user],
@@ -107,7 +105,7 @@ describe('User Management Component', () => {
           }),
         ),
       );
-      <%- clientTestFramework %>.spyOn(service, 'update').mockReturnValue(of(user));
+      vitest.spyOn(service, 'update').mockReturnValue(of(user));
 
       // WHEN
       comp.setActive(user, true);

--- a/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/service/user-management.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/service/user-management.service.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const tsKeyId = user.primaryKey.tsSampleValues[0]; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';

--- a/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/update/user-management-update.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/admin/user-management/update/user-management-update.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const tsKeyId = user.primaryKey.tsSampleValues[0]; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 <%_ if (enableTranslation) { _%>
@@ -64,7 +62,7 @@ describe('User Management Update Component', () => {
     it('should call update service on save for existing user', inject([], () => {
       // GIVEN
       const entity = { id: <%- tsKeyId %> } as IUserManagement;
-      <%- clientTestFramework %>.spyOn(service, 'update').mockReturnValue(of(entity));
+      vitest.spyOn(service, 'update').mockReturnValue(of(entity));
       comp.editForm.patchValue(entity);
       // WHEN
       comp.save();
@@ -77,7 +75,7 @@ describe('User Management Update Component', () => {
     it('should call create service on save for new user', inject([], () => {
       // GIVEN
       const entity = { login: 'foo' } as IUserManagement;
-      <%- clientTestFramework %>.spyOn(service, 'create').mockReturnValue(of(entity));
+      vitest.spyOn(service, 'create').mockReturnValue(of(entity));
       comp.editForm.patchValue(entity);
       // WHEN
       comp.save();

--- a/generators/angular/templates/src/main/webapp/app/home/home.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/home/home.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 <%_ if (!authenticationTypeOauth2) { _%>
@@ -55,14 +53,14 @@ describe('Home Component', () => {
         {
           provide: AccountService,
           useValue: {
-            isAuthenticated: <%- clientTestFramework %>.fn(),
+            isAuthenticated: vitest.fn(),
           },
         },
 <%_ if (authenticationTypeOauth2) { _%>
         {
           provide: LoginService,
           useValue: {
-            login: <%- clientTestFramework %>.fn(),
+            login: vitest.fn(),
           },
         },
 <%_ } _%>
@@ -74,11 +72,11 @@ describe('Home Component', () => {
     fixture = TestBed.createComponent(Home);
     comp = fixture.componentInstance;
     mockAccountService = TestBed.inject(AccountService);
-    mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(null));
+    mockAccountService.identity = vitest.fn(() => of(null));
 <%_ if (!authenticationTypeOauth2) { _%>
 
     mockRouter = TestBed.inject(Router);
-    <%- clientTestFramework %>.spyOn(mockRouter, 'navigate');
+    vitest.spyOn(mockRouter, 'navigate');
 
 <%_ } else { _%>
     mockLoginService = TestBed.inject(LoginService);

--- a/generators/angular/templates/src/main/webapp/app/layouts/main/main.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/main/main.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { DOCUMENT } from '@angular/common';
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -66,7 +64,7 @@ describe('Main', () => {
         {
           provide: AccountService,
           useValue: {
-            identity: <%- clientTestFramework %>.fn(() => of(null)),
+            identity: vitest.fn(() => of(null)),
           },
         },
         { provide: TitleStrategy, useClass: AppPageTitleStrategy },
@@ -106,10 +104,10 @@ describe('Main', () => {
     beforeEach(() => {
       routerState.snapshot.root = { data: {} };
 <%_ if (enableTranslation) { _%>
-      <%- clientTestFramework %>.spyOn(translateService, 'get').mockImplementation((key: string | string[]) => of(`${key as string} translated`));
-      <%- clientTestFramework %>.spyOn(translateService, 'getCurrentLang').mockReturnValue('<%- nativeLanguage %>');
+      vitest.spyOn(translateService, 'get').mockImplementation((key: string | string[]) => of(`${key as string} translated`));
+      vitest.spyOn(translateService, 'getCurrentLang').mockReturnValue('<%- nativeLanguage %>');
 <%_ } _%>
-      <%- clientTestFramework %>.spyOn(titleService, 'setTitle');
+      vitest.spyOn(titleService, 'setTitle');
       comp.ngOnInit();
     });
 
@@ -262,7 +260,7 @@ describe('Main', () => {
 
       // WHEN
   <%_ if (enableI18nRTL) { _%>
-      findLanguageFromKeyPipe.isRTL = <%- clientTestFramework %>.fn(() => false);
+      findLanguageFromKeyPipe.isRTL = vitest.fn(() => false);
   <%_ } _%>
       langChangeSubject.next({ lang: 'lang1', translations: {} });
 
@@ -274,7 +272,7 @@ describe('Main', () => {
 
       // WHEN
   <%_ if (enableI18nRTL) { _%>
-      findLanguageFromKeyPipe.isRTL = <%- clientTestFramework %>.fn(() => true);
+      findLanguageFromKeyPipe.isRTL = vitest.fn(() => true);
   <%_ } _%>
       langChangeSubject.next({ lang: 'lang2', translations: {} });
 

--- a/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/navbar/navbar.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
@@ -73,7 +71,7 @@ describe('Navbar Component', () => {
     fixture = TestBed.createComponent(Navbar);
     comp = fixture.componentInstance;
 <%_ if (applicationTypeGateway && microfrontend) { _%>
-    comp.loadMicrofrontendsEntities = <%- clientTestFramework %>.fn();
+    comp.loadMicrofrontendsEntities = vitest.fn();
 <%_ } _%>
     accountService = TestBed.inject(AccountService);
     profileService = TestBed.inject(ProfileService);
@@ -81,7 +79,7 @@ describe('Navbar Component', () => {
 
   it('should call profileService.getProfileInfo on init', () => {
     // GIVEN
-    <%- clientTestFramework %>.spyOn(profileService, 'getProfileInfo').mockReturnValue(of(new ProfileInfo()));
+    vitest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of(new ProfileInfo()));
 
     // WHEN
     comp.ngOnInit();

--- a/generators/angular/templates/src/main/webapp/app/layouts/profiles/page-ribbon.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/layouts/profiles/page-ribbon.spec.ts.ejs
@@ -1,6 +1,4 @@
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
@@ -22,7 +20,7 @@ describe('Page Ribbon Component', () => {
 
   it('should call profileService.getProfileInfo on init', () => {
     // GIVEN
-    <%- clientTestFramework %>.spyOn(profileService, 'getProfileInfo').mockReturnValue(of(new ProfileInfo()));
+    vitest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of(new ProfileInfo()));
 
     // WHEN
     comp.ngOnInit();

--- a/generators/angular/templates/src/main/webapp/app/login/login.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/login/login.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ElementRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Navigation, Router } from '@angular/router';
@@ -53,13 +51,13 @@ describe('Login', () => {
         {
           provide: AccountService,
           useValue: {
-            isAuthenticated: <%- clientTestFramework %>.fn(),
+            isAuthenticated: vitest.fn(),
           },
         },
         {
           provide: LoginService,
           useValue: {
-            login: <%- clientTestFramework %>.fn(() => of({})),
+            login: vitest.fn(() => of({})),
           },
         },
       ],
@@ -70,7 +68,7 @@ describe('Login', () => {
     fixture = TestBed.createComponent(Login);
     comp = fixture.componentInstance;
     mockRouter = TestBed.inject(Router);
-    <%- clientTestFramework %>.spyOn(mockRouter, 'navigate');
+    vitest.spyOn(mockRouter, 'navigate');
     mockLoginService = TestBed.inject(LoginService);
     mockAccountService = TestBed.inject(AccountService);
   });
@@ -78,7 +76,7 @@ describe('Login', () => {
   describe('ngOnInit', () => {
     it('should call accountService.identity on Init', () => {
       // GIVEN
-      mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(null));
+      mockAccountService.identity = vitest.fn(() => of(null));
 
       // WHEN
       comp.ngOnInit();
@@ -89,7 +87,7 @@ describe('Login', () => {
 
     it('should call accountService.isAuthenticated on Init', () => {
       // GIVEN
-      mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(null));
+      mockAccountService.identity = vitest.fn(() => of(null));
 
       // WHEN
       comp.ngOnInit();
@@ -100,7 +98,7 @@ describe('Login', () => {
 
     it('should navigate to home page on Init if authenticated=true', () => {
       // GIVEN
-      mockAccountService.identity = <%- clientTestFramework %>.fn(() => of(null));
+      mockAccountService.identity = vitest.fn(() => of(null));
       mockAccountService.isAuthenticated = () => true;
 
       // WHEN
@@ -115,7 +113,7 @@ describe('Login', () => {
     it('should set focus to username input after the view has been initialized', () => {
       // GIVEN
       const node = {
-        focus: <%- clientTestFramework %>.fn(),
+        focus: vitest.fn(),
       };
       comp.username = signal(new ElementRef(node));
 
@@ -153,7 +151,7 @@ describe('Login', () => {
 
     it('should authenticate the user but not navigate to home page if authentication process is already routing to cached url from localstorage', () => {
       // GIVEN
-      <%- clientTestFramework %>.spyOn(mockRouter, 'currentNavigation').mockReturnValue({} as Navigation);
+      vitest.spyOn(mockRouter, 'currentNavigation').mockReturnValue({} as Navigation);
 
       // WHEN
       comp.login();
@@ -165,7 +163,7 @@ describe('Login', () => {
 
     it('should stay on login form and show error message on login error', () => {
       // GIVEN
-      mockLoginService.login = <%- clientTestFramework %>.fn(() => throwError(Error));
+      mockLoginService.login = vitest.fn(() => throwError(Error));
 
       // WHEN
       comp.login();

--- a/generators/angular/templates/src/main/webapp/app/shared/alert/alert-error.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/alert/alert-error.spec.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 <%_ const mainAlertField = enableTranslation ? 'translationKey' : 'message'; _%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 <%_ if (enableTranslation) { _%>

--- a/generators/angular/templates/src/main/webapp/app/shared/alert/alert.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/alert/alert.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertService } from 'app/core/util/alert.service';
@@ -36,8 +34,8 @@ describe('Alert Component', () => {
         {
           provide: AlertService,
           useValue: {
-            clear: <%- clientTestFramework %>.fn(),
-            get: <%- clientTestFramework %>.fn(),
+            clear: vitest.fn(),
+            get: vitest.fn(),
           },
         },
       ],

--- a/generators/angular/templates/src/main/webapp/app/shared/auth/has-any-authority.directive.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/auth/has-any-authority.directive.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest, type Mock } from 'vitest';
-<%_ } _%>
 import { Component, ChangeDetectionStrategy, ElementRef, WritableSignal, signal, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
@@ -46,7 +44,7 @@ describe('HasAnyAuthorityDirective tests', () => {
 
   beforeEach(() => {
     currentAccount = signal<Account | null>({ activated: true, authorities: [] } as any);
-    hasAnyAuthority = <%- clientTestFramework %>.fn((): boolean => Boolean(currentAccount()));
+    hasAnyAuthority = vitest.fn((): boolean => Boolean(currentAccount()));
 
     TestBed.configureTestingModule({
       providers: [

--- a/generators/angular/templates/src/main/webapp/app/shared/date/format-medium-date.pipe.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/date/format-medium-date.pipe.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import dayjs from 'dayjs/esm';
 
 import FormatMediumDatePipe from './format-medium-date.pipe';

--- a/generators/angular/templates/src/main/webapp/app/shared/date/format-medium-datetime.pipe.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/date/format-medium-datetime.pipe.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import dayjs from 'dayjs/esm';
 
 import FormatMediumDatetimePipe from './format-medium-datetime.pipe';

--- a/generators/angular/templates/src/main/webapp/app/shared/filter/filter.model.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/filter/filter.model.spec.ts.ejs
@@ -1,6 +1,4 @@
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { convertToParamMap, ParamMap, Params } from '@angular/router';
 import { FilterOptions, FilterOption } from './filter.model';
 
@@ -80,7 +78,7 @@ describe('FilterModel Tests', () => {
     describe('clear', () => {
       it("removes empty filters and doesn't emit next element", () => {
         const filters = new FilterOptions([new FilterOption('foo'), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         filters.clear();
 
@@ -89,7 +87,7 @@ describe('FilterModel Tests', () => {
       });
       it('removes empty filters and emits next element', () => {
         const filters = new FilterOptions([new FilterOption('foo', ['existingFoo1']), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         filters.clear();
 
@@ -101,7 +99,7 @@ describe('FilterModel Tests', () => {
     describe('addFilter', () => {
       it('adds a non existing FilterOption, returns true and emit next element', () => {
         const filters = new FilterOptions([new FilterOption('foo', ['existingFoo1', 'existingFoo2']), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const result = filters.addFilter('addedFilter', 'addedValue');
 
@@ -114,7 +112,7 @@ describe('FilterModel Tests', () => {
       });
       it('adds a non existing value to FilterOption, returns true and emit next element', () => {
         const filters = new FilterOptions([new FilterOption('foo', ['existingFoo1', 'existingFoo2']), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const result = filters.addFilter('foo', 'addedValue1', 'addedValue2');
 
@@ -126,7 +124,7 @@ describe('FilterModel Tests', () => {
       });
       it("doesn't add FilterOption values already added, returns false and doesn't emit next element", () => {
         const filters = new FilterOptions([new FilterOption('foo', ['existingFoo1', 'existingFoo2']), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const result = filters.addFilter('foo', 'existingFoo1', 'existingFoo2');
 
@@ -139,7 +137,7 @@ describe('FilterModel Tests', () => {
     describe('removeFilter', () => {
       it('removes an existing FilterOptions and returns true', () => {
         const filters = new FilterOptions([new FilterOption('foo', ['existingFoo1', 'existingFoo2']), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const result = filters.removeFilter('foo', 'existingFoo1');
 
@@ -149,7 +147,7 @@ describe('FilterModel Tests', () => {
       });
       it("doesn't remove a non existing FilterOptions values returns false", () => {
         const filters = new FilterOptions([new FilterOption('foo', ['existingFoo1', 'existingFoo2']), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const result = filters.removeFilter('foo', 'nonExisting1');
 
@@ -159,7 +157,7 @@ describe('FilterModel Tests', () => {
       });
       it("doesn't remove a non existing FilterOptions returns false", () => {
         const filters = new FilterOptions([new FilterOption('foo', ['existingFoo1', 'existingFoo2']), new FilterOption('bar')]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const result = filters.removeFilter('nonExisting', 'nonExisting1');
 
@@ -194,7 +192,7 @@ describe('FilterModel Tests', () => {
 
       it('should parse from Params if there are any and not emit next element', () => {
         const filters: FilterOptions = new FilterOptions([new FilterOption('foo', ['bar'])]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
         const paramMap: ParamMap = convertToParamMap(oneValidParam);
 
         filters.initializeFromParams(paramMap);
@@ -206,7 +204,7 @@ describe('FilterModel Tests', () => {
       it('should parse from Params and have none if there are none', () => {
         const filters: FilterOptions = new FilterOptions();
         const paramMap: ParamMap = convertToParamMap(noValidParam);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         filters.initializeFromParams(paramMap);
 
@@ -216,7 +214,7 @@ describe('FilterModel Tests', () => {
 
       it('should parse from Params and have a parameter with 2 values and one additional value', () => {
         const filters: FilterOptions = new FilterOptions([new FilterOption('hello.in', ['world'])]);
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const paramMap: ParamMap = convertToParamMap(paramWithTwoValues);
 
@@ -228,7 +226,7 @@ describe('FilterModel Tests', () => {
 
       it('should parse from Params and have a parameter with 2 keys', () => {
         const filters: FilterOptions = new FilterOptions();
-        <%- clientTestFramework %>.spyOn(filters.filterChanges, 'next');
+        vitest.spyOn(filters.filterChanges, 'next');
 
         const paramMap: ParamMap = convertToParamMap(paramWithTwoKeys);
 

--- a/generators/angular/templates/src/main/webapp/app/shared/language/translate.directive.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/language/translate.directive.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateService, provideTranslateService } from '@ngx-translate/core';
@@ -48,7 +46,7 @@ describe('TranslateDirective Tests', () => {
   });
 
   it('should change HTML', () => {
-    const spy = <%- clientTestFramework %>.spyOn(translateService, 'get');
+    const spy = vitest.spyOn(translateService, 'get');
 
     fixture.detectChanges();
 

--- a/generators/angular/templates/src/main/webapp/app/shared/pagination/item-count.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/pagination/item-count.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>

--- a/generators/angular/templates/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { Component, ChangeDetectionStrategy, DebugElement, Type, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -47,7 +45,7 @@ import { SortState, sortStateSignal } from './sort-state';
 })
 class TestSortByDirective {
   sortState = sortStateSignal({ predicate: 'name' });
-  transition = <%- clientTestFramework %>.fn();
+  transition = vitest.fn();
 
   private readonly library = inject(FaIconLibrary);
 
@@ -123,7 +121,7 @@ describe('Directive: SortByDirective', () => {
   it('multiple clicks at same component, should call SortDirective sort', () => {
     // GIVEN
     const sortDirective = tableHead.injector.get(SortDirective as Type<SortDirective>);
-    sortDirective.sort = <%- clientTestFramework %>.fn();
+    sortDirective.sort = vitest.fn();
 
     // WHEN
     fixture.detectChanges();

--- a/generators/angular/templates/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { Component, ChangeDetectionStrategy, DebugElement, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -39,7 +37,7 @@ import { SortState, sortStateSignal } from './sort-state';
 })
 class TestSortDirective {
   sortState = sortStateSignal({ predicate: 'ID' });
-  transition = <%- clientTestFramework %>.fn().mockImplementation((sortState: SortState) => {
+  transition = vitest.fn().mockImplementation((sortState: SortState) => {
     this.sortState.set(sortState);
   });
 }

--- a/generators/angular/templates/src/main/webapp/app/shared/sort/sort.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/sort/sort.service.spec.ts.ejs
@@ -16,9 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (clientTestFrameworkVitest) { _%>
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-<%_ } _%>
 import { SortService } from './sort.service';
 
 describe('sort state', () => {


### PR DESCRIPTION
Related to #31458 