### PR TITLE
internal: Attach per-file editorMetadata to written files and use it at the bootstrap commit pipeline, so the bootstrap generator no longer depends on the project configuration

### DIFF
--- a/generators/base-core/api.d.ts
+++ b/generators/base-core/api.d.ts
@@ -4,6 +4,17 @@ export type EditFileCallback<Generator = CoreGenerator> = (this: Generator, cont
 
 export type EditFileOptions = { create?: boolean; ignoreNonExisting?: boolean | string; assertModified?: boolean; autoCrlf?: boolean };
 
+/**
+ * Metadata attached to the files written through the generator write helpers.
+ * Available as `file.editorMetadata` to the `jhipster:bootstrap` commit transforms.
+ */
+export type EditorMetadata = {
+  /** Git repository root of the project the file belongs to, used to look up git attributes. */
+  gitRoot?: string;
+  /** Remove the `jhipster-needle-` lines from the file when committing. */
+  removeNeedles?: boolean;
+};
+
 export type CascadedEditFileCallback<Generator = CoreGenerator> = (
   ...callbacks: EditFileCallback<Generator>[]
 ) => CascadedEditFileCallback<Generator>;

--- a/generators/base-core/generator.ts
+++ b/generators/base-core/generator.ts
@@ -70,6 +70,7 @@ import type {
   CascadedEditFileCallback,
   EditFileCallback,
   EditFileOptions,
+  EditorMetadata,
   ValidationResult,
   WriteContext,
   WriteFileOptions,
@@ -77,7 +78,7 @@ import type {
 import { convertWriteFileSectionsToBlocks, loadConfig } from './internal/index.ts';
 import { createJHipster7Context } from './internal/jhipster7-context.ts';
 import { CUSTOM_PRIORITIES, PRIORITY_NAMES, PRIORITY_PREFIX, QUEUES } from './priorities.ts';
-import { type NeedleInsertion, createNeedleCallback, joinCallbacks } from './support/index.ts';
+import { CONTEXT_DATA_GIT_ROOT_KEY, type NeedleInsertion, createNeedleCallback, joinCallbacks } from './support/index.ts';
 import type { Config as CoreConfig, Features as CoreFeatures, GenericTask, Options as CoreOptions } from './types.ts';
 
 const {
@@ -237,6 +238,21 @@ export default class CoreGenerator<
    */
   usage(): string {
     return super.usage().replace('yo jhipster:', 'jhipster ');
+  }
+
+  /**
+   * Metadata attached by yeoman-generator to the files written through the write helpers (`writeFiles`, `editFile`,
+   * `writeDestination`, `renderTemplate`, `copyTemplate`, ...), available as `file.editorMetadata` to the
+   * `jhipster:bootstrap` commit transforms. Generators that are not bound to a project (`uniqueGlobally` feature)
+   * attach no metadata. `gitRoot` is the directory where the `jhipster:git` generator of the current context
+   * initializes the repository, if any.
+   */
+  override get editorMetadata(): EditorMetadata | undefined {
+    if (this.features.uniqueGlobally) {
+      return undefined;
+    }
+    const gitRoot = this.getContextData<string | undefined>(CONTEXT_DATA_GIT_ROOT_KEY, { factory: () => undefined });
+    return gitRoot ? { gitRoot } : {};
   }
 
   /**

--- a/generators/base-core/support/constants.ts
+++ b/generators/base-core/support/constants.ts
@@ -16,9 +16,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './constants.ts';
-export * from './needles.ts';
-// TODO Backwards compatibility, to be removed in v10
-export * from '../../../lib/utils/os.ts';
-export * from './properties-file.ts';
-export * from './write-files.ts';
+/** Context data key holding the directory where the `jhipster:git` generator initializes the repository. */
+export const CONTEXT_DATA_GIT_ROOT_KEY = 'jhipster:git:root';

--- a/generators/base-core/support/needles.ts
+++ b/generators/base-core/support/needles.ts
@@ -397,7 +397,11 @@ export function createBaseNeedle<Generator extends CoreGenerator = CoreGenerator
   return callback;
 }
 
-export const createNeedleTransform = () =>
+/**
+ * Transform that removes needles from file contents.
+ * Files not matching the `filter` are passed through untouched.
+ */
+export const createNeedleTransform = (options?: { filter?: (file: MemFsEditorFile) => boolean }) =>
   transformContents<MemFsEditorFile>(content => {
     if (content) {
       let contentAsString = content.toString();
@@ -410,4 +414,4 @@ export const createNeedleTransform = () =>
       }
     }
     return content;
-  });
+  }, options);

