### PR TITLE
ci-cd: do not make wrapper executable, it was fixed ages ago

### DIFF
--- a/generators/ci-cd/__snapshots__/ci-cd.spec.ts.snap
+++ b/generators/ci-cd/__snapshots__/ci-cd.spec.ts.snap
@@ -52,7 +52,6 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Gradle Angular
     inputs:
       command: 'install'
     displayName: 'INSTALL: launch npm install'
-  - script: chmod +x gradlew
   - task: Npm@1
     inputs:
       command: 'custom'
@@ -181,7 +180,6 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Gradle Angular
     displayName: 'CHECK: Snyk monitor'
     env:
       SNYK_TOKEN: $(SNYK_TOKEN)
-  - script: chmod +x gradlew
   - task: Npm@1
     inputs:
       command: 'custom'
@@ -298,7 +296,6 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Maven Angular 
     inputs:
       command: 'install'
     displayName: 'INSTALL: launch npm install'
-  - script: chmod +x mvnw
   - task: Npm@1
     inputs:
       command: 'custom'
@@ -427,7 +424,6 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: Maven Angular 
     displayName: 'CHECK: Snyk monitor'
     env:
       SNYK_TOKEN: $(SNYK_TOKEN)
-  - script: chmod +x mvnw
   - task: Npm@1
     inputs:
       command: 'custom'
