### PR TITLE
react: improve user-management

### DIFF
--- a/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/react/templates/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -59,13 +59,20 @@ export const UserManagementUpdate = () => {
     } else {
       dispatch(updateUser(values));
     }
-    handleClose();
   };
 
   const user = useAppSelector(state => state.userManagement.user);
   const loading = useAppSelector(state => state.userManagement.loading);
   const updating = useAppSelector(state => state.userManagement.updating);
+  const updateSuccess = useAppSelector(state => state.userManagement.updateSuccess);
   const authorities = useAppSelector(state => state.userManagement.authorities);
+
+  // Navigate back only once the request has completed, otherwise a concurrent request may observe a stale state.
+  useEffect(() => {
+    if (updateSuccess) {
+      handleClose();
+    }
+  }, [updateSuccess]);
 
   return (
     <div>


### PR DESCRIPTION
Navigate back on updateSuccess via a useEffect, exactly the pattern the React entity update pages already use, instead of right after dispatch. Side benefit: a failed save no longer silently navigates away.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
