### PR TITLE
angular: esbuild plugins usable by native federation and vitest

### DIFF
--- a/generators/angular/templates/build-plugins/define-esbuild.ts.ejs
+++ b/generators/angular/templates/build-plugins/define-esbuild.ts.ejs
@@ -19,8 +19,6 @@
 import { copyFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 
-import type { ApplicationBuilderOptions } from '@angular/build';
-import type { Target } from '@angular-devkit/architect';
 import type { Plugin } from 'esbuild';
 import { globSync } from 'tinyglobby';
 
@@ -32,16 +30,18 @@ const copyFromPackage = (sourceDir: string, glob: string): void => {
   }
 };
 
-export default (builderOptions: ApplicationBuilderOptions, _target: Target): Plugin => {
-  mkdirSync(swaggerUiDir, { recursive: true });
-  copyFromPackage(path.join(path.dirname(require.resolve('axios/package.json')), 'dist'), 'axios.min.js');
-  copyFromPackage(require('swagger-ui-dist').getAbsoluteFSPath(), '{*.{png,css},swagger-ui-{bundle,standalone-preset}.js}');
+export default {
+  name: 'define:vars',
+  setup(build) {
+    mkdirSync(swaggerUiDir, { recursive: true });
+    copyFromPackage(path.join(path.dirname(require.resolve('axios/package.json')), 'dist'), 'axios.min.js');
+    copyFromPackage(require('swagger-ui-dist').getAbsoluteFSPath(), '{*.{png,css},swagger-ui-{bundle,standalone-preset}.js}');
 
-  builderOptions.define ??= {};
-  builderOptions.define.__VERSION__ = JSON.stringify(process.env.APP_VERSION ?? 'unknown');
-
-  return {
-    name: 'define:vars',
-    setup(_build) {},
-  };
-};
+    build.initialOptions.define ??= {};
+    build.initialOptions.define.__VERSION__ = JSON.stringify(process.env.APP_VERSION ?? 'unknown');
+    // If this URL is left empty (""), then it will be relative to the current context.
+    // If you use an API server, in `prod` mode, you will need to enable CORS
+    // (see the `jhipster.cors` common JHipster property in the `application-*.yml` configurations)
+    build.initialOptions.define.SERVER_API_URL = "''";
+  },
+} satisfies Plugin;

--- a/generators/angular/templates/src/main/webapp/app/shared/date/duration.pipe.ts.ejs
+++ b/generators/angular/templates/src/main/webapp/app/shared/date/duration.pipe.ts.ejs
@@ -19,6 +19,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 import dayjs from 'dayjs/esm';
+// Plugins are registered in app/config/dayjs, the type augmentations are required when the pipe is built standalone.
+import 'dayjs/esm/plugin/duration';
+import 'dayjs/esm/plugin/relativeTime';
 
 @Pipe({
   name: 'duration',

--- a/generators/angular/templates/vitest-base.config.ts.ejs
+++ b/generators/angular/templates/vitest-base.config.ts.ejs
@@ -19,8 +19,32 @@
 // Learn more about Vitest configuration options at https://vitest.dev/config/
 
 import { defineConfig } from 'vitest/config';
+<%_ if (clientBundlerEsbuild && enableTranslation) { _%>
+
+import { prepareLanguage } from './build-plugins/i18n-esbuild';
+
+const i18nPrefix = '\0i18n/';
+<%_ } _%>
 
 export default defineConfig({
+<%_ if (clientBundlerEsbuild && enableTranslation) { _%>
+  plugins: [
+    {
+      // Resolve the `i18n/<lang>.json` translation bundles provided by build-plugins/i18n-esbuild.ts at build time.
+      name: 'jhipster:i18n',
+      resolveId(id) {
+        return /^i18n\/[^/]+\.json$/.test(id) ? `${i18nPrefix}${id.slice('i18n/'.length)}` : undefined;
+      },
+      async load(id) {
+        if (id.startsWith(i18nPrefix)) {
+          const language = id.slice(i18nPrefix.length, -'.json'.length);
+          return `export default ${JSON.stringify(await prepareLanguage(language))};`;
+        }
+        return undefined;
+      },
+    },
+  ],
+<%_ } _%>
   test: {
     coverage: {
       reportsDirectory: '<%- temporaryDir %>test-results',


### PR DESCRIPTION
- define-esbuild is a plain esbuild plugin defining __VERSION__ and SERVER_API_URL, so it can be injected in builders other than @angular-builders/custom-esbuild
- vitest resolves the i18n bundles provided by the i18n esbuild plugin
- duration pipe imports the dayjs plugin types it relies on, allowing to build app/shared/date standalone

Related to https://github.com/jhipster/generator-jhipster/issues/34669

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
