### PR TITLE
spring-boot: fix missing webapp in the gradle prod jar

### DIFF
--- a/generators/spring-boot/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/spring-boot/templates/gradle/profile_prod.gradle.ejs
@@ -40,6 +40,12 @@ bootRun {
 <%_ if (!skipClient) { _%>
 def webapp = tasks.register('webapp', NpmTask) {
     dependsOn(npmInstall)
+    // Tells Gradle that this task owns the client build directory. Without it, the stale output
+    // cleanup empties build/resources/main before processResources runs on a clean build folder,
+    // and the webapp never makes it into the jar.
+    outputs.dir("<%- clientDistDir %>")
+        .withPropertyName("webapp-build-dir")
+    outputs.upToDateWhen { false }
     args = ["run", "webapp:prod"]
     environment = [APP_VERSION: project.version]
 }


### PR DESCRIPTION
Related to #34149 

Try with
<img width="1219" height="280" alt="image" src="https://github.com/user-attachments/assets/d8d084f9-3411-4593-9d01-5158b11108eb" />
because build failed on #34524 

I will revert this if PR is OK