### PR TITLE
generate-blueprint: apply defaults to selected generators

### DIFF
--- a/generators/generate-blueprint/generator.spec.ts
+++ b/generators/generate-blueprint/generator.spec.ts
@@ -1,4 +1,3 @@
-
 /**
  * Copyright 2013-2026 the original author or authors from the JHipster project.
  *

--- a/generators/generate-blueprint/generator.spec.ts
+++ b/generators/generate-blueprint/generator.spec.ts
@@ -1,3 +1,4 @@
+
 /**
  * Copyright 2013-2026 the original author or authors from the JHipster project.
  *
@@ -48,17 +49,24 @@ describe(`generator - ${generator}`, () => {
     before(async () => {
       await helpers
         .runJHipster()
-        .withOptions({ defaults: true, subGenerators: ['app'] })
+        .withOptions({ defaults: true, subGenerators: ['app'], additionalSubGenerators: 'custom, app' })
         .withAnswers({ sbs: false, command: true, priorities: ['writing'] })
         .withSkipWritingPriorities()
         .withMockedGenerators(mockedGenerators);
     });
 
-    it('should apply defaults to selected sub-generators without prompting', () => {
+    it('should apply defaults to selected and additional sub-generators without prompting', () => {
       expect(result.generator.getSubGeneratorStorage('app').getAll()).toMatchObject({
         sbs: true,
         command: false,
         priorities: [],
+        written: false,
+      });
+      expect(result.generator.getSubGeneratorStorage('custom').getAll()).toMatchObject({
+        sbs: true,
+        command: false,
+        priorities: [],
+        written: false,
       });
     });
   });

--- a/generators/generate-blueprint/generator.spec.ts
+++ b/generators/generate-blueprint/generator.spec.ts
@@ -44,6 +44,25 @@ describe(`generator - ${generator}`, () => {
   });
   describe('blueprint support', () => testBlueprintSupport(helpers.commandName!));
 
+  describe('defaults option', () => {
+    before(async () => {
+      await helpers
+        .runJHipster()
+        .withOptions({ defaults: true, subGenerators: ['app'] })
+        .withAnswers({ sbs: false, command: true, priorities: ['writing'] })
+        .withSkipWritingPriorities()
+        .withMockedGenerators(mockedGenerators);
+    });
+
+    it('should apply defaults to selected sub-generators without prompting', () => {
+      expect(result.generator.getSubGeneratorStorage('app').getAll()).toMatchObject({
+        sbs: true,
+        command: false,
+        priorities: [],
+      });
+    });
+  });
+
   describe('migration', () => {
     describe('javascriptBlueprint option', () => {
       describe('blueprints prior to v9.0.1', () => {

--- a/generators/generate-blueprint/generator.ts
+++ b/generators/generate-blueprint/generator.ts
@@ -71,6 +71,19 @@ export default class extends GenerateBlueprintBaseGenerator {
         }
         if (this.options.defaults) {
           this.config.defaults(defaultConfig({ config: this.jhipsterConfig }));
+
+          const selectedSubGenerators = (this.jhipsterConfig.subGenerators ?? []) as string[];
+          const additionalSubGenerators = this.jhipsterConfig.additionalSubGenerators ?? '';
+          const subGenerators = [
+            ...selectedSubGenerators,
+            ...additionalSubGenerators
+              .split(',')
+              .map(subGenerator => subGenerator.trim())
+              .filter(Boolean),
+          ];
+          for (const subGenerator of new Set(subGenerators)) {
+            this.getSubGeneratorStorage(subGenerator).defaults(defaultSubGeneratorConfig());
+          }
         }
       },
     });


### PR DESCRIPTION
Fixes #33923

## Problem

`generate-blueprint --defaults --sub-generators app` applies defaults to the top-level configuration, but still prompts for each selected sub-generator. This blocks unattended blueprint upgrades and exits with `ExitPromptError` in non-interactive environments.

## Change

Apply `defaultSubGeneratorConfig()` to every selected built-in and additional sub-generator when `--defaults` is enabled. Duplicate selections are collapsed before initializing their storage.

A regression test supplies conflicting prompt answers and verifies that the stored per-generator values remain the documented defaults, proving the prompts are skipped.

## Verification

- Manual reproduction before the patch: command stops at "Is app generator a side-by-side blueprint?"
- Manual verification after the patch: the same command completes and generates the blueprint without interaction
- `npx esmocha generators/generate-blueprint/generator.spec.ts --no-parallel --no-insight` — 26 passing
- `npm run lint` — passing
- `npm run check-types` — passing

## AI assistance disclosure

OpenAI Codex assisted with reproducing the issue, implementing the focused change, and preparing the regression test. The resulting diff was reviewed and tested locally. Both commits include a `Co-authored-by: OpenAI Codex <codex@openai.com>` trailer.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green (pending)
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary (not applicable)
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary (not applicable)
- [x] Documentation is added/updated where necessary (not applicable)
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [x] AI coding assistant use is disclosed above and credited via `Co-authored-by:` trailers
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code
