### PR TITLE
Angular: fix titles for entity routes

### DIFF
--- a/generators/angular/needles.spec.ts
+++ b/generators/angular/needles.spec.ts
@@ -74,7 +74,7 @@ describe('needle API Angular generator : JHipster with blueprint', () => {
       `${CLIENT_MAIN_SRC_DIR}app/entities/entity.routes.ts`,
       '  {\n' +
         "    path: 'entityUrl',\n" +
-        "    data: { pageTitle: 'entity.home.title' },\n" +
+        "    title: 'entity.home.title',\n" +
         "    loadChildren: () => import('./entityFolderName/entityFileName.routes'),\n" +
         '  }',
     );

--- a/generators/angular/support/needles.ts
+++ b/generators/angular/support/needles.ts
@@ -66,14 +66,14 @@ export function addEntitiesRoute<const E extends ClientEntity, const A extends C
     ...entities.map(entity => {
       const { i18nKeyPrefix, entityNamePlural, entityFolderName, entityFileName, entityUrl } = entity;
 
-      const pageTitle = enableTranslation ? `${i18nKeyPrefix}.home.title` : entityNamePlural;
+      const title = enableTranslation ? `${i18nKeyPrefix}.home.title` : entityNamePlural;
       const modulePath = `./${entityFolderName}/${entityFileName}.routes`;
 
       return addRoute({
         needle: 'jhipster-needle-add-entity-route',
         route: entityUrl,
         modulePath,
-        pageTitle,
+        title,
       });
     }),
   );


### PR DESCRIPTION
Before
<img width="475" height="455" alt="image" src="https://github.com/user-attachments/assets/84566cea-3e9d-417c-9dc6-b7f8c3a423ab" />



After
<img width="523" height="443" alt="image" src="https://github.com/user-attachments/assets/2d77d482-3342-4ae9-8be5-d576bba10ed3" />
