### PR TITLE
vue: refactor account store to use `setup` syntax and `storeToRefs` f…

### DIFF
--- a/generators/vue/templates/src/main/webapp/app/account/account.service.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/account.service.spec.ts.ejs
@@ -27,7 +27,11 @@ import { AUTHENTICATION_TOKEN_KEY } from '@/shared/jhipster/constants';
 <%_ } _%>
 
 const resetStore = (store: AccountStore) => {
-  store.$reset();
+  store.logout();
+  store.authenticate(null);
+  store.profilesLoaded = false;
+  store.activeProfiles = '';
+  store.ribbonOnProfiles = '';
 };
 
 const axiosStub = {

--- a/generators/vue/templates/src/main/webapp/app/account/login.service.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/login.service.spec.ts.ejs
@@ -67,6 +67,8 @@ describe('Login Service test suite', () => {
 <%_ } _%>
 
   it('should call global logout when asked to', () => {
+    axiosStub.post.mockResolvedValue({});
+
     loginService.logout();
 
     expect(axiosStub.post).toHaveBeenCalledWith('api/logout');

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.spec.ts.ejs
@@ -18,18 +18,19 @@
 -%>
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed } from 'vue';
-import { shallowMount } from '@vue/test-utils';
 import { type Router } from 'vue-router';
 import { createTestingPinia } from '@pinia/testing';
+import { shallowMount } from '@vue/test-utils';
 
-import { useStore } from '@/store';
-import { createRouter } from '@/router';
 <%_ if (authenticationUsesCsrf) { _%>
 import type LoginService from '@/account/login.service';
 <%_ } _%>
 <%_ if (generateUserManagement) { _%>
 import { useLoginModal } from '@/account/login-modal';
 <%_ } _%>
+import { createRouter } from '@/router';
+import { useStore } from '@/store';
+
 import JhiNavbar from './jhi-navbar.vue';
 <%_ if (microfrontend) { _%>
 
@@ -129,26 +130,41 @@ describe('JhiNavbar', () => {
     expect(accountService.hasAnyAuthorityAndCheckAuth).toHaveBeenCalled();
   });
 
-  it('logout should clear credentials', async () => {
+  it('logout should clear credentials and return to the home page when no provider URL is returned', async () => {
     store.setAuthentication({ login: 'test' });
 <%_ if (authenticationTypeOauth2) { _%>
-    const logoutUrl = '/to-match';
-    (loginService.logout as any).mockReturnValue(Promise.resolve({ data: { logoutUrl } }));
-<%_ } else if (authenticationUsesCsrf) { _%>
+    await router.push('/forbidden');
+<%_ } _%>
+<%_ if (authenticationUsesCsrf) { _%>
     (loginService.logout as any).mockReturnValue(Promise.resolve({}));
 <%_ } _%>
 
     await jhiNavbar.logout();
 
-<%_ if (!authenticationTypeJwt) { _%>
+<%_ if (authenticationTypeJwt) { _%>
+    expect(jhiNavbar.authenticated).toBeFalsy();
+<%_ } else { _%>
     expect(loginService.logout).toHaveBeenCalled();
   <%_ if (authenticationTypeOauth2) { _%>
-    expect(router.currentRoute.value.path).toBe(logoutUrl);
-  <%_ } _%>
-<%_ } else { _%>
     expect(jhiNavbar.authenticated).toBeFalsy();
+    expect(router.currentRoute.value.path).toBe('/');
+  <%_ } _%>
 <%_ } _%>
   });
+<%_ if (authenticationTypeOauth2) { _%>
+
+  it('logout should not navigate with router for external url', async () => {
+    store.setAuthentication({ login: 'test' });
+    const logoutUrl = 'http://keycloak:9080/logout';
+    (loginService.logout as any).mockReturnValue(Promise.resolve({ data: { logoutUrl } }));
+    const routerPushSpy = vi.spyOn(router, 'push');
+
+    await jhiNavbar.logout();
+
+    expect(loginService.logout).toHaveBeenCalled();
+    expect(routerPushSpy).not.toHaveBeenCalled();
+  });
+<%_ } _%>
 
   it('should determine active route', async () => {
     await router.push('/forbidden');

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -97,24 +97,27 @@ export default defineComponent({
       localStorage.removeItem(AUTHENTICATION_TOKEN_KEY);
       sessionStorage.removeItem(AUTHENTICATION_TOKEN_KEY);
       store.logout();
-      if (router.currentRoute.value.path !== '/') {
-        router.push('/');
-      }
 <%_ } else { _%>
       const response = await loginService.logout();
       store.logout();
+
   <%_ if (authenticationTypeOauth2) { _%>
-      window.location.href = response.data.logoutUrl;
-      const next = response.data?.logoutUrl ?? '/';
-      if (router.currentRoute.value.path !== next) {
+      const next = response.data?.logoutUrl;
+
+      if (next) {
+        if (/^https?:\/\//i.test(next)) {
+          window.location.href = next;
+          return;
+        }
         await router.push(next);
+        return;
       }
-  <%_ } else { _%>
+
+  <%_ } _%>
+<%_ } _%>
       if (router.currentRoute.value.path !== '/') {
         await router.push('/');
       }
-  <%_ } _%>
-<%_ } _%>
     },
 
     return {

--- a/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -17,6 +17,7 @@
  limitations under the License.
 -%>
 import { computed, <%- microfrontend ? 'defineAsyncComponent, ' : '' %>defineComponent, inject, ref, type Ref } from 'vue';
+import { storeToRefs } from 'pinia'
 <%_ if (enableTranslation) { _%>
 import { useI18n } from 'vue-i18n';
 <%_ } _%>
@@ -83,7 +84,7 @@ export default defineComponent({
 
     const openAPIEnabled = computed(() => store.activeProfiles.includes('api-docs'));
     const inProduction = computed(() => store.activeProfiles.includes('prod'));
-    const authenticated = computed(() => store.authenticated);
+    const { authenticated } = storeToRefs(store)
 
     const subIsActive = (input: string | string[]) => {
       const paths = Array.isArray(input) ? input : [input];

--- a/generators/vue/templates/src/main/webapp/app/main.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/main.ts.ejs
@@ -90,7 +90,7 @@ const app = createApp({
     const translationService = new TranslationService(i18n);
 
     const changeLanguage = async (newLanguage: string) => {
-      if (i18n.locale.value !== newLanguage) {
+      if (newLanguage && i18n.locale.value !== newLanguage) {
         await translationService.refreshTranslation(newLanguage);
         translationStore.setCurrentLanguage(newLanguage);
       }
@@ -103,7 +103,7 @@ const app = createApp({
       () => store.account,
       async value => {
         if (!translationService.getLocalStoreLanguage()) {
-          await changeLanguage(value.langKey);
+          await changeLanguage(value?.langKey);
         }
       },
     );
@@ -158,7 +158,7 @@ const app = createApp({
           localStorage.removeItem(AUTHENTICATION_TOKEN_KEY);
 <%_ } _%>
           store.logout();
-          if (!url.endsWith('api/account') && !url.endsWith('api/<%- authenticationTypeSession ? 'authentication' : 'authenticate' %>')) {
+          if (!url?.endsWith('api/account') && !url?.endsWith('api/<%- authenticationTypeSession ? 'authentication' : 'authenticate' %>')) {
             // Ask for a new authentication
 <%_ if (authenticationTypeOauth2) { _%>
             window.location.reload();

--- a/generators/vue/templates/src/main/webapp/app/shared/config/store/account-store.ts.ejs
+++ b/generators/vue/templates/src/main/webapp/app/shared/config/store/account-store.ts.ejs
@@ -17,52 +17,60 @@
  limitations under the License.
 -%>
 import { defineStore } from 'pinia'
+import { ref, computed } from 'vue';
 
-export interface AccountStateStorable {
-  logon: boolean | null;
-  userIdentity: any;
-  authenticated: boolean;
-  profilesLoaded: boolean;
-  ribbonOnProfiles: string;
-  activeProfiles: string;
-}
+export const useAccountStore = defineStore('main', () => {
+  const userIdentity = ref(null);
+  const logon = ref(null);
+  const profilesLoaded = ref(false);
+  const activeProfiles = ref('');
+  const ribbonOnProfiles = ref('');
 
-export const defaultAccountState: AccountStateStorable = {
-  logon: null,
-  userIdentity: null,
-  authenticated: false,
-  profilesLoaded: false,
-  ribbonOnProfiles: '',
-  activeProfiles: '',
-};
+  const account = computed(() => userIdentity.value);
+  const authenticated = computed(() => !!userIdentity.value);
 
-export const useAccountStore = defineStore('main', {
-  state: (): AccountStateStorable => ({ ...defaultAccountState }),
-  getters: {
-    account: state => state.userIdentity,
-  },
-  actions: {
-    authenticate(promise) {
-      this.logon = promise;
-    },
-    setAuthentication(identity) {
-      this.userIdentity = identity;
-      this.authenticated = true;
-      this.logon = null;
-    },
-    logout() {
-      this.userIdentity = null;
-      this.authenticated = false;
-      this.logon = null;
-    },
-    setProfilesLoaded() {
-      this.profilesLoaded = true;
-    },
-    setActiveProfiles(profile) {
-      this.activeProfiles = profile;
-    },
-    setRibbonOnProfiles(ribbon) {
-      this.ribbonOnProfiles = ribbon;
-    },
-  },
+  function authenticate(promise) {
+    logon.value = promise;
+  }
+
+  function setAuthentication(identity) {
+    userIdentity.value = identity;
+    logon.value = null;
+  }
+
+  function logout() {
+    userIdentity.value = null;
+    logon.value = null;
+  }
+
+  function setProfilesLoaded() {
+    profilesLoaded.value = true;
+  }
+
+  function setActiveProfiles(profile) {
+    activeProfiles.value = profile;
+  }
+
+  function setRibbonOnProfiles(ribbon) {
+    ribbonOnProfiles.value = ribbon;
+  }
+
+  return {
+    // State
+    userIdentity,
+    logon,
+    profilesLoaded,
+    activeProfiles,
+    ribbonOnProfiles,
+    // Getters
+    account,
+    authenticated,
+    // Actions
+    authenticate,
+    setAuthentication,
+    logout,
+    setProfilesLoaded,
+    setActiveProfiles,
+    setRibbonOnProfiles,
+  };
 });


### PR DESCRIPTION
…or better reactivity

Cherrypick from https://github.com/jhipster/generator-jhipster/pull/34149.

Related to https://github.com/jhipster/generator-jhipster/issues/34173.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
