### PR TITLE
fix: default selected blueprint sub-generators

### DIFF
--- a/generators/generate-blueprint/generator.spec.ts
+++ b/generators/generate-blueprint/generator.spec.ts
@@ -109,6 +109,88 @@ describe(`generator - ${generator}`, () => {
         });
       });
     });
+    describe('defaults option with selected sub-generator', () => {
+      before(async () => {
+        await helpers.runJHipster().withOptions({ defaults: true, subGenerators: ['app'] }).withMockedGenerators(mockedGenerators);
+      });
+      it('should compose with init generator', () => {
+        result.assertGeneratorComposedOnce('jhipster:init');
+      });
+      it('should write the selected generator without prompting for sub-generator answers', () => {
+        expect(result.getStateSnapshot()).toMatchInlineSnapshot(`
+{
+  ".blueprint/cli/commands.ts": {
+    "stateCleared": "modified",
+  },
+  ".blueprint/generate-sample/command.ts": {
+    "stateCleared": "modified",
+  },
+  ".blueprint/generate-sample/generator.ts": {
+    "stateCleared": "modified",
+  },
+  ".blueprint/generate-sample/index.ts": {
+    "stateCleared": "modified",
+  },
+  ".blueprint/generate-sample/templates/samples/sample.jdl": {
+    "stateCleared": "modified",
+  },
+  ".github/workflows/generator.yml": {
+    "stateCleared": "modified",
+  },
+  ".yo-rc.json": {
+    "stateCleared": "modified",
+  },
+  "README.md": {
+    "stateCleared": "modified",
+  },
+  "cli/cli-customizations.cts": {
+    "stateCleared": "modified",
+  },
+  "cli/cli.cts": {
+    "stateCleared": "modified",
+  },
+  "generators/app/command.ts": {
+    "stateCleared": "modified",
+  },
+  "generators/app/generator.spec.ts": {
+    "stateCleared": "modified",
+  },
+  "generators/app/generator.ts": {
+    "stateCleared": "modified",
+  },
+  "generators/app/index.ts": {
+    "stateCleared": "modified",
+  },
+  "generators/base-generator.ts": {
+    "stateCleared": "modified",
+  },
+  "package.json": {
+    "stateCleared": "modified",
+  },
+  "tsconfig.json": {
+    "stateCleared": "modified",
+  },
+  "vitest.config.ts": {
+    "stateCleared": "modified",
+  },
+  "vitest.test-setup.ts": {
+    "stateCleared": "modified",
+  },
+}
+`);
+      });
+      it('should store default sub-generator config', () => {
+        result.assertJHipsterConfigContent({
+          generators: {
+            app: {
+              sbs: true,
+              command: false,
+              priorities: [],
+            },
+          },
+        });
+      });
+    });
     describe('local-blueprint option', () => {
       before(async () => {
         await helpers.runJHipster().withOptions({ localBlueprint: true }).withMockedGenerators(mockedGenerators);

--- a/generators/generate-blueprint/generator.ts
+++ b/generators/generate-blueprint/generator.ts
@@ -57,6 +57,19 @@ export default class extends GenerateBlueprintBaseGenerator {
     super(args, options, { storeJHipsterVersion: true, ...features });
   }
 
+  applySubGeneratorDefaults(subGenerator: string, allPriorities?: boolean) {
+    const subGeneratorStorage = this.getSubGeneratorStorage(subGenerator);
+    if (this.options.defaults) {
+      subGeneratorStorage.defaults({
+        ...defaultSubGeneratorConfig(),
+        ...(allPriorities ? { [PRIORITIES]: BASE_PRIORITY_NAMES_LIST } : {}),
+      });
+    } else if (allPriorities) {
+      subGeneratorStorage.defaults({ [PRIORITIES]: BASE_PRIORITY_NAMES_LIST });
+    }
+    return subGeneratorStorage;
+  }
+
   async beforeQueue() {
     if (!this.fromBlueprint) {
       await this.composeWithBlueprints();
@@ -90,10 +103,7 @@ export default class extends GenerateBlueprintBaseGenerator {
         const { allPriorities } = this.options;
         const subGenerators = (this.jhipsterConfig.subGenerators ?? []) as string[];
         for (const subGenerator of subGenerators) {
-          const subGeneratorStorage = this.getSubGeneratorStorage(subGenerator);
-          if (allPriorities) {
-            subGeneratorStorage.defaults({ [PRIORITIES]: BASE_PRIORITY_NAMES_LIST });
-          }
+          const subGeneratorStorage = this.applySubGeneratorDefaults(subGenerator, allPriorities);
           await this.prompt(subGeneratorPrompts({ subGenerator, localBlueprint, additionalSubGenerator: false }), subGeneratorStorage);
         }
       },
@@ -105,10 +115,7 @@ export default class extends GenerateBlueprintBaseGenerator {
           .split(',')
           .map(sub => sub.trim())
           .filter(Boolean)) {
-          const subGeneratorStorage = this.getSubGeneratorStorage(subGenerator);
-          if (allPriorities) {
-            subGeneratorStorage.defaults({ [PRIORITIES]: BASE_PRIORITY_NAMES_LIST });
-          }
+          const subGeneratorStorage = this.applySubGeneratorDefaults(subGenerator, allPriorities);
           await this.prompt(subGeneratorPrompts({ subGenerator, localBlueprint, additionalSubGenerator: true }), subGeneratorStorage);
         }
       },


### PR DESCRIPTION
Fix #33923

## Summary

- Apply default sub-generator configuration when `generate-blueprint` runs with `--defaults`.
- Preserve existing `--all-priorities` behavior while avoiding interactive sub-generator prompts for selected and additional sub-generators.
- Add regression coverage for `--defaults --sub-generators app`.

## Verification

```
node_modules/.bin/esmocha.cmd generators/generate-blueprint/generator.spec.ts --no-insight --forbid-only
```

Result: 28 passing, 14 pending.

## Notes

This change was prepared with AI assistance and personally reviewed/tested before submission.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [x] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [x] I have personally reviewed, understood, and tested the changes — including any AI-generated code
