### PR TITLE
Sonar: Object literal shorthand syntax should be used

### DIFF
--- a/generators/client/templates/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/src/main/webapp/swagger-ui/index.html.ejs
@@ -168,7 +168,7 @@
           presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
           plugins: [SwaggerUIBundle.plugins.DownloadUrl, AlwaysEnableTryItOutPlugin],
           tryItOutEnabled: true,
-          requestInterceptor: function (req) {
+          requestInterceptor(req) {
 <%_ if (authenticationUsesCsrf) { _%>
             req.headers['X-XSRF-TOKEN'] = getCSRF();
 <%_ } else { _%>


### PR DESCRIPTION
<img width="256" height="24" alt="image" src="https://github.com/user-attachments/assets/d30b7c79-ca4b-43a2-81c5-5f5b29495d88" />
