### PR TITLE
Angular: not import TranslatePipe when it's useless

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/list/_entityFile_.ts.ejs
@@ -51,7 +51,9 @@ import { Alert } from 'app/shared/alert/alert';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 <%_ if (enableTranslation) { _%>
 import { TranslateDirective } from 'app/shared/language';
+  <%_ if (searchEngineAny) { _%>
 import { TranslatePipe } from '@ngx-translate/core';
+  <%_ } _%>
 <%_ } _%>
 import { sortStateSignal, SortDirective, SortByDirective, type SortState, SortService } from 'app/shared/sort';
 import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
@@ -114,7 +116,9 @@ import { InfiniteScrollDirective } from 'ngx-infinite-scroll';
       SortByDirective,
 <%_ if (enableTranslation) { _%>
       TranslateDirective,
+  <%_ if (searchEngineAny) { _%>
       TranslatePipe,
+  <%_ } _%>
 <%_ } _%>
 <%_ if (anyFieldIsDuration) { _%>
       DurationPipe,


### PR DESCRIPTION
Fix
<img width="706" height="110" alt="image" src="https://github.com/user-attachments/assets/b908e3c7-1c05-443c-a19c-503a18a38abb" />