--- a/generators/base-simple-application/generators/bootstrap/generator.ts
+++ b/generators/base-simple-application/generators/bootstrap/generator.ts
@@ -70,14 +70,6 @@ export default class BaseSimpleApplicationBootstrapGenerator extends BaseSimpleA
 
   get preparing() {
     return this.asPreparingTaskGroup({
-      async removeNeedles({ application }) {
-        if (application.removeNeedles) {
-          // This sets the bootstrap generator's removeNeedles flag to true so it removes needles from generated files.
-          // Needles will be removed from every generated file. To apply this to generated project files only, we need https://github.com/SBoudrias/mem-fs/issues/67.
-          const bootstrapGenerator = await this.dependsOnJHipster('bootstrap');
-          bootstrapGenerator.removeNeedles = true;
-        }
-      },
       preparing({ applicationDefaults }) {
         if (this.useVersionPlaceholders) {
           applicationDefaults({

--- a/generators/base/generator.spec.ts
+++ b/generators/base/generator.spec.ts
@@ -204,4 +204,41 @@ describe(`generator - ${generator}`, () => {
       });
     });
   });
+
+  describe('editorMetadata', () => {
+    class WritingGenerator extends BaseGenerator {
+      get [BaseGenerator.WRITING]() {
+        return this.asWritingTaskGroup({
+          write() {
+            this.writeDestination('written.txt', 'content');
+            this.editFile('edited.txt', { create: true }, () => 'content');
+          },
+        });
+      }
+    }
+
+    const editorMetadataOf = (file: string) => result.memFs.get(result.generator.destinationPath(file)).editorMetadata;
+
+    describe('by default', () => {
+      before(async () => {
+        await helpers.run(WritingGenerator).withJHipsterGenerators({ useDefaultMocks: true });
+      });
+
+      it('should attach empty metadata to written files', () => {
+        expect(editorMetadataOf('written.txt')).toEqual({});
+        expect(editorMetadataOf('edited.txt')).toEqual({});
+      });
+    });
+
+    describe('with removeNeedles config', () => {
+      before(async () => {
+        await helpers.run(WritingGenerator).withJHipsterConfig({ removeNeedles: true }).withJHipsterGenerators({ useDefaultMocks: true });
+      });
+
+      it('should attach removeNeedles to written files', () => {
+        expect(editorMetadataOf('written.txt')).toEqual({ removeNeedles: true });
+        expect(editorMetadataOf('edited.txt')).toEqual({ removeNeedles: true });
+      });
+    });
+  });
 });

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -173,7 +173,7 @@ export default class BaseGenerator<
    */
   get editorMetadata(): EditorMetadata | undefined {
     const editorMetadata = super.editorMetadata;
-    return editorMetadata && this.jhipsterConfig?.removeNeedles ? { ...editorMetadata, removeNeedles: true } : editorMetadata;
+    return this.jhipsterConfig?.removeNeedles ? { ...editorMetadata, removeNeedles: true } : editorMetadata;
   }
 
   get #control(): Control {

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -30,6 +30,7 @@ import type { PackageJson } from 'type-fest';
 import type { ExportGeneratorOptionsFromCommand, ExportStoragePropertiesFromCommand, ParsableCommand } from '../../lib/command/types.ts';
 import { packageJson } from '../../lib/index.ts';
 import { packageNameToNamespace } from '../../lib/utils/index.ts';
+import type { EditorMetadata } from '../base-core/api.ts';
 import CoreGenerator from '../base-core/index.ts';
 import { PRIORITY_NAMES } from '../base-core/priorities.ts';
 import type { GenericTask } from '../base-core/types.ts';
@@ -165,6 +166,14 @@ export default class BaseGenerator<
    */
   delegateTasksToBlueprint<TaskGroupType>(tasksGetter: () => TaskGroupType): TaskGroupType {
     return this.delegateToBlueprint ? ({} as TaskGroupType) : tasksGetter();
+  }
+
+  /**
+   * Adds the `removeNeedles` project configuration to the written files metadata.
+   */
+  get editorMetadata(): EditorMetadata | undefined {
+    const editorMetadata = super.editorMetadata;
+    return editorMetadata && this.jhipsterConfig?.removeNeedles ? { ...editorMetadata, removeNeedles: true } : editorMetadata;
   }
 
   get #control(): Control {

--- a/generators/bootstrap/generator.spec.ts
+++ b/generators/bootstrap/generator.spec.ts
@@ -16,14 +16,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, expect } from 'esmocha';
+import { before, describe, expect, it } from 'esmocha';
 import { basename } from 'node:path';
 
 import { shouldSupportFeatures } from '../../test/support/tests.ts';
+import BaseGenerator from '../base/index.ts';
 
 import Generator from './index.ts';
 
-import { defaultHelpers as helpers } from '#testing';
+import { defaultHelpers as helpers, result } from '#testing';
 
 const generator = basename(import.meta.dirname);
 
@@ -45,6 +46,40 @@ describe(`generator - ${generator}`, () => {
       expect(() => bootstrapGenerator.jhipsterConfigWithDefaults).toThrow(
         'jhipsterConfigWithDefaults is not available in uniqueGlobally generators',
       );
+    });
+  });
+
+  describe('removeNeedles', () => {
+    const content = 'first\n// jhipster-needle-add-content - JHipster will add content here\nlast\n';
+
+    class NeedleGenerator extends BaseGenerator {
+      get [BaseGenerator.WRITING]() {
+        return this.asWritingTaskGroup({
+          write() {
+            this.writeDestination('file.txt', content);
+          },
+        });
+      }
+    }
+
+    describe('with removeNeedles config', () => {
+      before(async () => {
+        await helpers.run(NeedleGenerator).withJHipsterConfig({ removeNeedles: true }).withJHipsterGenerators();
+      });
+
+      it('should remove needles from the committed file', () => {
+        result.assertEqualsFileContent('file.txt', 'first\nlast\n');
+      });
+    });
+
+    describe('without removeNeedles config', () => {
+      before(async () => {
+        await helpers.run(NeedleGenerator).withJHipsterGenerators();
+      });
+
+      it('should keep needles', () => {
+        result.assertEqualsFileContent('file.txt', content);
+      });
     });
   });
 });

--- a/generators/bootstrap/generator.ts
+++ b/generators/bootstrap/generator.ts
@@ -64,10 +64,6 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   prettierJava = false;
   prettierOptions: PrettierOptions = { plugins: [] };
   refreshOnCommit = false;
