### PR TITLE
React/Vue: bump webpack-dev-server to v6.0.0

### DIFF
--- a/generators/react/resources/package.json
+++ b/generators/react/resources/package.json
@@ -70,8 +70,8 @@
     "vitest": "4.1.9",
     "vitest-sonar-reporter": "3.0.0",
     "webpack": "5.108.3",
-    "webpack-cli": "7.1.0",
-    "webpack-dev-server": "5.2.6",
+    "webpack-cli": "7.2.1",
+    "webpack-dev-server": "6.0.0",
     "webpack-merge": "6.0.1",
     "webpack-notifier": "1.15.0",
     "workbox-webpack-plugin": "7.4.1"

--- a/generators/vue/resources/package.json
+++ b/generators/vue/resources/package.json
@@ -67,8 +67,8 @@
     "vue-style-loader": "4.1.3",
     "webpack": "5.108.3",
     "webpack-bundle-analyzer": "5.3.0",
-    "webpack-cli": "7.1.0",
-    "webpack-dev-server": "5.2.6",
+    "webpack-cli": "7.2.1",
+    "webpack-dev-server": "6.0.0",
     "webpack-merge": "6.0.1",
     "workbox-webpack-plugin": "7.4.1"
   },


### PR DESCRIPTION
https://github.com/webpack/webpack-cli/releases
<img width="897" height="234" alt="image" src="https://github.com/user-attachments/assets/63dd8f7f-f507-4379-a1ea-e7832b4567e3" />
