### PR TITLE
[Angular] Fix style for the strength bar list selector

### DIFF
--- a/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.scss.ejs
+++ b/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.scss.ejs
@@ -19,7 +19,7 @@
 /* ==========================================================================
 start Password strength bar style
 ========================================================================== */
-ul#strength {
+ul#strengthBar {
   display: inline;
   list-style: none;
   margin: 0 0 0 15px;


### PR DESCRIPTION
Before
<img width="332" height="219" alt="image" src="https://github.com/user-attachments/assets/a9864bc3-ec46-40aa-899b-7e169d5b7094" />

After
<img width="395" height="194" alt="image" src="https://github.com/user-attachments/assets/0d362906-c92b-43e9-a64a-0d9161125159" />

id used https://github.com/jhipster/generator-jhipster/blob/e30d388614b7126e9af3a8364f8f9e4ac19a672a/generators/angular/templates/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.html.ejs#L21
