### PR TITLE
Fix Angular prettier HTML glob on Windows

### DIFF
--- a/generators/angular/generator.spec.ts
+++ b/generators/angular/generator.spec.ts
@@ -23,6 +23,7 @@ import { basename } from 'node:path';
 import { clientFrameworkTypes } from '../../lib/jhipster/index.ts';
 import { CLIENT_MAIN_SRC_DIR } from '../generator-constants.ts';
 
+import { buildAngularPrettierHtmlGlob } from './generator.ts';
 import Generator from './index.ts';
 
 import { checkEnforcements, shouldSupportFeatures, testBlueprintSupport } from '#test-support';
@@ -88,6 +89,13 @@ describe(`generator - ${clientFramework}`, () => {
   describe('blueprint support', () => testBlueprintSupport(generator));
 
   checkEnforcements({ client: true }, generator);
+
+  describe('prettier configuration', () => {
+    it('uses POSIX globs for Angular HTML overrides', () => {
+      expect(buildAngularPrettierHtmlGlob('src/main/webapp/')).toBe('src/main/webapp/**/*.html');
+      expect(buildAngularPrettierHtmlGlob('src\\main\\webapp\\')).toBe('src/main/webapp/**/*.html');
+    });
+  });
 
   it('samples matrix should match snapshot', () => {
     expect(testSamples).toMatchSnapshot();

--- a/generators/angular/generator.ts
+++ b/generators/angular/generator.ts
@@ -53,6 +53,9 @@ import type {
 
 const { ANGULAR } = clientFrameworkTypes;
 
+export const buildAngularPrettierHtmlGlob = (clientSrcDir: string) =>
+  path.posix.join(clientSrcDir.replaceAll(path.win32.sep, path.posix.sep), '**/*.html');
+
 export class AngularApplicationGenerator extends BaseApplicationGenerator<
   AngularEntity,
   AngularApplication,
@@ -388,7 +391,7 @@ export default class AngularGenerator extends AngularApplicationGenerator {
     return this.asPostWritingTaskGroup({
       addPrettierConfig({ application, source }) {
         source.mergePrettierConfig?.({
-          overrides: [{ files: path.join(application.clientSrcDir, '**/*.html'), options: { parser: 'angular' } }],
+          overrides: [{ files: buildAngularPrettierHtmlGlob(application.clientSrcDir), options: { parser: 'angular' } }],
         });
       },
       clientBundler({ application, source }) {


### PR DESCRIPTION
Fixes #34091

## Summary

Prettier expects glob patterns to use POSIX separators. The Angular generator currently builds the HTML override with `path.join`, so on Windows it can emit backslash-separated patterns that fail to match generated `.html` files. When that override does not apply, Prettier can parse Angular templates with the wrong parser and fail during build formatting.

This PR adds a small helper that normalizes `clientSrcDir` to POSIX separators before joining the `**/*.html` override, then covers both POSIX-style and Windows-style input paths with a focused regression test.

AI assistance disclosure: this PR was prepared with assistance from OpenAI Codex, then reviewed and tested before submission. The commit includes the required `Co-authored-by:` trailer.

## Validation

- `npx esmocha generators/angular/generator.spec.ts --grep "uses POSIX globs" --forbid-only`
- `npx eslint generators/angular/generator.ts generators/angular/generator.spec.ts --max-warnings 0`
- `npm run compile`
- `npm run check-types`
- `git diff --check`

I also ran the full `generators/angular/generator.spec.ts` locally; the new regression passed, but unrelated generator-run cases fail in this local clone because Yeoman cannot resolve a locally registered `generator-jhipster` package.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green (pending GitHub Actions)
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary (not applicable)
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary (not applicable)
- [x] Documentation is added/updated where necessary (not applicable)
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [x] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [x] I have personally reviewed, understood, and tested the changes - including any AI-generated code
