### PR TITLE
docs: add Sourcey-generated llms index

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,14 @@
+# generator-jhipster
+
+> Internally, JHipster uses Yeoman as the core. JHipster is the most popular generator of all time.
+
+## Documentation
+
+- [JHipster architecture](/generator-jhipster/architecture/): Internally, JHipster uses Yeoman as the core. JHipster is the most popular generator of all time.
+- [JHipster development](/generator-jhipster/development/): JHipster is a Yeoman Generator, so you must follow the Yeoman authoring documentation in order to be able to run and test your changes.
+- [Contributing to JHipster](/generator-jhipster/contributing/): Are you ready to contribute to JHipster? We'd love to have you on board, and we will help you as much as we can. Here are the guidelines we'd like you to follow so that we can be of more help:
+- [JHipster Blueprints](/generator-jhipster/blueprints/): Blueprints allow adding new features or changing current features.
+- [JHipster-RFC-1: JHipster Kubernetes Operator](/generator-jhipster/rfcs/1-jhipster-rfc-k8s-operator/): The JHipster Operators use Kubernetes CRDs (Custom Resource Definitions) to encapsulate operational knowledge about JHipster Applications.
+- [JHipster-RFC-2: JHipster Control Center](/generator-jhipster/rfcs/2-jhipster-rfc-jhipster-control-center/): As of JHipster 6.5, the JHipster administrator's management and monitoring UI is spread out to various places (JHipster Registry, angular/react/vue pages) which causes code duplication and slows down their evolution. This RFC proposes to move this functionality to an external application that can be used in different development and production scenarios. In the following, this application will be referred to as the **JHipster Control Center**.
+- [JHipster-RFC-4: Entities as a core feature.](/generator-jhipster/rfcs/4-jhipster-rfc-entity-as-core/): This RFC proposes to implement entities as JHipster core feature instead of generators.
+- [JHipster-RFC-6: jhipster generator file structure](/generator-jhipster/rfcs/6-jhipster-rfc-jhipster-generator-file-structure/): The goal of this RFC is to describe the generator conventions and file structure for the JHipster generator that enhances modularity, maintainability, and ease of use. The new structure will allow for better organization of files and directories, making it easier for developers to navigate and contribute to the project.

--- a/sourcey.llms.config.ts
+++ b/sourcey.llms.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, markdown } from 'sourcey';
+
+export default defineConfig({
+  name: 'generator-jhipster',
+  description:
+    'Architecture, development, contribution, blueprint, and RFC documentation from generator-jhipster commit 819adc170c499f0871a9b77c32d6f98b00f8e391.',
+  baseUrl: '/generator-jhipster',
+  prettyUrls: 'slash',
+  navigation: {
+    tabs: [
+      {
+        tab: 'Documentation',
+        slug: '',
+        source: markdown({
+          groups: [
+            {
+              group: 'Contributor Guide',
+              pages: ['ARCHITECTURE', 'DEVELOPMENT', 'CONTRIBUTING', 'BLUEPRINTS'],
+            },
+            {
+              group: 'Design RFCs',
+              pages: [
+                'rfcs/1-jhipster-rfc-k8s-operator',
+                'rfcs/2-jhipster-rfc-jhipster-control-center',
+                'rfcs/4-jhipster-rfc-entity-as-core',
+                'rfcs/6-jhipster-rfc-jhipster-generator-file-structure',
+              ],
+            },
+          ],
+        }),
+      },
+    ],
+  },
+});


### PR DESCRIPTION
Closes #34414

## What changed

- adds a root `llms.txt` index for contributor and architecture documentation
- adds `sourcey.llms.config.ts` so the index is reproducible and reviewable
- maps eight existing documents without changing generator runtime behavior

## Reproduction evidence

- source repository commit: `819adc170c499f0871a9b77c32d6f98b00f8e391`
- Sourcey version: `3.6.5`
- command: `node node_modules/sourcey/dist/cli.js build --config sourcey.llms.config.ts --output <output-dir>`
- generated pages: `8`
- `llms.txt` SHA-256: `8B271CF4ED5FA8F3F33EFE2080A2E5A42428E5D0636A17333E5605D4C189CF13`
- a clean second build produced the same hash

Audited entries: architecture, development, contributing, blueprints, Kubernetes Operator RFC, Control Center RFC, Entities RFC, and generator file-structure RFC. Every generated URL resolved to its corresponding `index.html` in the build output.

## Validation

- `git diff --check`
- Prettier 3.9.6 check for both added files
- clean Sourcey rebuild with identical SHA-256
- documentation-only commits use `[ci skip]` as allowed by the contribution guide

Prepared with AI assistance. The generated summaries come from the repository's own Markdown via Sourcey; I personally reviewed the configuration, all eight entries, and the reproducible output.

---

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green (documentation-only commits intentionally use `[ci skip]`)
- [x] Tests are added where necessary (not applicable: generated documentation index)
- [x] The JDL part is updated if necessary (not applicable)
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary (not applicable)
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [x] I have personally reviewed, understood, and tested the changes — including any AI-generated code
