### PR TITLE
[Angular] Add missing form-label class to language select label

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/settings/settings.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/settings/settings.html.ejs
@@ -138,7 +138,7 @@
 
       @if (languages.length > 0) {
         <div class="mb-3">
-          <label for="langKey">__jhiTranslateTag__('settings.form.language')</label>
+          <label class="form-label" for="langKey">__jhiTranslateTag__('settings.form.language')</label>
           <select class="form-control" id="langKey" name="langKey" formControlName="langKey" data-cy="langKey">
           @for (language of languages; track $index) {
             <option [value]="language">{{ language | findLanguageFromKey }}</option>


### PR DESCRIPTION
Before
<img width="496" height="450" alt="image" src="https://github.com/user-attachments/assets/b3e3330d-b108-42b4-a6d8-dc37fd3c8b53" />

After
<img width="487" height="456" alt="image" src="https://github.com/user-attachments/assets/46afd2b3-711b-4b4e-ad6b-3881d7d3ebd7" />
