### PR TITLE
spring-boot: prevent SecurityUtils from returning anonymousUser

### DIFF
--- a/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/security/SecurityUtils.java.ejs
@@ -22,6 +22,7 @@ package <%- packageName %>.security;
 import <%- packageName %>.config.Constants;
 <%_ } _%>
 
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -97,7 +98,8 @@ public final class SecurityUtils {
     }
 
     private static String extractPrincipal(Authentication authentication) {
-        if (authentication == null) {
+        // AnonymousAuthenticationToken has a String principal that would fall through below
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
             return null;
         } else if (authentication.getPrincipal() instanceof UserDetails springSecurityUser) {
             return springSecurityUser.getUsername();

--- a/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_imperative.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_imperative.java.ejs
@@ -25,6 +25,7 @@ import static <%- packageName %>.security.SecurityUtils.USER_ID_CLAIM;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -72,6 +73,16 @@ class SecurityUtilsUnitTest {
         SecurityContextHolder.setContext(securityContext);
         Optional<String> login = SecurityUtils.getCurrentUserLogin();
         assertThat(login).contains("admin");
+    }
+
+    @Test
+    void testGetCurrentUserLoginForAnonymousUser() {
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        var authorities = List.of(new SimpleGrantedAuthority(AuthoritiesConstants.ANONYMOUS));
+        securityContext.setAuthentication(new AnonymousAuthenticationToken("key", "anonymousUser", authorities));
+        SecurityContextHolder.setContext(securityContext);
+        Optional<String> login = SecurityUtils.getCurrentUserLogin();
+        assertThat(login).isEmpty();
     }
 <%_ if (authenticationTypeOauth2) { _%>
 

--- a/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_reactive.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/security/SecurityUtilsUnitTest_reactive.java.ejs
@@ -29,6 +29,7 @@ import static <%- packageName %>.security.SecurityUtils.USER_ID_CLAIM;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -59,6 +60,16 @@ class SecurityUtilsUnitTest {
             .contextWrite(ReactiveSecurityContextHolder.withAuthentication(new UsernamePasswordAuthenticationToken("admin", "admin")))
             .block();
         assertThat(login).isEqualTo("admin");
+    }
+
+    @Test
+    void testGetCurrentUserLoginForAnonymousUser() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(AuthoritiesConstants.ANONYMOUS));
+        String login = SecurityUtils.getCurrentUserLogin()
+            .contextWrite(ReactiveSecurityContextHolder.withAuthentication(new AnonymousAuthenticationToken("key", "anonymousUser", authorities)))
+            .block();
+        assertThat(login).isNull();
     }
 <%_ if (authenticationTypeJwt) { _%>
 


### PR DESCRIPTION
## Description

`SecurityUtils.extractPrincipal` returns any `String` principal as a login. For unauthenticated requests, Spring Security's `AnonymousAuthenticationFilter` sets an `AnonymousAuthenticationToken` whose principal is the string `"anonymousUser"`, so `getCurrentUserLogin()` returns `Optional.of("anonymousUser")` instead of an empty `Optional`.

As a result the `orElse(Constants.SYSTEM)` fallback in `SpringSecurityAuditorAware` is unreachable, so the audit columns of users written through the unauthenticated account endpoints hold `"anonymousUser"` instead of `"system"`.

This PR returns `null` for `AnonymousAuthenticationToken`. The check is on the token type rather than on the `"anonymousUser"` string, so a customised anonymous principal name is covered too. Tests are added to both the imperative and reactive `SecurityUtilsUnitTest` templates, which previously never constructed a real `AnonymousAuthenticationToken`.

Verified locally on a stock 9.2.0 monolith (SQL / JWT) with a throwaway integration test: `POST /api/register`, `GET /api/activate` and `POST /api/account/reset-password/init` all persist `"anonymousUser"` in `created_by` / `last_modified_by` before this change, and `"system"` after.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [x] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
