### PR TITLE
spring-boot: add ProcessBuilder log

### DIFF
--- a/generators/spring-boot/generator.ts
+++ b/generators/spring-boot/generator.ts
@@ -798,6 +798,7 @@ ${application.jhipsterDependenciesVersion?.includes('-CICD') ? '' : '// '}mavenL
         if (!application.dockerServices?.length) return;
 
         source.addMainLog!({ name: 'org.springframework.boot.docker', level: 'WARN' });
+        source.addMainLog!({ name: 'java.lang.ProcessBuilder', level: 'INFO' });
 
         const dockerComposeArtifact = { groupId: 'org.springframework.boot', artifactId: 'spring-boot-docker-compose' };
         if (application.buildToolGradle) {


### PR DESCRIPTION
Silence the JDK `ProcessBuilder` debug logging in applications that use `spring-boot-docker-compose`.

Since JDK 24, `ProcessBuilder.start()` logs every spawned process through the `java.lang.ProcessBuilder` system logger at `DEBUG`, with the pid, working directory, command and a stack trace. The dev profile sets `logging.level.ROOT: DEBUG` and Spring Boot bridges the JDK logger into Logback, so each `docker compose` command run by `spring-boot-docker-compose` (it keeps polling `docker compose ps` while the containers start) prints a multi-line block with a stack trace during application startup.

This adds a `java.lang.ProcessBuilder` logger at `INFO` to `logback-spring.xml`, next to the existing `org.springframework.boot.docker` entry, only for applications with docker services. The JDK default is unchanged everywhere else, and tests are unaffected since they run with root logging off and use Testcontainers through the Docker API.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
