### PR TITLE
Fix: bump eslint from 10.7.0 to 10.8.0

### DIFF
--- a/lib/eslint/index.ts
+++ b/lib/eslint/index.ts
@@ -17,7 +17,11 @@
  * limitations under the License.
  */
 
+import type { Config } from 'eslint/config';
+
 import base from './base.ts';
 import recommended from './recommended.ts';
 
-export default { recommended, base };
+const configs: { recommended: Config; base: Config } = { recommended, base };
+
+export default configs;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "dockerfile-ast": "0.7.1",
         "dot-properties": "1.1.1",
         "ejs": "6.0.1",
-        "eslint": "10.7.0",
+        "eslint": "10.8.0",
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-java-lang": "0.6.0",
         "eslint-plugin-unused-imports": "4.4.1",
@@ -730,9 +730,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1"
@@ -4766,9 +4766,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -4777,7 +4777,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -4801,7 +4801,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "dockerfile-ast": "0.7.1",
     "dot-properties": "1.1.1",
     "ejs": "6.0.1",
-    "eslint": "10.7.0",
+    "eslint": "10.8.0",
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-java-lang": "0.6.0",
     "eslint-plugin-unused-imports": "4.4.1",


### PR DESCRIPTION
Fix #34255 

<img width="1454" height="432" alt="image" src="https://github.com/user-attachments/assets/011649c3-0b54-4323-9b8b-7cabff7bedfe" />