-  // TODO: This feature is project-specific; it depends on https://github.com/SBoudrias/mem-fs/issues/67 being implemented so we can add a transform to remove needles based on file metadata.
-  // Metadata should be set on the writeFiles API based on the application.removeNeedles config.
-  /** @experimental This should be dropped if a meta-based transform is implemented */
-  removeNeedles = false;
 
   constructor(args?: string[], options?: BaseOptions, features?: BaseFeatures) {
     super(args, options, { uniqueGlobally: true, customCommitTask: () => this.commitTask(), ...features });
@@ -183,7 +179,7 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
     { log, ...options }: PipelineOptions<MemFsEditorFile> & { log?: string } = {},
     ...transforms: FileTransform<MemFsEditorFile>[]
   ) {
-    const { autoCrlf = isWin32, devBlueprintEnabled, removeNeedles, skipYoResolve } = this.options;
+    const { autoCrlf = isWin32, devBlueprintEnabled, skipYoResolve } = this.options;
     const pipelineOptions: GeneratorPipelineOptions = {
       refresh: false,
       // Let pending files pass through.
@@ -230,11 +226,13 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
         transformStreams.push(createYoResolveTransform());
       }
 
-      transformStreams.push(forceYoFiles(), createSortConfigFilesTransform(), createForceWriteConfigFilesTransform());
-
-      if (removeNeedles) {
-        transformStreams.push(createNeedleTransform());
-      }
+      transformStreams.push(
+        forceYoFiles(),
+        createSortConfigFilesTransform(),
+        createForceWriteConfigFilesTransform(),
+        // Needles are removed from the files whose project enabled `removeNeedles`, see `editorMetadata` at base-core.
+        createNeedleTransform({ filter: file => Boolean(file.editorMetadata?.removeNeedles) }),
+      );
 
       if (!this.skipPrettier) {
         const ignoreErrors = this.options.ignoreErrors || this.upgradeCommand;

--- a/generators/bootstrap/support/auto-crlf-transform.spec.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.spec.ts
@@ -18,7 +18,7 @@
  */
 
 import { after, before, describe, expect, it } from 'esmocha';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { Readable } from 'node:stream';
@@ -167,6 +167,20 @@ describe('generator - bootstrap - utils', () => {
 
       it('should fall back to content detection even inside a git repository', async () => {
         await expect(runAutoCrlfTransform(repoDir, filePaths)).resolves.toEqual(fallback);
+      });
+
+      it('should keep the line endings of existing files', async () => {
+        await writeFile(join(repoDir, 'existing-lf.txt'), 'a\nb\n');
+        await writeFile(join(repoDir, 'existing-crlf.txt'), 'a\r\nb\r\n');
+        await writeFile(join(repoDir, 'existing-single-line.txt'), 'a');
+        await expect(
+          runAutoCrlfTransform(repoDir, ['existing-lf.txt', 'existing-crlf.txt', 'existing-single-line.txt', 'new.txt']),
+        ).resolves.toEqual({
+          'existing-lf.txt': 'line1\nline2\n',
+          'existing-crlf.txt': 'line1\r\nline2\r\n',
+          'existing-single-line.txt': 'line1\r\nline2\r\n',
+          'new.txt': 'line1\r\nline2\r\n',
+        });
       });
     });
   });

--- a/generators/bootstrap/support/auto-crlf-transform.spec.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.spec.ts
@@ -33,7 +33,13 @@ import { defaultHelpers as helpers } from '#testing';
 const gitAttributes = `* text=auto
 *.bat text eol=crlf
 *.sh text eol=lf
+*.noeol -eol
+*.nobinary -binary
+*.native eol=native
+*.bin binary
 `;
