### PR TITLE
Angular: fix bootswatch theme build failure from broken google fonts import

### DIFF
--- a/generators/angular/generator.spec.ts
+++ b/generators/angular/generator.spec.ts
@@ -226,6 +226,27 @@ describe(`generator - ${clientFramework}`, () => {
     });
   });
 
+  describe('clientTheme: bootswatch theme', () => {
+    before(async () => {
+      await helpers
+        .runJHipster(generator)
+        .withJHipsterConfig({
+          clientFramework,
+          clientTheme: 'flatly',
+        })
+        .withSharedApplication({ getWebappTranslation: () => 'translated-value' })
+        .withMockedSource()
+        .withMockedGenerators(['jhipster:common', 'jhipster:client:i18n']);
+    });
+
+    it('should disable bootswatch web-font-path before importing the theme (#33691)', () => {
+      runResult.assertFileContent(
+        `${CLIENT_MAIN_SRC_DIR}content/scss/vendor.scss`,
+        /\$web-font-path: false;\n@import 'bootswatch\/dist\/flatly\/bootswatch';/,
+      );
+    });
+  });
+
   describe('builtIn UserManagementEntity', () => {
     before(async () => {
       await dryRunHelpers

--- a/generators/angular/templates/src/main/webapp/content/scss/vendor.scss.ejs
+++ b/generators/angular/templates/src/main/webapp/content/scss/vendor.scss.ejs
@@ -30,6 +30,9 @@ eg $input-color: red;
 // Import Bootstrap source files from node_modules
 @import 'bootstrap/scss/bootstrap';
 <%_ if (!clientThemeNone) { _%>
+// Prevent bootswatch from importing its Google Fonts URL: the interpolated `@import url(...)`
+// it emits is not resolved correctly by the Angular esbuild-based Sass compiler (see #33691).
+$web-font-path: false;
 @import 'bootswatch/dist/<%- clientTheme %>/bootswatch';
 <%_ } _%>
 


### PR DESCRIPTION
## What

Fixes the Angular client build failure reported in #33691 when using a Bootswatch `clientTheme` (e.g. `flatly`).

## Why

Bootswatch's `_bootswatch.scss` imports its Google Fonts URL like this:

```scss
$web-font-path: "https://fonts.googleapis.com/css2?family=Lato:..." !default;
@if $web-font-path {
  @import url("#{$web-font-path}");
}
```

The Angular application builder (`@angular/build`, esbuild-based) does not resolve this interpolated `@import url(...)` as an external URL. Instead it tries to resolve it as a module path, concatenating it with the local bootswatch package path, which fails with:

```
[ERROR] Could not resolve "../../../../../node_modules/bootswatch/dist/flatly||file:https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400&display=swap"
```

This reproduces 1:1 with the sample from the issue (`clientTheme: flatly`, Angular, JWT).

## Fix

Set `$web-font-path: false;` right before importing `bootswatch/dist/<theme>/bootswatch` in `vendor.scss.ejs`. Since JHipster uses the legacy `@import` (shared global scope), this pre-assignment makes bootswatch's own `!default` a no-op, so the broken font `@import url(...)` is never emitted. The theme's colors/variables (which come from the separate `variables` import) are unaffected.

## Testing

- Reproduced the exact build error using `jhipster from-issue 33691`, then confirmed the fix resolves it and `npm run webapp:build` completes cleanly, with the compiled CSS still carrying the Flatly theme colors (`--bs-primary: #2c3e50`) and no `fonts.googleapis.com` reference.
- Added a regression test in `generators/angular/generator.spec.ts` asserting the generated `vendor.scss` disables `$web-font-path` before importing a Bootswatch theme.
- Full `generators/angular` test suite passes (1530 passing, 0 failing), no snapshot changes needed.
- `npm run lint-fix` and `npm run check-types` pass clean.

Fix #33691