### PR TITLE
Vue: drop the duplicated entity name in the detail page heading

### DIFF
--- a/generators/vue/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-details.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/entities/_entityFolder_/_entityFile_-details.vue.ejs
@@ -2,7 +2,7 @@
     <div class="d-flex justify-content-center">
         <div class="col-8">
             <div v-if="<%- entityInstance %>">
-                <h2 class="jh-entity-heading" data-cy="<%- entityInstance %>DetailsHeading"><span>{{ t$('<%- i18nKeyPrefix %>.detail.title') }}<%- entityAngularName %></span> {{<%- entityInstance %>.<%- primaryKey.name %>}}</h2>
+                <h2 class="jh-entity-heading" data-cy="<%- entityInstance %>DetailsHeading"><span>{{ t$('<%- i18nKeyPrefix %>.detail.title') }}</span> {{<%- entityInstance %>.<%- primaryKey.name %>}}</h2>
                 <dl class="row-md jh-entity-details">
 <%_ for (field of fields.filter(field => !field.id)) { _%>
   <%_ const { fieldName, fieldType } = field; _%>


### PR DESCRIPTION
**Before**
<img width="247" height="177" alt="image" src="https://github.com/user-attachments/assets/2b551a7f-ca85-4424-8261-0f89eb4da0db" />

**After**
<img width="261" height="178" alt="image" src="https://github.com/user-attachments/assets/be307ce1-d3cc-4a62-a194-b50242a1b559" />
