### PR TITLE
Angular: use form-label consistently in the login form

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/login/login.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/login/login.html.ejs
@@ -25,7 +25,7 @@
       }
       <form class="form" (ngSubmit)="login()" [formGroup]="loginForm">
         <div class="mb-3">
-          <label class="username-label" for="username">__jhiTranslateTag__('global.form.username.label')</label>
+          <label class="form-label" for="username">__jhiTranslateTag__('global.form.username.label')</label>
           <input
             type="text"
             #username
@@ -39,7 +39,7 @@
         </div>
 
         <div class="mb-3">
-          <label for="password">__jhiTranslateTag__('login.form.password')</label>
+          <label class="form-label" for="password">__jhiTranslateTag__('login.form.password')</label>
           <input
             type="password"
             class="form-control"


### PR DESCRIPTION
Same as all forms

Before
<img width="930" height="155" alt="image" src="https://github.com/user-attachments/assets/22fcee9d-6e71-49e4-973f-8520021f8917" />

After
<img width="938" height="178" alt="image" src="https://github.com/user-attachments/assets/18992173-6080-459c-9008-08f7db03a01d" />
