### PR TITLE
internal: try to generate value for pattern a few times

### DIFF
--- a/generators/base-application/support/prepare-field.ts
+++ b/generators/base-application/support/prepare-field.ts
@@ -328,8 +328,14 @@ export function prepareCommonFieldForTemplates(
     const re = faker.createRandexp(field.fieldValidateRulesPattern!);
     if (!re) {
       generator.log.warn(`Error creating generator for pattern ${field.fieldValidateRulesPattern}`);
+      return undefined;
     }
-    return re?.gen();
+    // Patterns accepting an empty value (`*`, `?`, ...) may generate one, retry a few times to get a usable value.
+    let value = re.gen();
+    for (let attempt = 0; value.length === 0 && attempt < 10; attempt++) {
+      value = re.gen();
+    }
+    return value;
   };
 
   field.uniqueValue = [];


### PR DESCRIPTION
Fields with pattern validation may need to try to generate the value a few times before it succeed.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