+
+const binaryContents = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0a, 0x00, 0x1a, 0x0a, 0x00]);
 
 const runAutoCrlfTransform = async (
   baseDir: string,
@@ -42,7 +48,7 @@ const runAutoCrlfTransform = async (
 ): Promise<Record<string, string>> => {
   const files = filePaths.map(filePath => ({
     path: join(baseDir, filePath),
-    contents: Buffer.from('line1\nline2\n'),
+    contents: filePath.endsWith('.png') ? binaryContents : Buffer.from('line1\nline2\n'),
     state: 'modified',
     editorMetadata,
   })) as unknown as MemFsEditorFile[];
@@ -86,45 +92,28 @@ describe('generator - bootstrap - utils', () => {
   });
 
   describe('::autoCrlfTransform', () => {
-    const filePaths = ['file.txt', 'file.sh', 'file.bat', 'nested/file.txt', 'nested/file.sh'];
+    const filePaths = [
+      'file.txt',
+      'file.sh',
+      'file.bat',
+      'nested/file.txt',
+      'nested/file.sh',
+      'file.noeol',
+      'file.nobinary',
+      'file.native',
+      'file.bin',
+      'colon: file.txt',
+      'image.png',
+    ];
+    // Without attributes every text file gets CRLF, binary contents are detected and left untouched.
+    const fallback = Object.fromEntries(
+      filePaths.map(filePath => [filePath, filePath.endsWith('.png') ? binaryContents.toString() : 'line1\r\nline2\r\n']),
+    );
 
     const prepareBaseDir = async (): Promise<string> => {
       const result = await helpers.prepareTemporaryDir().withFiles({ '.gitattributes': gitAttributes }).commitFiles();
       return result.cwd;
     };
-
-    describe('inside a git repository', () => {
-      let baseDir: string;
-
-      before(async () => {
-        baseDir = await prepareBaseDir();
-        await simpleGit({ baseDir }).init();
-      });
-
-      it('should normalize line endings using gitattributes', async () => {
-        await expect(runAutoCrlfTransform(baseDir, filePaths)).resolves.toMatchObject({
-          'file.txt': 'line1\r\nline2\r\n',
-          'file.sh': 'line1\nline2\n',
-          'file.bat': 'line1\r\nline2\r\n',
-          'nested/file.txt': 'line1\r\nline2\r\n',
-          'nested/file.sh': 'line1\nline2\n',
-        });
-      });
-    });
-
-    describe('outside a git repository', () => {
-      let baseDir: string;
-
-      before(async () => {
-        baseDir = await prepareBaseDir();
-      });
-
-      it('should leave files untouched instead of throwing', async () => {
-        await expect(runAutoCrlfTransform(baseDir, filePaths)).resolves.toMatchObject(
-          Object.fromEntries(filePaths.map(filePath => [filePath, 'line1\nline2\n'])),
-        );
-      });
-    });
 
     describe('with gitRoot metadata', () => {
       let repoDir: string;
@@ -141,25 +130,43 @@ describe('generator - bootstrap - utils', () => {
         await rm(plainDir, { recursive: true, force: true });
       });
 
-      it('should look up attributes from the git root', async () => {
-        await expect(runAutoCrlfTransform(repoDir, filePaths, { gitRoot: repoDir })).resolves.toMatchObject({
+      it('should normalize line endings using the gitattributes of the git root', async () => {
+        await expect(runAutoCrlfTransform(repoDir, filePaths, { gitRoot: repoDir })).resolves.toEqual({
           'file.txt': 'line1\r\nline2\r\n',
           'file.sh': 'line1\nline2\n',
+          'file.bat': 'line1\r\nline2\r\n',
           'nested/file.txt': 'line1\r\nline2\r\n',
           'nested/file.sh': 'line1\nline2\n',
+          // unset, native and paths containing `: ` are treated as unspecified
+          'file.noeol': 'line1\r\nline2\r\n',
+          'file.nobinary': 'line1\r\nline2\r\n',
+          'file.native': 'line1\r\nline2\r\n',
+          'colon: file.txt': 'line1\r\nline2\r\n',
+          // binary files are left untouched
+          'file.bin': 'line1\nline2\n',
+          'image.png': binaryContents.toString(),
         });
       });
 
-      it('should leave files untouched when the git root is not a git repository', async () => {
-        await expect(runAutoCrlfTransform(repoDir, filePaths, { gitRoot: plainDir })).resolves.toMatchObject(
-          Object.fromEntries(filePaths.map(filePath => [filePath, 'line1\nline2\n'])),
-        );
+      it('should fall back to content detection when the git root is not a git repository', async () => {
+        await expect(runAutoCrlfTransform(repoDir, filePaths, { gitRoot: plainDir })).resolves.toEqual(fallback);
       });
 
-      it('should fall back to the parent lookup when the git root does not exist', async () => {
-        await expect(runAutoCrlfTransform(repoDir, ['file.txt'], { gitRoot: join(repoDir, 'missing') })).resolves.toMatchObject({
-          'file.txt': 'line1\r\nline2\r\n',
-        });
+      it('should fall back to content detection when the git root does not exist', async () => {
+        await expect(runAutoCrlfTransform(repoDir, filePaths, { gitRoot: join(repoDir, 'missing') })).resolves.toEqual(fallback);
+      });
+    });
+
+    describe('without gitRoot metadata', () => {
+      let repoDir: string;
+
+      before(async () => {
+        repoDir = await prepareBaseDir();
+        await simpleGit({ baseDir: repoDir }).init();
+      });
+
+      it('should fall back to content detection even inside a git repository', async () => {
+        await expect(runAutoCrlfTransform(repoDir, filePaths)).resolves.toEqual(fallback);
       });
     });
   });

--- a/generators/bootstrap/support/auto-crlf-transform.spec.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.spec.ts
@@ -17,7 +17,9 @@
  * limitations under the License.
  */
 
-import { before, describe, expect, it } from 'esmocha';
+import { after, before, describe, expect, it } from 'esmocha';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { Readable } from 'node:stream';
 
@@ -33,11 +35,16 @@ const gitAttributes = `* text=auto
 *.sh text eol=lf
 `;
 
-const runAutoCrlfTransform = async (baseDir: string, filePaths: string[]): Promise<Record<string, string>> => {
+const runAutoCrlfTransform = async (
+  baseDir: string,
+  filePaths: string[],
+  editorMetadata?: Record<string, unknown>,
+): Promise<Record<string, string>> => {
   const files = filePaths.map(filePath => ({
     path: join(baseDir, filePath),
     contents: Buffer.from('line1\nline2\n'),
     state: 'modified',
+    editorMetadata,
   })) as unknown as MemFsEditorFile[];
 
   const contents: Record<string, string> = {};
@@ -116,6 +123,43 @@ describe('generator - bootstrap - utils', () => {
         await expect(runAutoCrlfTransform(baseDir, filePaths)).resolves.toMatchObject(
           Object.fromEntries(filePaths.map(filePath => [filePath, 'line1\nline2\n'])),
         );
+      });
+    });
+
+    describe('with gitRoot metadata', () => {
+      let repoDir: string;
+      let plainDir: string;
+
+      before(async () => {
+        repoDir = await prepareBaseDir();
+        await simpleGit({ baseDir: repoDir }).init();
+        // Created outside the yeoman-test lifecycle: preparing another temporary dir would drop `repoDir`.
+        plainDir = await mkdtemp(join(tmpdir(), 'jhipster-auto-crlf-'));
+      });
+
+      after(async () => {
+        await rm(plainDir, { recursive: true, force: true });
+      });
+
+      it('should look up attributes from the git root', async () => {
+        await expect(runAutoCrlfTransform(repoDir, filePaths, { gitRoot: repoDir })).resolves.toMatchObject({
+          'file.txt': 'line1\r\nline2\r\n',
+          'file.sh': 'line1\nline2\n',
+          'nested/file.txt': 'line1\r\nline2\r\n',
+          'nested/file.sh': 'line1\nline2\n',
+        });
+      });
+
+      it('should leave files untouched when the git root is not a git repository', async () => {
+        await expect(runAutoCrlfTransform(repoDir, filePaths, { gitRoot: plainDir })).resolves.toMatchObject(
+          Object.fromEntries(filePaths.map(filePath => [filePath, 'line1\nline2\n'])),
+        );
+      });
+
+      it('should fall back to the parent lookup when the git root does not exist', async () => {
+        await expect(runAutoCrlfTransform(repoDir, ['file.txt'], { gitRoot: join(repoDir, 'missing') })).resolves.toMatchObject({
+          'file.txt': 'line1\r\nline2\r\n',
+        });
       });
     });
   });

--- a/generators/bootstrap/support/auto-crlf-transform.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.ts
@@ -17,48 +17,14 @@
  * limitations under the License.
  */
 import { createReadStream } from 'node:fs';
-import { stat } from 'node:fs/promises';
-import path from 'node:path';
 
 import { isBinaryFile } from 'isbinaryfile';
 import type { MemFsEditorFile } from 'mem-fs-editor';
 import { isFileStateModified } from 'mem-fs-editor/state';
 import { transform } from 'p-transform';
-import { type SimpleGit, simpleGit } from 'simple-git';
+import { simpleGit } from 'simple-git';
 
 import { CRLF, normalizeLineEndings } from '../../../lib/utils/index.ts';
-
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await stat(filePath);
-    return true;
-  } catch (error: any) {
-    if (error.code !== 'ENOENT') throw error;
-    return false;
-  }
-}
-
-async function findExistingParent(filePath: string): Promise<string> {
-  let currentPath = path.resolve(path.dirname(filePath));
-
-  while (currentPath) {
-    try {
-      await stat(currentPath);
-      return currentPath;
-    } catch (error: any) {
-      // Ignore error if directory doesn't exist, continue moving up
-      if (error.code !== 'ENOENT') throw error;
-    }
-
-    const parentPath = path.dirname(currentPath);
-    if (parentPath === currentPath) {
-      break;
-    }
-    currentPath = parentPath;
-  }
-
-  throw new Error(`No existing parent directory found for path: ${filePath}`);
-}
 
 /**
  * Detect the file first line endings
@@ -85,73 +51,50 @@ export function detectCrLf(filePath: string): Promise<boolean | undefined> {
 }
 
 const autoCrlfTransform = async (_config: { baseDir?: string } = {}) => {
-  // A git process is spawned for every lookup, cache the git instance by directory.
-  // Directories which are not inside a git repository are cached as undefined.
-  const gitCache = new Map<string, Promise<SimpleGit | undefined>>();
-  const getGit = (baseDir: string): Promise<SimpleGit | undefined> => {
-    let git = gitCache.get(baseDir);
-    if (!git) {
-      git = (async () => {
-        const git = simpleGit({ baseDir }).env({
-          HOME: process.env.HOME,
-          PATH: process.env.PATH,
-          LANG: 'C',
-          LC_ALL: 'C',
-        });
-        return (await git.checkIsRepo()) ? git : undefined;
-      })();
-      gitCache.set(baseDir, git);
-    }
-    return git;
-  };
-
   return transform(async (file: MemFsEditorFile) => {
     if (!isFileStateModified(file)) {
       return file;
     }
 
-    try {
-      const fstat = await stat(file.path);
-      if (fstat.isFile()) {
-        if (await isBinaryFile(file.contents!)) {
-          return file;
-        }
-      }
-    } catch {
-      // File doesn't exist.
-    }
-
-    // The generator that wrote the file knows the git root of its project, look up attributes from there.
-    // Files written without metadata fall back to the closest existing parent directory.
+    // The generator that wrote the file registered the repository root as `gitRoot` metadata, trust it.
     const { gitRoot } = file.editorMetadata ?? {};
-    const baseDir = typeof gitRoot === 'string' && (await pathExists(gitRoot)) ? gitRoot : await findExistingParent(file.path);
-    const git = await getGit(baseDir);
-    if (!git) {
-      // Attributes cannot be looked up outside a git repository. The repository is initialized at the post writing
-      // priority, `--skip-git` may be used, and the root folder of a workspaces application is never initialized.
-      return file;
-    }
+    const attrs = typeof gitRoot === 'string' ? await checkAttributes(gitRoot, file.path) : undefined;
 
-    const checkAttrs = await git.raw('check-attr', 'binary', 'eol', '--', file.path);
-    const attrs = Object.fromEntries(
-      checkAttrs
-        .split(/\r\n|\r|\n/)
-        .map(attr => attr.split(': '))
-        .map(([_file, attr, value]) => [attr, value]),
-    );
-    if (!['set', 'unspecified'].includes(attrs.binary)) {
-      throw new Error(`Unexpected value for binary attribute: ${attrs.binary}`);
-    }
-    if (!['lf', 'crlf', 'unspecified'].includes(attrs.eol)) {
-      throw new Error(`Unexpected value for eol attribute: ${attrs.eol}`);
-    }
+    // Only explicit attribute values drive the decision. `unset` (`-binary`, `-eol`), `unspecified`, `native` and
+    // anything unexpected are treated as unspecified: line endings are best effort and must not abort the commit.
+    // Without a repository to look up attributes from (Storage writes like `.yo-rc.json`, `--skip-git`, failed
+    // initialization) binary files are detected from their contents and text files get the default line endings.
+    const isBinary = attrs ? attrs.binary === 'set' : await isBinaryFile(file.contents!);
+    const eol = attrs?.eol;
 
-    if (attrs.eol === 'crlf' || (attrs.binary !== 'set' && attrs.eol !== 'lf')) {
+    if (eol === 'crlf' || (!isBinary && eol !== 'lf')) {
       file.contents = Buffer.from(normalizeLineEndings(file.contents!.toString(), CRLF));
     }
 
     return file;
   });
 };
+
+/**
+ * Look up the `binary` and `eol` git attributes of a file, undefined when git cannot answer.
+ */
+async function checkAttributes(gitRoot: string, filePath: string): Promise<Record<string, string> | undefined> {
+  let checkAttrs: string;
+  try {
+    // `-z` output is `<path>\0<attribute>\0<value>\0` triples, paths may contain `: `.
+    checkAttrs = await simpleGit({ baseDir: gitRoot })
+      .env({ HOME: process.env.HOME, PATH: process.env.PATH, LANG: 'C', LC_ALL: 'C' })
+      .raw('check-attr', '-z', 'binary', 'eol', '--', filePath);
+  } catch {
+    // Not a repository (initialization failed), missing directory or git cannot be executed.
+    return undefined;
+  }
+  const fields = checkAttrs.split('\0');
+  const attrs: Record<string, string> = {};
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    attrs[fields[index + 1]] = fields[index + 2];
+  }
+  return attrs;
+}
 
 export default autoCrlfTransform;

--- a/generators/bootstrap/support/auto-crlf-transform.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.ts
@@ -28,6 +28,16 @@ import { type SimpleGit, simpleGit } from 'simple-git';
 
 import { CRLF, normalizeLineEndings } from '../../../lib/utils/index.ts';
 
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error: any) {
+    if (error.code !== 'ENOENT') throw error;
+    return false;
+  }
+}
+
 async function findExistingParent(filePath: string): Promise<string> {
   let currentPath = path.resolve(path.dirname(filePath));
 
@@ -111,7 +121,10 @@ const autoCrlfTransform = async (_config: { baseDir?: string } = {}) => {
       // File doesn't exist.
     }
 
-    const baseDir = await findExistingParent(file.path);
+    // The generator that wrote the file knows the git root of its project, look up attributes from there.
+    // Files written without metadata fall back to the closest existing parent directory.
+    const { gitRoot } = file.editorMetadata ?? {};
+    const baseDir = typeof gitRoot === 'string' && (await pathExists(gitRoot)) ? gitRoot : await findExistingParent(file.path);
     const git = await getGit(baseDir);
     if (!git) {
       // Attributes cannot be looked up outside a git repository. The repository is initialized at the post writing

--- a/generators/bootstrap/support/auto-crlf-transform.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.ts
@@ -60,14 +60,21 @@ const autoCrlfTransform = async (_config: { baseDir?: string } = {}) => {
     const { gitRoot } = file.editorMetadata ?? {};
     const attrs = typeof gitRoot === 'string' ? await checkAttributes(gitRoot, file.path) : undefined;
 
-    // Only explicit attribute values drive the decision. `unset` (`-binary`, `-eol`), `unspecified`, `native` and
-    // anything unexpected are treated as unspecified: line endings are best effort and must not abort the commit.
-    // Without a repository to look up attributes from (Storage writes like `.yo-rc.json`, `--skip-git`, failed
-    // initialization) binary files are detected from their contents and text files get the default line endings.
-    const isBinary = attrs ? attrs.binary === 'set' : await isBinaryFile(file.contents!);
-    const eol = attrs?.eol;
+    let useCrlf: boolean;
+    if (attrs) {
+      // Only explicit attribute values drive the decision. `unset` (`-binary`, `-eol`), `unspecified`, `native` and
+      // anything unexpected are treated as unspecified: line endings are best effort and must not abort the commit.
+      const isBinary = attrs.binary === 'set';
+      useCrlf = attrs.eol === 'crlf' || (!isBinary && attrs.eol !== 'lf');
+    } else {
+      // Without a repository to look up attributes from (Storage writes like `.yo-rc.json`, `--skip-git`, failed
+      // initialization) binary files are detected from their contents, text files keep the line endings of the
+      // existing file on disk and new files get the default line endings.
+      const isBinary = await isBinaryFile(file.contents!);
+      useCrlf = !isBinary && ((await detectCrLf(file.path).catch(() => undefined)) ?? true);
+    }
 
-    if (eol === 'crlf' || (!isBinary && eol !== 'lf')) {
+    if (useCrlf) {
       file.contents = Buffer.from(normalizeLineEndings(file.contents!.toString(), CRLF));
     }
 

--- a/generators/bootstrap/support/auto-crlf-transform.ts
+++ b/generators/bootstrap/support/auto-crlf-transform.ts
@@ -60,19 +60,16 @@ const autoCrlfTransform = async (_config: { baseDir?: string } = {}) => {
     const { gitRoot } = file.editorMetadata ?? {};
     const attrs = typeof gitRoot === 'string' ? await checkAttributes(gitRoot, file.path) : undefined;
 
-    let useCrlf: boolean;
-    if (attrs) {
-      // Only explicit attribute values drive the decision. `unset` (`-binary`, `-eol`), `unspecified`, `native` and
-      // anything unexpected are treated as unspecified: line endings are best effort and must not abort the commit.
-      const isBinary = attrs.binary === 'set';
-      useCrlf = attrs.eol === 'crlf' || (!isBinary && attrs.eol !== 'lf');
-    } else {
-      // Without a repository to look up attributes from (Storage writes like `.yo-rc.json`, `--skip-git`, failed
-      // initialization) binary files are detected from their contents, text files keep the line endings of the
-      // existing file on disk and new files get the default line endings.
-      const isBinary = await isBinaryFile(file.contents!);
-      useCrlf = !isBinary && ((await detectCrLf(file.path).catch(() => undefined)) ?? true);
-    }
+    // An explicit `binary` attribute wins (`set`, or `unset` for `-binary`); otherwise, and without a repository
+    // (Storage writes like `.yo-rc.json`, `--skip-git`, failed initialization), binary files are detected from
+    // their contents. Only explicit `eol` values drive the decision: `unset` (`-eol`), `unspecified`, `native`
+    // and anything unexpected are treated as unspecified, line endings are best effort and must not abort the
+    // commit. Without attributes, existing files keep the line endings found on disk and new files get CRLF.
+    const isBinary = attrs?.binary === 'set' || (attrs?.binary !== 'unset' && (await isBinaryFile(file.contents!)));
+    const useCrlf =
+      attrs ?
+        attrs.eol === 'crlf' || (!isBinary && attrs.eol !== 'lf')
+      : !isBinary && ((await detectCrLf(file.path).catch(() => undefined)) ?? true);
 
     if (useCrlf) {
       file.contents = Buffer.from(normalizeLineEndings(file.contents!.toString(), CRLF));

--- a/generators/git/generator.spec.ts
+++ b/generators/git/generator.spec.ts
@@ -16,9 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { before, describe, expect, it } from 'esmocha';
-import { access } from 'node:fs/promises';
-import { basename, resolve } from 'node:path';
+import { after, before, describe, expect, it } from 'esmocha';
+import { access, mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+import { simpleGit } from 'simple-git';
 
 import { testBlueprintSupport } from '../../test/support/tests.ts';
 
@@ -46,11 +49,40 @@ describe(`generator - ${generator}`, () => {
       it('should create .git', async () => {
         await expect(access(resolve(runResult.cwd, '.git'))).resolves.toBeUndefined();
       });
+      it('should attach the git root to written files', () => {
+        const { generator } = runResult;
+        expect(runResult.memFs.get(generator.destinationPath('.gitignore')).editorMetadata).toEqual({
+          gitRoot: generator.destinationPath(),
+        });
+      });
       it('should create 1 commit', async () => {
         const git = runResult.generator.createGit();
         await expect(git.log()).resolves.toMatchObject({
           total: 1,
           latest: { message: expect.stringMatching(/^Initial version of/) },
+        });
+      });
+    });
+    describe('inside an existing repository at a parent folder', () => {
+      let parentDir: string;
+
+      before(async () => {
+        // Created outside the yeoman-test lifecycle: starting the run context would drop a prepared temporary dir.
+        parentDir = await mkdtemp(join(tmpdir(), 'jhipster-git-parent-'));
+        await simpleGit({ baseDir: parentDir }).init();
+        await mkdir(resolve(parentDir, 'child'));
+        await helpers.runJHipster(generator).cd(resolve(parentDir, 'child')).withOptions({ skipGit: false });
+      });
+      after(async () => {
+        await rm(parentDir, { recursive: true, force: true });
+      });
+      it('should not create a nested .git', async () => {
+        await expect(access(resolve(parentDir, 'child', '.git'))).rejects.toMatchObject({ code: 'ENOENT' });
+      });
+      it('should attach the parent repository root to written files', async () => {
+        const { generator } = runResult;
+        expect(runResult.memFs.get(generator.destinationPath('.gitignore')).editorMetadata).toEqual({
+          gitRoot: await realpath(parentDir),
         });
       });
     });
@@ -60,6 +92,10 @@ describe(`generator - ${generator}`, () => {
       });
       it('should not create .git', async () => {
         await expect(access(resolve(runResult.cwd, '.git'))).rejects.toMatchObject({ code: 'ENOENT' });
+      });
+      it('should not attach a git root to written files', () => {
+        const { generator } = runResult;
+        expect(runResult.memFs.get(generator.destinationPath('.gitignore')).editorMetadata).toEqual({});
       });
     });
     describe('regenerating', () => {

--- a/generators/git/generator.ts
+++ b/generators/git/generator.ts
@@ -22,6 +22,7 @@ import chalk from 'chalk';
 import { CheckRepoActions } from 'simple-git';
 
 import BaseGenerator from '../base/index.ts';
+import { CONTEXT_DATA_GIT_ROOT_KEY } from '../base-core/support/index.ts';
 
 import { files } from './files.ts';
 import type { Config as GitConfig, GeneratorProperties as GitGeneratorProperties, Options as GitOptions } from './types.ts';
@@ -53,6 +54,15 @@ export default class GitGenerator extends BaseGenerator<GitConfig, GitOptions> {
       async initializeMonorepository() {
         if (!this.skipGit && this.jhipsterConfig.monorepository) {
           await this.initializeGitRepository();
+        }
+      },
+      async registerGitRoot() {
+        if (!this.skipGit) {
+          // Files written to this context belong to the repository `initializeGitRepository` will initialize, or to
+          // the existing repository it reuses (a child application of a monorepository uses the root one).
+          const git = this.createGit();
+          const gitRoot = (await git.checkIsRepo()) ? await git.revparse(['--show-toplevel']) : this.destinationPath();
+          this.getContextData(CONTEXT_DATA_GIT_ROOT_KEY, { override: gitRoot });
         }
       },
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "typescript-eslint": "8.69.0",
         "yaml": "2.9.0",
         "yeoman-environment": "7.0.0",
-        "yeoman-generator": "8.3.2"
+        "yeoman-generator": "8.4.0"
       },
       "bin": {
         "jhipster": "dist/cli/jhipster.cjs"
@@ -10892,9 +10892,9 @@
       }
     },
     "node_modules/yeoman-generator": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-8.3.2.tgz",
-      "integrity": "sha512-o7XKYHpyLnxJU/Zh+yfNv8owT1YlrVT4DN5xTSqARaYQZNny8bu+aUo6zRYRgwg1VskWbMp07vlyqUi6FSUwRw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-8.4.0.tgz",
+      "integrity": "sha512-8yMkAfuAPqOaN9dsdf2hGxgCGuSIV3c/RmPKXWoe5YZ4HX2zXnDS9D/AoXlUw9OSPeRVpBe4vh92vTBi840Evw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/debug": "^4.1.13",
@@ -10905,7 +10905,7 @@
         "execa": "^9.6.1",
         "latest-version": "^9.0.0",
         "lodash-es": "^4.18.1",
-        "mem-fs-editor": "^12.0.4",
+        "mem-fs-editor": "^12.0.9",
         "minimist": "^1.2.8",
         "read-package-up": "^12.0.0",
         "semver": "^7.7.4",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "typescript-eslint": "8.69.0",
     "yaml": "2.9.0",
     "yeoman-environment": "7.0.0",
-    "yeoman-generator": "8.3.2"
+    "yeoman-generator": "8.4.0"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "5.10.0",


### PR DESCRIPTION
### Editor metadata

- yeoman-generator 8.4.0 attaches `BaseGenerator.editorMetadata` to every file written through its fs helpers (`writeDestination`, `writeDestinationJSON`, `copyTemplate`, `copyTemplateAsync`, `copyDestination`, `renderTemplate`, `renderTemplateAsync`), stored by mem-fs-editor as `file.editorMetadata`.
- base-core overrides the getter with `{ gitRoot }`, nothing for `uniqueGlobally` generators such as bootstrap.
- `generators/base` adds `removeNeedles: true` from `jhipsterConfig.removeNeedles`.
- The git generator registers the repository root in the context data (`jhipster:git:root`) at initializing: `git rev-parse --show-toplevel` when a repository already exists at or above the destination (child applications of a monorepository resolve the root repository), `destinationPath()` when it will create one. Without a git generator in the context there is no `gitRoot`.

### removeNeedles

The bootstrap commit pipeline always registers the needle transform, filtered on `file.editorMetadata.removeNeedles`, so needles are only removed from the files of a project that enabled it. The `removeNeedles` bootstrap property and the base-simple-application task that set it are gone.

This also fixes needle removal, which was silently dead on main: `commitSharedFs` read `this.options.removeNeedles` while base-simple-application set the class property. A 15-entity app generated with `removeNeedles true` still had needles in 52 files.

### autoCrlf

- Attributes are looked up with `git check-attr -z` from `editorMetadata.gitRoot`, trusted as is. The parent-directory walk and the `checkIsRepo` round trip are removed.
- The per-directory git cache is removed with the walk. It memoized simple-git instances and known non-repositories because the walk produced a different base directory for nearly every folder of the generated app. With `gitRoot` there is one base directory per project, constructing a simple-git instance spawns nothing, and the cases that used to hit a non-repository (`--skip-git`, missing git binary) register no `gitRoot` and never reach git; only a failed `git init` remains, which is rare and already reported.
- When git cannot answer (no `gitRoot`: Storage writes like `.yo-rc.json`, `--skip-git`; failed initialization; missing directory) the transform falls back to content detection: `isBinaryFile` decides whether the file is binary, existing files keep the line endings detected on disk, and new files get the CRLF default. This replaces the "skip outside a git repository" behavior from #34675.
- `unset` (`-eol`, `-binary`), `native` and unexpected attribute values are treated as unspecified instead of throwing, and paths containing `: ` are parsed correctly.

### Tests

- base: metadata attached by `writeDestination` and `editFile`, with and without `removeNeedles`.
- bootstrap: needle removal through a real commit, with and without the config.
- git: `gitRoot` attached with git enabled, absent with `--skip-git`, and resolved to the parent repository when generating inside one.
- autoCrlf: gitattributes lookup (including negated, native, binary and `colon: file` cases), and the fallback for a non-repository root, a missing root, no metadata, and existing LF/CRLF files.

This PR was developed with Claude Code assistance; the changes were reviewed manually.

Closes #34309.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
