### PR TITLE
Vue: add the missing badge class on the configuration values

### DIFF
--- a/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/admin/configuration/configuration.vue.ejs
@@ -45,7 +45,7 @@
               <div class="row" v-for="key in keys(entry.properties)" :key="key">
                 <div class="col-md-4">{{ key }}</div>
                 <div class="col-md-8">
-                  <span class="float-end bg-secondary break">{{ entry.properties[key] }}</span>
+                  <span class="float-end badge bg-secondary break">{{ entry.properties[key] }}</span>
                 </div>
               </div>
             </td>
@@ -67,7 +67,7 @@
             <tr v-for="item of allConfiguration[key]" :key="item.key">
               <td class="break">{{ item.key }}</td>
               <td class="break">
-                <span class="float-end bg-secondary break">{{ item.val }}</span>
+                <span class="float-end badge bg-secondary break">{{ item.val }}</span>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
**Before**
<img width="1840" height="459" alt="image" src="https://github.com/user-attachments/assets/16bf05c5-92f0-4206-9cbe-c8c9bbb05324" />

**After**
<img width="1843" height="452" alt="image" src="https://github.com/user-attachments/assets/d0d11ae8-edfb-4f2f-b028-74b6b6b8a867" />