@@ -544,7 +540,6 @@ exports[`generator - CI-CD Azure Pipelines tests Azure Pipelines: autoconfigure 
     inputs:
       command: 'install'
     displayName: 'INSTALL: launch npm install'
-  - script: chmod +x mvnw
   - task: Npm@1
     inputs:
       command: 'custom'
@@ -646,9 +641,6 @@ jobs:
                 key: v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "package-lock.json" }}
 
             - run:
-                name: Give Executable Power
-                command: 'chmod +x gradlew'
-            - run:
                 name: Backend tests
                 command: npm run ci:backend:test
             - run:
@@ -737,9 +729,6 @@ jobs:
                 key: v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "package-lock.json" }}
 
             - run:
-                name: Give Executable Power
-                command: 'chmod +x gradlew'
-            - run:
                 name: Backend tests
                 command: npm run ci:backend:test
             - run:
@@ -816,9 +805,6 @@ jobs:
                     - ~/.m2
                 key: v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "package-lock.json" }}
 
-            - run:
-                name: Give Executable Power
-                command: 'chmod +x mvnw'
             - run:
                 name: Backend tests
                 command: npm run ci:backend:test
@@ -908,9 +894,6 @@ jobs:
                 key: v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "package-lock.json" }}
 
             - run:
-                name: Give Executable Power
-                command: 'chmod +x mvnw'
-            - run:
                 name: Backend tests
                 command: npm run ci:backend:test
             - run:
@@ -986,9 +969,7 @@ jobs:
             - name: Install Node.js packages
               run: npm install
             - name: Run backend test
-              run: |
-                  chmod +x gradlew
-                  npm run ci:backend:test
+              run: npm run ci:backend:test
             - name: Run frontend test
               run: npm run ci:frontend:test
             - name: Package application
@@ -1075,9 +1056,7 @@ jobs:
               env:
                   SNYK_TOKEN: \${{ secrets.SNYK_TOKEN }}
             - name: Run backend test
-              run: |
-                  chmod +x gradlew
-                  npm run ci:backend:test
+              run: npm run ci:backend:test
             - name: Run frontend test
               run: npm run ci:frontend:test
             - name: Analyze code with SonarQube
@@ -1212,9 +1191,7 @@ jobs:
             - name: Install Node.js packages
               run: npm install
             - name: Run backend test
-              run: |
-                  chmod +x mvnw
-                  npm run ci:backend:test
+              run: npm run ci:backend:test
             - name: Run frontend test
               run: npm run ci:frontend:test
             - name: Package application
@@ -1295,9 +1272,7 @@ jobs:
               env:
                   SNYK_TOKEN: \${{ secrets.SNYK_TOKEN }}
             - name: Run backend test
-              run: |
-                  chmod +x mvnw
-                  npm run ci:backend:test
+              run: npm run ci:backend:test
             - name: Run frontend test
               run: npm run ci:frontend:test
             - name: Analyze code with SonarQube
@@ -1451,9 +1426,7 @@ jobs:
             - name: Install Node.js packages
               run: npm install
             - name: Run backend test
-              run: |
-                  chmod +x mvnw
-                  npm run ci:backend:test
+              run: npm run ci:backend:test
             - name: Run frontend test
               run: npm run ci:frontend:test
             - name: Package application
@@ -2296,7 +2269,6 @@ node {
     }
 
     stage('clean') {
-        sh "chmod +x gradlew"
         sh "./gradlew clean --no-daemon"
     }
     stage('nohttp') {
@@ -2481,7 +2453,6 @@ node {
         }
 
         stage('clean') {
-            sh "chmod +x mvnw"
             sh "./mvnw -ntp clean -P-webapp"
         }
         stage('nohttp') {
@@ -2755,7 +2726,6 @@ node {
     }
 
     stage('clean') {
-        sh "chmod +x mvnw"
         sh "./mvnw -ntp clean -P-webapp"
     }
     stage('nohttp') {
@@ -2942,7 +2912,6 @@ node {
     }
 
     stage('clean') {
-        sh "chmod +x mvnw"
         sh "./mvnw -ntp clean -P-webapp"
     }
     stage('nohttp') {
@@ -3224,7 +3193,6 @@ before_install:
 install:
   - npm install
 script:
-  - chmod +x gradlew
   - npm run ci:backend:test
   - npm run ci:frontend:test
   - npm run java:jar:prod
@@ -3300,7 +3268,6 @@ before_install:
 install:
   - npm install
 script:
-  - chmod +x mvnw
   - npm run ci:backend:test
   - npm run ci:frontend:test
   - npm run java:jar:prod
@@ -3380,7 +3347,6 @@ script:
   - chmod +x snyk
   - ./snyk test --all-projects || true
   - ./snyk monitor --all-projects
-  - chmod +x mvnw
   - npm run ci:backend:test
   - npm run ci:frontend:test
   - npm run java:jar:prod

--- a/generators/ci-cd/generators/azure/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/generators/azure/templates/azure-pipelines.yml.ejs
@@ -72,11 +72,6 @@ jobs:
       SNYK_TOKEN: $(SNYK_TOKEN)
 <%_ } _%>
 <%_ if (!skipServer) { _%>
-  <%_ if (buildToolMaven) { _%>
-  - script: chmod +x mvnw
-  <%_ } else if (buildToolGradle) { _%>
-  - script: chmod +x gradlew
-  <%_ } _%>
   - task: Npm@1
     inputs:
       command: 'custom'

--- a/generators/ci-cd/generators/circle/templates/.circleci/config.yml.ejs
+++ b/generators/ci-cd/generators/circle/templates/.circleci/config.yml.ejs
@@ -72,13 +72,6 @@ jobs:
 <%_ } _%>
 
             - run:
-                name: Give Executable Power
-<%_ if (buildToolMaven) { _%>
-                command: 'chmod +x mvnw'
-<%_ } else if (buildToolGradle) { _%>
-                command: 'chmod +x gradlew'
-<%_ } _%>
-            - run:
                 name: Backend tests
                 command: <%- nodePackageManager %> run ci:backend:test
 <%_ if (!skipClient) { _%>

--- a/generators/ci-cd/generators/github/templates/.github/workflows/main.yml.ejs
+++ b/generators/ci-cd/generators/github/templates/.github/workflows/main.yml.ejs
@@ -86,13 +86,7 @@ jobs:
 <%_ } _%>
 <%_ if (!skipServer) { _%>
             - name: Run backend test
-              run: |
-  <%_ if (buildToolMaven) { _%>
-                  chmod +x mvnw
-  <%_ } else if (buildToolGradle) { _%>
-                  chmod +x gradlew
-  <%_ } _%>
-                  <%- nodePackageManager %> run ci:backend:test
+              run: <%- nodePackageManager %> run ci:backend:test
   <%_ if (!skipClient) { _%>
             - name: Run frontend test
               run: <%- nodePackageManager %> run ci:frontend:test

--- a/generators/ci-cd/generators/jenkins/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/generators/jenkins/templates/jenkins/Jenkinsfile.ejs
@@ -35,7 +35,6 @@ node {
 
 <%_ if (buildToolMaven) { _%>
 <%- indent %>    stage('clean') {
-<%- indent %>        sh "chmod +x mvnw"
 <%- indent %>        sh "./mvnw -ntp clean -P-webapp"
 <%- indent %>    }
 <%- indent %>    stage('nohttp') {
@@ -103,7 +102,6 @@ node {
 <%- indent %>    }
 <%_ } else if (buildToolGradle) { _%>
 <%- indent %>    stage('clean') {
-<%- indent %>        sh "chmod +x gradlew"
 <%- indent %>        sh "./gradlew clean --no-daemon"
 <%- indent %>    }
 <%- indent %>    stage('nohttp') {

--- a/generators/ci-cd/generators/travis/templates/.travis.yml.ejs
+++ b/generators/ci-cd/generators/travis/templates/.travis.yml.ejs
@@ -68,11 +68,6 @@ script:
   - ./snyk test --all-projects || true
   - ./snyk monitor --all-projects
 <%_ } _%>
-<%_ if (buildToolMaven) { _%>
-  - chmod +x mvnw
-<%_ } else if (buildToolGradle) { _%>
-  - chmod +x gradlew
-<%_ } _%>
   - <%- nodePackageManager %> run ci:backend:test
 <%_ if (!skipClient) { _%>
   - <%- nodePackageManager %> run ci:frontend:test


### PR DESCRIPTION
generator-jhipster generates executable wrapper for a long now now.

Cherrypick from https://github.com/jhipster/generator-jhipster/pull/31848
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
