### PR TITLE
chore: fix test slowness

### DIFF
--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -22,7 +22,6 @@ import { basename, extname, isAbsolute, join, join as joinPath, relative } from 
 import { relative as posixRelative } from 'node:path/posix';
 
 import { requireNamespace } from '@yeoman/namespace';
-import type { GeneratorMeta } from '@yeoman/types';
 import chalk from 'chalk';
 import latestVersion from 'latest-version';
 import { get, kebabCase, merge, mergeWith, set, snakeCase } from 'lodash-es';
@@ -178,7 +177,6 @@ export default class CoreGenerator<
   // Override the type of `env` to be a full Environment
   declare env: Environment;
   declare log: Logger;
-  declare _meta?: GeneratorMeta;
 
   constructor(args?: string[], options?: Options, features?: Features) {
     super(args, options, {

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -133,7 +133,7 @@ export default class BaseGenerator<
           if (this.blueprintConfig!.blueprintVersion) {
             this.getContextData(this.#getBlueprintOldVersionKey(), { factory: () => this.blueprintConfig!.blueprintVersion });
           }
-          const blueprintPackageJson = JSON.parse(readFileSync(this._meta!.packagePath!, 'utf8'));
+          const blueprintPackageJson = this._meta.getPackageJson!<PackageJson>()!;
           this.blueprintConfig!.blueprintVersion = blueprintPackageJson.version;
         } catch {
           this.log(`Could not retrieve version of blueprint '${this.options.namespace}'`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@yeoman/conflicter": "4.1.0",
         "@yeoman/namespace": "2.1.0",
         "@yeoman/transform": "2.1.2",
-        "@yeoman/types": "1.11.1",
+        "@yeoman/types": "1.12.1",
         "chalk": "6.0.0",
         "chevrotain": "13.2.0",
         "commander": "15.0.0",
@@ -59,8 +59,8 @@
         "typescript": "6.0.3",
         "typescript-eslint": "8.67.0",
         "yaml": "2.9.0",
-        "yeoman-environment": "6.1.0",
-        "yeoman-generator": "8.2.2"
+        "yeoman-environment": "6.2.0",
+        "yeoman-generator": "8.3.0"
       },
       "bin": {
         "jhipster": "dist/cli/jhipster.cjs"
@@ -3859,9 +3859,9 @@
       }
     },
     "node_modules/@yeoman/types": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@yeoman/types/-/types-1.11.1.tgz",
-      "integrity": "sha512-27CI5hHQAHfq8ohYILmLNzClbdzBJzu+ny9AzUVV6naJO0l4/+t+67QDKlwQvt+TW3oE5j74I/Mh4Kn14rsVXA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@yeoman/types/-/types-1.12.1.tgz",
+      "integrity": "sha512-zG9JQiz/1XqDZMCK40ThHNoe40tnFAUKGzNB22CMEugHVi+jG6eGhNBBl+05LZb6QnMj5vvGPvK3HOi0uz2w2Q==",
       "license": "MIT",
       "engines": {
         "node": "^16.13.0 || >=18.12.0"
@@ -10936,16 +10936,19 @@
       }
     },
     "node_modules/yeoman-environment": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-6.1.0.tgz",
-      "integrity": "sha512-QSKMfrSx3js9fxbMDBa+sZG0ctF0NDxcO6VA5BnrWdo6wqhdalT2IUU/ZrNakQLZQ76E3B6b0lXHKEA7ivsWxA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-6.2.0.tgz",
+      "integrity": "sha512-n4V0tM8zKKMldJvdqOA54SGcO3Al5N1ISUuDI5QmE5Li5NdH8VJr2wafjaPr+qe/ID1ZjnY99vQNkmF3JVd/qA==",
       "license": "BSD-2-Clause",
+      "workspaces": [
+        "test/generators"
+      ],
       "dependencies": {
         "@yeoman/adapter": "^4.0.2",
         "@yeoman/conflicter": "^4.1.0",
         "@yeoman/namespace": "^2.1.0",
         "@yeoman/transform": "^2.1.1",
-        "@yeoman/types": "^1.11.0",
+        "@yeoman/types": "^1.11.1",
         "arrify": "^3.0.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
@@ -11083,9 +11086,9 @@
       }
     },
     "node_modules/yeoman-generator": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-8.2.2.tgz",
-      "integrity": "sha512-GIvRULf09VrTyJ1nMIxCRFTI8gzW9zsAxVXTHOmsWVKZ7QYPdByRQvFtnp0XOObM6dvDSoAwBhuYR6i5inp/ig==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-8.3.0.tgz",
+      "integrity": "sha512-stpxbDj2KQj4CysTd15z51uMJmfXdTzvlQ9TSMwZxVaN5NJ6a0zWMX84GNx+bEhntZs6FoFS5Hnkdck4NRyu1g==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/debug": "^4.1.13",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@yeoman/conflicter": "4.1.0",
     "@yeoman/namespace": "2.1.0",
     "@yeoman/transform": "2.1.2",
-    "@yeoman/types": "1.11.1",
+    "@yeoman/types": "1.12.1",
     "chalk": "6.0.0",
     "chevrotain": "13.2.0",
     "commander": "15.0.0",
@@ -174,8 +174,8 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.67.0",
     "yaml": "2.9.0",
-    "yeoman-environment": "6.1.0",
-    "yeoman-generator": "8.2.2"
+    "yeoman-environment": "6.2.0",
+    "yeoman-generator": "8.3.0"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "5.10.0",


### PR DESCRIPTION
Mocha tests speed has improved 35-40% on CI.
From almost 5min to ~3min.
Remaining npm test time is related to prettier and eslint.

Fixes https://github.com/jhipster/generator-jhipster/issues/34626
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
