### PR TITLE
React: define the missing w-40/w-60 helpers used by the configuration table

### DIFF
--- a/generators/react/templates/src/main/webapp/app/app.scss.ejs
+++ b/generators/react/templates/src/main/webapp/app/app.scss.ejs
@@ -142,6 +142,14 @@ Generic styles
   background-color: red;
 }
 
+.w-40 {
+  width: 40% !important;
+}
+
+.w-60 {
+  width: 60% !important;
+}
+
 .break {
   white-space: normal;
   word-break: break-all;


### PR DESCRIPTION
Already present in Angular and Vue
https://github.com/jhipster/generator-jhipster/blob/d6fb09cee696c7aa7f037194b42dca9059e86807/generators/angular/templates/src/main/webapp/content/scss/global.scss.ejs#L111
https://github.com/jhipster/generator-jhipster/blob/d6fb09cee696c7aa7f037194b42dca9059e86807/generators/vue/templates/src/main/webapp/content/scss/global.scss.ejs#L127

Before
<img width="1849" height="485" alt="image" src="https://github.com/user-attachments/assets/1eb9040e-2d67-41f1-b97e-1366937219d4" />

After
<img width="1851" height="413" alt="image" src="https://github.com/user-attachments/assets/2d8943be-9896-4589-8c17-80568d6f8f33" />
