### PR TITLE
Angular 22: strictTemplates is now enabled by default

### DIFF
--- a/generators/angular/templates/tsconfig.json.ejs
+++ b/generators/angular/templates/tsconfig.json.ejs
@@ -49,7 +49,6 @@
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true,
     "preserveWhitespaces": true
   }
 }


### PR DESCRIPTION
<img width="770" height="285" alt="image" src="https://github.com/user-attachments/assets/dac2bd77-9a63-425e-ae68-7546ea1d9aaa" />

https://blog.ninja-squad.com/2026/06/03/what-is-new-angular-22.0

Related to #33989 