### PR TITLE
ci: make cypress video recording conditional based on pull request label

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -178,6 +178,9 @@ jobs:
         if: steps.compare.outputs.equals != 'true' && runner.os == 'Linux'
         run: npm run ci:e2e:run --if-present
         timeout-minutes: 15
+        env:
+          CYPRESS_video: >-
+            ${{ contains(github.event.pull_request.labels.*.name, 'ci: cypress-video') && 'true' || 'false' }}
       - name: Store the application
         uses: actions/upload-artifact@v7
         if: always() && (steps.backend.outcome == 'failure' || steps.e2e.outcome == 'failure' || steps.frontend.outcome == 'failure' || steps.packaging.outcome == 'failure' || steps.docker-compose.outcome == 'failure')
@@ -199,12 +202,14 @@ jobs:
         with:
           name: log-${{ matrix.sample }}
           path: ${{ github.workspace }}/app/**/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: 'E2E: Store failure cypress assets'
         uses: actions/upload-artifact@v7
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.sample }}
-          path: ${{ github.workspace }}/app/**/cypress/screenshots
+          name: cypress-${{ matrix.sample }}
+          path: |
+            ${{ github.workspace }}/app/**/cypress/screenshots
+            ${{ github.workspace }}/app/**/cypress/videos
       - name: Dump docker logs
         if: always() && runner.os == 'Linux'
         uses: jwalton/gh-docker-logs@v2

--- a/.github/workflows/generator-graalvm.yml
+++ b/.github/workflows/generator-graalvm.yml
@@ -130,6 +130,9 @@ jobs:
       - run: npm run native-e2e --if-present
         id: e2e
         if: steps.compare.outputs.has-backend-changes == 'true'
+        env:
+          CYPRESS_video: >-
+            ${{ contains(github.event.pull_request.labels.*.name, 'ci: cypress-video') && 'true' || 'false' }}
       - name: Store the application
         uses: actions/upload-artifact@v7
         if: steps.compare.outputs.has-backend-changes == 'true' && always() && (steps.e2e.outcome == 'failure' || steps.packaging.outcome == 'failure')
@@ -145,12 +148,14 @@ jobs:
             !**/app/target/**
             !**/app/*/target/**
             !**/node_modules/**
-      - name: 'E2E: Store failure screenshots'
+      - name: 'E2E: Store failure cypress assets'
         uses: actions/upload-artifact@v7
-        if: steps.compare.outputs.has-backend-changes == 'true' && always() && steps.e2e.outcome == 'failure'
+        if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.sample }}
-          path: ${{ github.workspace }}/app/**/cypress/screenshots
+          name: cypress-${{ matrix.sample }}
+          path: |
+            ${{ github.workspace }}/app/**/cypress/screenshots
+            ${{ github.workspace }}/app/**/cypress/videos
       - name: Dump docker logs
         if: steps.compare.outputs.has-backend-changes == 'true' && always() && contains(matrix.os, 'ubuntu')
         uses: jwalton/gh-docker-logs@v2

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -178,6 +178,9 @@ jobs:
         if: steps.compare.outputs.equals != 'true' && runner.os == 'Linux'
         run: npm run ci:e2e:run --if-present
         timeout-minutes: 15
+        env:
+          CYPRESS_video: >-
+            ${{ contains(github.event.pull_request.labels.*.name, 'ci: cypress-video') && 'true' || 'false' }}
       - name: Store the application
         uses: actions/upload-artifact@v7
         if: always() && (steps.backend.outcome == 'failure' || steps.e2e.outcome == 'failure' || steps.frontend.outcome == 'failure' || steps.packaging.outcome == 'failure' || steps.docker-compose.outcome == 'failure')
@@ -199,12 +202,14 @@ jobs:
         with:
           name: log-${{ matrix.sample }}
           path: ${{ github.workspace }}/app/**/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: 'E2E: Store failure cypress assets'
         uses: actions/upload-artifact@v7
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.sample }}
-          path: ${{ github.workspace }}/app/**/cypress/screenshots
+          name: cypress-${{ matrix.sample }}
+          path: |
+            ${{ github.workspace }}/app/**/cypress/screenshots
+            ${{ github.workspace }}/app/**/cypress/videos
       - name: Dump docker logs
         if: always() && runner.os == 'Linux'
         uses: jwalton/gh-docker-logs@v2

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -178,6 +178,9 @@ jobs:
         if: steps.compare.outputs.equals != 'true' && runner.os == 'Linux'
         run: npm run ci:e2e:run --if-present
         timeout-minutes: 15
+        env:
+          CYPRESS_video: >-
+            ${{ contains(github.event.pull_request.labels.*.name, 'ci: cypress-video') && 'true' || 'false' }}
       - name: Store the application
         uses: actions/upload-artifact@v7
         if: always() && (steps.backend.outcome == 'failure' || steps.e2e.outcome == 'failure' || steps.frontend.outcome == 'failure' || steps.packaging.outcome == 'failure' || steps.docker-compose.outcome == 'failure')
@@ -199,12 +202,14 @@ jobs:
         with:
           name: log-${{ matrix.sample }}
           path: ${{ github.workspace }}/app/**/test-results/**/*.xml
-      - name: 'E2E: Store failure screenshots'
+      - name: 'E2E: Store failure cypress assets'
         uses: actions/upload-artifact@v7
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.sample }}
-          path: ${{ github.workspace }}/app/**/cypress/screenshots
+          name: cypress-${{ matrix.sample }}
+          path: |
+            ${{ github.workspace }}/app/**/cypress/screenshots
+            ${{ github.workspace }}/app/**/cypress/videos
       - name: Dump docker logs
         if: always() && runner.os == 'Linux'
         uses: jwalton/gh-docker-logs@v2

--- a/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/plugins/index.ts.ejs
@@ -44,8 +44,14 @@ export default <%- cypressCoverage ? 'async ' : '' %>(on: Cypress.PluginEvents, 
 <%_ } _%>
     if (browser.name === 'chrome' && browser.isHeadless) {
       launchOptions.args.push('--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage');
-      return launchOptions;
     }
+    if (browser.family === 'chromium' && browser.name !== 'electron') {
+      launchOptions.args.push(
+        // Forces Chrome/Edge to open a large window so the viewport doesn't scale down
+        '--window-size=1920,1080',
+      );
+    }
+    return launchOptions;
   });
 
   // Allows logging with cy.task('log', 'message') or cy.task('table', object)


### PR DESCRIPTION
Add cypress video support to improve debugging of cypress errors.
Cherrypick from https://github.com/jhipster/generator-jhipster/pull/34149.

Related to https://github.com/jhipster/generator-jhipster/issues/34173.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
