### PR TITLE
spring-boot: update elasticsearch index only after transaction commit

### DIFF
--- a/generators/spring-boot/generators/data-elasticsearch/__snapshots__/generator.spec.ts.snap
+++ b/generators/spring-boot/generators/data-elasticsearch/__snapshots__/generator.spec.ts.snap
@@ -173,6 +173,9 @@ exports[`generator - elasticsearch gateway-jwt-reactive(false)-maven-enableTrans
   "src/main/java/tech/jhipster/service/mapper/UserMapper.java": {
     "stateCleared": "modified",
   },
+  "src/main/java/tech/jhipster/util/TransactionUtils.java": {
+    "stateCleared": "modified",
+  },
   "src/main/java/tech/jhipster/web/filter/SpaWebFilter.java": {
     "stateCleared": "modified",
   },
@@ -1265,6 +1268,9 @@ exports[`generator - elasticsearch microservice-jwt-reactive(false)-maven-enable
   "src/main/java/tech/jhipster/service/mapper/EntityMapper.java": {
     "stateCleared": "modified",
   },
+  "src/main/java/tech/jhipster/util/TransactionUtils.java": {
+    "stateCleared": "modified",
+  },
   "src/main/java/tech/jhipster/web/rest/AnotherSimpleResource.java": {
     "stateCleared": "modified",
   },
@@ -2279,6 +2285,9 @@ exports[`generator - elasticsearch monolith-jwt-reactive(false)-maven-enableTran
   "src/main/java/tech/jhipster/service/mapper/UserMapper.java": {
     "stateCleared": "modified",
   },
+  "src/main/java/tech/jhipster/util/TransactionUtils.java": {
+    "stateCleared": "modified",
+  },
   "src/main/java/tech/jhipster/web/filter/SpaWebFilter.java": {
     "stateCleared": "modified",
   },
@@ -3001,6 +3010,9 @@ exports[`generator - elasticsearch monolith-oauth2-reactive(false)-maven-enableT
     "stateCleared": "modified",
   },
   "src/main/java/tech/jhipster/service/mapper/EntityMapper.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/tech/jhipster/util/TransactionUtils.java": {
     "stateCleared": "modified",
   },
   "src/main/java/tech/jhipster/web/filter/SpaWebFilter.java": {
@@ -3731,6 +3743,9 @@ exports[`generator - elasticsearch monolith-session-reactive(false)-maven-enable
     "stateCleared": "modified",
   },
   "src/main/java/tech/jhipster/service/mapper/UserMapper.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/tech/jhipster/util/TransactionUtils.java": {
     "stateCleared": "modified",
   },
   "src/main/java/tech/jhipster/web/filter/SpaWebFilter.java": {

--- a/generators/spring-boot/generators/data-elasticsearch/files.ts
+++ b/generators/spring-boot/generators/data-elasticsearch/files.ts
@@ -33,6 +33,12 @@ export const files = asWriteFilesSection<JavaApplication>({
       ],
     },
     {
+      condition: generator => !generator.reactive,
+      path: `${SERVER_MAIN_SRC_DIR}_package_/`,
+      renameTo: moveToJavaPackageSrcDir,
+      templates: ['util/TransactionUtils.java'],
+    },
+    {
       condition: generator => generator.generateBuiltInUserEntity,
       path: `${SERVER_MAIN_SRC_DIR}_package_/`,
       renameTo: moveToJavaPackageSrcDir,

--- a/generators/spring-boot/generators/data-elasticsearch/templates/src/main/java/_package_/_entityPackage_/repository/search/_entityClass_SearchRepository.java.ejs
+++ b/generators/spring-boot/generators/data-elasticsearch/templates/src/main/java/_package_/_entityPackage_/repository/search/_entityClass_SearchRepository.java.ejs
@@ -42,13 +42,12 @@ import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.repository.<%- reactive ? 'Reactive' : '' %>ElasticsearchRepository;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 <%_ if (reactive) { _%>
 import reactor.core.publisher.Flux;
 <%_ } else { _%>
+import <%- packageName %>.util.TransactionUtils;
+
+import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 <%_ } _%>
 <%_ if (primaryKey.typeUUID) { _%>
@@ -108,10 +107,8 @@ interface <%- entityClass %>SearchRepositoryInternal {
     Page<<%- persistClass %>> search(Query query);
   <%_ } _%>
 
-    @Async
     void index(<%- persistClass %> entity);
 
-    @Async
     void deleteFromIndexById(<%- primaryKey.type %> id);
 }
 
@@ -119,10 +116,12 @@ class <%- entityClass %>SearchRepositoryInternalImpl implements <%- entityClass 
 
     private final ElasticsearchTemplate elasticsearchTemplate;
     private final <%- entityClass %>Repository repository;
+    private final Executor taskExecutor;
 
-    <%- entityClass %>SearchRepositoryInternalImpl(ElasticsearchTemplate elasticsearchTemplate, <%- entityClass %>Repository repository) {
+    <%- entityClass %>SearchRepositoryInternalImpl(ElasticsearchTemplate elasticsearchTemplate, <%- entityClass %>Repository repository, Executor taskExecutor) {
         this.elasticsearchTemplate = elasticsearchTemplate;
         this.repository = repository;
+        this.taskExecutor = taskExecutor;
     }
 
   <%_ if (paginationNo) { _%>
@@ -156,12 +155,15 @@ class <%- entityClass %>SearchRepositoryInternalImpl implements <%- entityClass 
 
     @Override
     public void index(<%- persistClass %> entity) {
-        repository.find<%- implementsEagerLoadApis ? 'OneWithEagerRelationships' : 'ById' %>(entity.<%- primaryKey.propertySupplierName %>()).ifPresent(elasticsearchTemplate::save);
+        <%- primaryKey.type %> id = entity.<%- primaryKey.propertySupplierName %>();
+        TransactionUtils.runAfterCommit(() ->
+            taskExecutor.execute(() -> repository.find<%- implementsEagerLoadApis ? 'OneWithEagerRelationships' : 'ById' %>(id).ifPresent(elasticsearchTemplate::save))
+        );
     }
 
     @Override
     public void deleteFromIndexById(<%- primaryKey.type %> id) {
-        elasticsearchTemplate.delete(String.valueOf(id), <%- persistClass %>.class);
+        TransactionUtils.runAfterCommit(() -> taskExecutor.execute(() -> elasticsearchTemplate.delete(String.valueOf(id), <%- persistClass %>.class)));
     }
 }
 <%_ } _%>

--- a/generators/spring-boot/generators/data-elasticsearch/templates/src/main/java/_package_/repository/search/UserSearchRepository.java.ejs
+++ b/generators/spring-boot/generators/data-elasticsearch/templates/src/main/java/_package_/repository/search/UserSearchRepository.java.ejs
@@ -34,11 +34,9 @@ import org.springframework.data.elasticsearch.repository.<%- reactive ? 'Reactiv
 
 import reactor.core.publisher.Flux;
 <%_ } else { _%>
-import org.springframework.scheduling.annotation.Async;
-  <%_ if (databaseTypeSql) { _%>
-import org.springframework.transaction.annotation.Transactional;
-  <%_ } _%>
+import <%- packageName %>.util.TransactionUtils;
 
+import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 <%_ } _%>
 <%_ if (databaseTypeCassandra || user.primaryKey.hasUUID) { _%>
@@ -78,16 +76,8 @@ class UserSearchRepositoryInternalImpl implements UserSearchRepositoryInternal {
 interface UserSearchRepositoryInternal {
     Stream<<%- user.persistClass %>> search(String query);
 
-    @Async
-  <%_ if (databaseTypeSql) { _%>
-    @Transactional
-  <%_ } _%>
     void index(<%- user.persistClass %> entity);
 
-    @Async
-  <%_ if (databaseTypeSql) { _%>
-    @Transactional
-  <%_ } _%>
     void deleteFromIndex(<%- user.persistClass %> entity);
 }
 
@@ -95,10 +85,12 @@ class UserSearchRepositoryInternalImpl implements UserSearchRepositoryInternal {
 
     private final ElasticsearchTemplate elasticsearchTemplate;
     private final UserRepository repository;
+    private final Executor taskExecutor;
 
-    UserSearchRepositoryInternalImpl(ElasticsearchTemplate elasticsearchTemplate, UserRepository repository) {
+    UserSearchRepositoryInternalImpl(ElasticsearchTemplate elasticsearchTemplate, UserRepository repository, Executor taskExecutor) {
         this.elasticsearchTemplate = elasticsearchTemplate;
         this.repository = repository;
+        this.taskExecutor = taskExecutor;
     }
 
     @Override
@@ -112,12 +104,13 @@ class UserSearchRepositoryInternalImpl implements UserSearchRepositoryInternal {
 
     @Override
     public void index(<%- user.persistClass %> entity) {
-        repository.findById(entity.getId()).ifPresent(elasticsearchTemplate::save);
+        <%- user.primaryKey.type %> id = entity.getId();
+        TransactionUtils.runAfterCommit(() -> taskExecutor.execute(() -> repository.findById(id).ifPresent(elasticsearchTemplate::save)));
     }
 
     @Override
     public void deleteFromIndex(<%- user.persistClass %> entity) {
-        elasticsearchTemplate.delete(entity);
+        TransactionUtils.runAfterCommit(() -> taskExecutor.execute(() -> elasticsearchTemplate.delete(entity)));
     }
 }
 <%_ } _%>

--- a/generators/spring-boot/generators/data-elasticsearch/templates/src/main/java/_package_/util/TransactionUtils.java.ejs
+++ b/generators/spring-boot/generators/data-elasticsearch/templates/src/main/java/_package_/util/TransactionUtils.java.ejs
@@ -1,0 +1,50 @@
+<%#
+ Copyright 2013-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%- packageName %>.util;
+
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Utility class for transaction-aware side effects.
+ */
+public final class TransactionUtils {
+
+    private TransactionUtils() {}
+
+    /**
+     * Run the given action after the current transaction commits,
+     * or immediately if no transaction is active.
+     * If the transaction rolls back, the action is discarded.
+     */
+    public static void runAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        action.run();
+                    }
+                }
+            );
+        } else {
+            action.run();
+        }
+    }
+}

--- a/generators/spring-boot/templates/src/main/java/_package_/_entityPackage_/service/UserService.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/_entityPackage_/service/UserService.java.ejs
@@ -185,7 +185,7 @@ public class UserService {
                 userRepository.save(user);
       <%_ } _%>
       <%_ if (searchEngineElasticsearch) { _%>
-                userSearchRepository.save(user);
+                userSearchRepository.index(user);
       <%_ } _%>
       <%_ if (cacheProviderAny) { _%>
                 this.clearUserCaches(user);
@@ -377,7 +377,7 @@ public class UserService {
         newUser.setAuthorities(authorities);
         userRepository.save(newUser);
       <%_ if (searchEngineElasticsearch) { _%>
-        userSearchRepository.save(newUser);
+        userSearchRepository.index(newUser);
       <%_ } _%>
       <%_ if (cacheProviderAny) { _%>
         this.clearUserCaches(newUser);

--- a/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
+++ b/generators/spring-boot/templates/src/test/java/_package_/_entityPackage_/web/rest/_entityClass_ResourceIT.java.ejs
@@ -54,6 +54,11 @@ import static <%- packageName %>.web.rest.TestUtil.createUpdateProxyForBean;
     if (databaseTypeSql && !reactive) {
       transactionalAnnotation = '\n    @Transactional';
     }
+    let searchIndexingAnnotation = transactionalAnnotation;
+    if (searchEngineElasticsearch && databaseTypeSql && !reactive) {
+      // no @Transactional: the search index is only updated after the transaction commits
+      searchIndexingAnnotation = '';
+    }
 _%>
 <%_ if (entityAbsolutePackage !== packageName) { _%>
 import <%- packageName %>.web.rest.TestUtil;
@@ -663,7 +668,7 @@ class <%- entityClass %>ResourceIT {
     }
 <%_ if (!readOnly) { _%>
 
-    @Test<%- transactionalAnnotation %>
+    @Test<%- searchIndexingAnnotation %>
     void create<%- entityClass %>() throws Exception {
         long databaseSizeBeforeCreate = getRepositoryCount();
   <%_ if (searchEngineElasticsearch) { _%>
@@ -1463,7 +1468,7 @@ class <%- entityClass %>ResourceIT {
     }
 <%_ if (!readOnly && updatableEntity) { _%>
 
-    @Test<%- transactionalAnnotation %>
+    @Test<%- searchIndexingAnnotation %>
     void putExisting<%- entityClass %>() throws Exception {
         // Initialize the database
   <%_ if (!primaryKey.derived) { _%>
@@ -1819,7 +1824,7 @@ class <%- entityClass %>ResourceIT {
 <%_ } _%>
 <%_ if (!readOnly) { _%>
 
-    @Test<%- transactionalAnnotation %>
+    @Test<%- searchIndexingAnnotation %>
     void delete<%- entityClass %>() <%- reactive ? '' : 'throws Exception ' %>{
         // Initialize the database
   <%_ if (!primaryKey.derived) { _%>
@@ -1860,8 +1865,15 @@ class <%- entityClass %>ResourceIT {
   <%_ } _%>
         assertDecrementedRepositoryCount(databaseSizeBeforeDelete);
   <%_ if (searchEngineElasticsearch) { _%>
+    <%_ if (reactive) { _%>
         int searchDatabaseSizeAfter = IterableUtil.sizeOf(<%- entityInstance %>SearchRepository.findAll()<%- callListBlock %>);
         assertThat(searchDatabaseSizeAfter).isEqualTo(searchDatabaseSizeBefore-1);
+    <%_ } else { _%>
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            int searchDatabaseSizeAfter = IterableUtil.sizeOf(<%- entityInstance %>SearchRepository.findAll()<%- callListBlock %>);
+            assertThat(searchDatabaseSizeAfter).isEqualTo(searchDatabaseSizeBefore-1);
+        });
+    <%_ } _%>
   <%_ } _%>
 
     }


### PR DESCRIPTION
The generated `@Async index()` is dispatched while the service transaction is still open, so the async thread can re-read the entity before the commit and index stale or missing data. `UserService.registerUser` and `activateRegistration` even call `userSearchRepository.save()` synchronously inside the transaction, so an Elasticsearch outage fails user registration.

Changes:

- Add a `TransactionUtils.runAfterCommit()` helper and make the search repositories defer the indexing work to the task executor only after the surrounding transaction has committed. Fire and forget semantics and error logging are unchanged, and when no transaction is active the action is dispatched immediately, so non-transactional stores (MongoDB, Neo4j) behave as before.
- Align the two synchronous `userSearchRepository.save()` calls in `UserService` to the async `index()` used everywhere else. This also avoids the explicit index refresh that `SimpleElasticsearchRepository` performs on every call, which the [Elasticsearch docs](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-refresh) recommend against, as refreshes are resource-intensive.
- Entity resource ITs asserting Elasticsearch content after a create, update or delete no longer use `@Transactional`: a test-managed transaction always rolls back, so the after-commit callback would never fire. These tests already clean up in `@AfterEach` and do not rely on the rollback.
- The delete assertion is wrapped in awaitility, like the create and update assertions already were.

Reactive output is not affected.

Verified by regenerating and running the entity resource ITs of two sample apps against this branch: PostgreSQL + Elasticsearch (transactional path) and MongoDB + Elasticsearch (non-transactional path).

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [x] I have personally reviewed, understood, and tested the changes — including any AI-generated code
