### PR TITLE
fix(config-hardening): strip template literals until a pass makes no change

### DIFF
--- a/generators/base-simple-application/support/config-hardening.spec.ts
+++ b/generators/base-simple-application/support/config-hardening.spec.ts
@@ -38,6 +38,20 @@ describe('generator - base-simple-application - support - config-hardening', () 
     });
   });
 
+  it('sanitizes placeholders that are only assembled once an inner match is removed', () => {
+    // `$` + `${}` + `{injected}`: stripping the empty placeholder joins the remaining characters
+    // into a new one, so a single replace pass leaves a live template literal behind.
+    const reassembling = '$' + '${}' + '{injected}';
+    const config: any = { foo: `prefix-${reassembling}-suffix` };
+
+    const cleanups = sanitizeConfigForNodeApplications(config);
+
+    expect(config.foo).toBe('prefix--suffix');
+    expect(cleanups).toEqual({
+      foo: { oldValue: `prefix-${reassembling}-suffix`, newValue: 'prefix--suffix' },
+    });
+  });
+
   it('does not fail on non-writable properties', () => {
     const config = {} as Record<string, string>;
 

--- a/generators/base-simple-application/support/config-hardening.ts
+++ b/generators/base-simple-application/support/config-hardening.ts
@@ -16,7 +16,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const stripTemplateLiteral = (value: string): string => (typeof value === 'string' ? value.replace(/\$\{[^}]*\}/g, '') : value);
+const TEMPLATE_LITERAL_PATTERN = /\$\{[^}]*\}/g;
+
+/**
+ * Strips template literal placeholders from a string.
+ *
+ * A single pass is not enough: removing a match joins the surrounding characters, which can
+ * assemble a new placeholder out of previously inert text (`$` + `${}` + `{payload}` collapses
+ * to `${payload}`). Repeat until a pass no longer changes the value. Each pass can only shorten
+ * the string, so the loop always terminates.
+ */
+const stripTemplateLiteral = (value: string): string => {
+  if (typeof value !== 'string') return value;
+  let previousValue;
+  let newValue = value;
+  do {
+    previousValue = newValue;
+    newValue = previousValue.replace(TEMPLATE_LITERAL_PATTERN, '');
+  } while (newValue !== previousValue);
+  return newValue;
+};
 
 type Cleanups = Record<string, { oldValue: string; newValue: string }>;
 


### PR DESCRIPTION
## Summary

`sanitizeConfigForNodeApplications` strips `${...}` from config strings with a single
`String.replace` pass. Removing a match joins the characters around it, so text that was
inert before the pass can be assembled into a placeholder afterwards. The sanitizer then
returns that placeholder untouched, because it never looks at the string again.

Minimal case — `$` + `${}` + `{injected}`:

| step | value |
| --- | --- |
| input | `$${}{injected}` |
| regex matches | `${}` at index 1 |
| after removal | `$` + `{injected}` = **`${injected}`** |

The empty placeholder is the payload: it is consumed by the sanitizer and its removal
splices the two halves of the real one together.

## Scope of this PR — please read before labelling

This fixes the sanitizer, **not** a reachable code-execution path. Being precise about what
was and was not verified:

- **Verified:** the bypass produces a live `${...}` in generated TypeScript. Generating an
  app with `fieldValidateRulesPattern: '$${}{MARKER}'` puts `${MARKER}` into
  `foo-form.service.ts` (Angular) and `foo-update.tsx` (React), while the naive
  `${MARKER}` is correctly stripped and never reaches any generated file. Both controls
  were run; they discriminate.
- **Not claimed:** an executing sink on `main`. In both files the marker lands in a
  non-interpolating position — a single-quoted string in Angular, a regex literal in React.
  Angular's `String.raw` sink, which *would* have interpolated it, was already removed in
  #32601. I could not construct a template-literal sink on current `main`, and I am not
  claiming one exists.

So the practical effect today is that a control which the codebase asserts holds
(`generators/base-application/generators/bootstrap/generator.spec.ts` → `security hardening`,
expecting `fieldValidateRulesPattern: ''`) does not hold for this input class. The value is
defence in depth for templates and blueprints that may introduce a backtick sink later —
which is exactly how #32601 arose.

## Change

`stripTemplateLiteral` now repeats the replace until a pass leaves the value unchanged.
Each pass can only shorten the string, so the loop terminates.

## Known residue, stated rather than hidden

- An unbalanced `${` with no closing `}` is still passed through. It cannot form a complete
  placeholder on its own, so I left it alone rather than widening the change.
- A bare string inside an array is still not sanitized (only objects in arrays are
  recursed). That behaviour is asserted by the existing test at `config-hardening.spec.ts`,
  so I treated it as intentional and did not touch it.

## Testing

- New regression test in `config-hardening.spec.ts` covering the reassembling input.
- `generators/base-simple-application/**`, `generators/base-application/**`,
  `generators/angular/**`, `generators/react/**`, `generators/vue/**`,
  `generators/client/**` → **6171 passing, 0 failing**, no snapshot changes.
- `npm run check-types` clean; prettier and eslint clean on the changed files.
- Re-ran the end-to-end generation after the fix: the marker no longer reaches any
  generated file.

## Disclosure

This change was produced with AI assistance (Claude). Per CONTRIBUTING.md I have read,
understood and tested it; the claim boundary above is deliberately drawn at what the
controls actually showed.

---

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
