### PR TITLE
[Angular] Add missing template ref for focused input

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/register/register.html.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/register/register.html.ejs
@@ -51,6 +51,7 @@
           <label class="form-label" for="login">__jhiTranslateTag__('global.form.username.label')</label>
           <input
             type="text"
+            #login
             class="form-control"
             id="login"
             name="login"


### PR DESCRIPTION
Fix
<img width="862" height="879" alt="image" src="https://github.com/user-attachments/assets/9fa8e5d4-7695-4e82-95c9-bee8dddd16a3" />
