### PR TITLE
Angular: remove duplicate httpMock.verify

### DIFF
--- a/generators/angular/__snapshots__/generator.spec.ts.snap
+++ b/generators/angular/__snapshots__/generator.spec.ts.snap
@@ -1227,7 +1227,6 @@ describe("UserManagement Service", () => {
 
       const req = httpMock.expectOne({ method: "GET" });
       req.flush([returnedFromService]);
-      httpMock.verify();
       expect(expectedResult).toMatchObject([expected]);
     });
 

--- a/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/service/_entityFile_.service.spec.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/entities/_entityFolder_/service/_entityFile_.service.spec.ts.ejs
@@ -123,7 +123,6 @@ describe('<%- entityAngularName %> Service', () => {
 
             const req = httpMock.expectOne({ method: 'GET' });
             req.flush([returnedFromService]);
-            httpMock.verify();
             expect(expectedResult).toMatchObject([expected]);
         });
 


### PR DESCRIPTION
Call in the `afterEach`