### PR TITLE
react: use literal versions in npm overrides

### DIFF
--- a/generators/react/templates/package.json.ejs
+++ b/generators/react/templates/package.json.ejs
@@ -111,9 +111,10 @@
     "workbox-webpack-plugin": "<%- nodeDependencies['workbox-webpack-plugin'] %>"
   },
   <%# An unknown dependency pulls in outdated react and react-dom, override them -%>
+  <%# Use literal versions, npm 10 fails to resolve $ references https://github.com/npm/cli/issues/5730 -%>
   "overrides": {
-    "react": "$react",
-    "react-dom": "$react-dom"
+    "react": "<%- nodeDependencies.react %>",
+    "react-dom": "<%- nodeDependencies['react-dom'] %>"
   },
   "engines": {
     "node": ">=<%- nodeVersion %>"


### PR DESCRIPTION
Fix #34548

npm 10 fails to resolve the `$react` / `$react-dom` references in a freshly generated app (npm/cli#5730, fixed in npm 11), so `npm install` fails with `Unable to resolve reference $react` on the npm bundled with Node 22.

**Fix**: render literal versions instead, same as the pre #33807 behavior in the workspace generator, which used literal versions to work around npm/cli#4437. The workspaces overrides copy is unaffected: `replacePlaceholder` only transforms `$` prefixed strings and passes literal values through unchanged.

Verified the rendered app installs with npm 10.8.2, 10.9.3 (bundled with Node 22.18.0) and npm 11.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [x] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
