### PR TITLE
quote jdl enum values that are not valid name tokens

### DIFF
--- a/lib/jdl/core/models/jdl-enum-value.spec.ts
+++ b/lib/jdl/core/models/jdl-enum-value.spec.ts
@@ -53,5 +53,27 @@ describe('jdl - JDLEnumValue', () => {
         expect(enumValue.toString()).toBe('FRENCH (frenchy)');
       });
     });
+    describe('with a value that is not a valid NAME token', () => {
+      it('should quote a value holding a special character', () => {
+        expect(new JDLEnumValue('Ue', '\u00dc').toString()).toBe('Ue ("\u00dc")');
+      });
+
+      it('should quote a value holding a space', () => {
+        expect(new JDLEnumValue('COMMA_SPACE', ', ').toString()).toBe('COMMA_SPACE (", ")');
+      });
+
+      it('should quote a value that would otherwise inject another enum entry', () => {
+        // Unquoted, `a), InjectedEnum(a` closes the parentheses and opens a second entry,
+        // so a single value would be exported as two enum values.
+        expect(new JDLEnumValue('Injected', 'a), InjectedEnum(a').toString()).toBe('Injected ("a), InjectedEnum(a")');
+      });
+    });
+    describe('with a value holding a double quote', () => {
+      it('should fail, as JDL strings have no escape sequence', () => {
+        expect(() => new JDLEnumValue('QUOTES', '"').toString()).toThrow(
+          /^The enum value '"' contains a double quote, which JDL cannot represent\.$/,
+        );
+      });
+    });
   });
 });

--- a/lib/jdl/core/models/jdl-enum-value.ts
+++ b/lib/jdl/core/models/jdl-enum-value.ts
@@ -17,6 +17,33 @@
  * limitations under the License.
  */
 
+/**
+ * Matches the lexer's NAME token (see parsing/lexer/shared-tokens.ts). An enum value is only safe to
+ * emit bare when it matches this; anything else has to be quoted so the export re-parses as itself.
+ */
+const NAME_PATTERN = /^[a-zA-Z_][a-zA-Z_\-\d]*$/;
+
+/**
+ * Renders an enum value for JDL output.
+ *
+ * The grammar accepts either a bare NAME or a quoted STRING inside the parentheses
+ * (see `enumProp` in parsing/jdl-parser.ts). Emitting a value that is neither produces JDL that
+ * re-parses as something other than what was exported — for `A("x), B(y")` the closing paren and
+ * comma are read as grammar, so one value silently becomes two enum entries.
+ */
+function stringifyEnumValue(value: string): string {
+  if (NAME_PATTERN.test(value)) {
+    return value;
+  }
+  if (value.includes('"')) {
+    // The STRING token is /"(?:[^"])*"/ — a plain literal with no escape sequence — so a value
+    // containing a double quote has no JDL representation at all. Failing loudly beats emitting
+    // JDL that silently parses back as different content.
+    throw new Error(`The enum value '${value}' contains a double quote, which JDL cannot represent.`);
+  }
+  return `"${value}"`;
+}
+
 export default class JDLEnumValue {
   name: string;
   value?: string;
@@ -32,7 +59,7 @@ export default class JDLEnumValue {
   }
 
   toString() {
-    const value = this.value ? ` (${this.value})` : '';
+    const value = this.value ? ` (${stringifyEnumValue(this.value)})` : '';
     return `${this.name}${value}`;
   }
 }


### PR DESCRIPTION
Fix #31082 (the export/injection half — see *Scope* below).

### The problem

`JDLEnumValue.toString()` interpolated the value straight into the parentheses:

```ts
const value = this.value ? ` (${this.value})` : '';
```

`enumProp` accepts either a bare `NAME` or a quoted `STRING` in that position, so a value that is neither gets re-read as grammar on the next import. Round-tripping the enum from the issue on `main`:

```
enum SpecialChars {
  Ue (Ü),
  Injected (a), InjectedEnum(a)
}
```

`), ` closes the parentheses and starts a new entry, so two declared values come back as **three** — the last one being an enum the author never wrote. That is the JDL-injection @nitram84 reported, and it also silently corrupts any value holding a space or a non-ASCII character.

### The fix

Emit the value bare only when it matches the lexer's `NAME` pattern (`/[a-zA-Z_][a-zA-Z_\-\d]*/`), and quote it otherwise. After the change the same enum round-trips exactly:

```
enum SpecialChars {
  Ue ("Ü"),
  Injected ("a), InjectedEnum(a")
}
```

reparsed → `[{"key":"Ue","value":"Ü"},{"key":"Injected","value":"a), InjectedEnum(a"}]`

One deliberate judgement call worth your review: the `STRING` token is `/"(?:[^"])*"/` and the lexer comments it as *"No escaping, no unicode, just a plain string literal"*, so a value containing `"` has **no** representation in JDL. Rather than emit output that parses back as something else, `toString()` now throws for that case. Happy to downgrade it to a warning or a silent strip if you would rather not add a throw on an export path.

### Scope

This addresses the export/injection half of #31082. The import half — `QUOTES("\"")` and friends failing to parse — needs an escape sequence in the `STRING` token, which is a grammar change with wider blast radius. I would rather land this separately and not smuggle a lexer change into a bug fix; glad to follow up if you want it.

### Verification

- 4 new cases in `jdl-enum-value.spec.ts`: special character, embedded space, the injection payload, and the unrepresentable double quote.
- Full JDL suite green locally: **1215 passing** (`npx esmocha lib/jdl`).
- Verified the round-trip above end-to-end through `parseFromContent`, and confirmed it fails on `main` before the change.
- `npm run prettier:format`, `eslint --max-warnings 5`, and `npm run check-types` all clean.

### Bounty

The bug bounty policy says to ask a project lead if work seems like it deserves one, so — @jdubois @mshima @DanielFran — would a fix in this area qualify? It is the same JDL-injection class as #32601. No problem at all if not; I would just rather ask up front than assume either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)