### PR TITLE
fix JDL enum round trips and annotation escaping

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,44 @@
 # JHipster development
 
 - [Generator development setup](#setup)
+- [Entity enum values](#entity-enum-values)
+
+## Entity enum values
+
+An entity's `fieldValues` accepts either the legacy raw string (`"FIRST,SECOND (two words)"`) or an array of entries:
+
+```json
+[{ "name": "FIRST" }, { "name": "SECOND", "value": "a), other(a" }, { "name": "EMPTY", "value": "" }]
+```
+
+Entity field definitions are stored in `.jhipster/<Entity>.json`. `.yo-rc.json` contains application configuration and entity names, not embedded enum field definitions.
+
+JDL import retains legacy strings for simple values, including spaces, Unicode and literal backslashes. It uses structured entries when custom values contain quotes, commas, parentheses or line breaks, or are empty. An omitted `value` means no custom value; `""` is an explicitly empty custom value.
+
+Use `parseEnumValues` and `serializeEnumValues` from `generator-jhipster/utils` rather than splitting `fieldValues` in generators or blueprints. Legacy strings are not JDL strings: quotes and backslashes are literal characters, not escapes. Ambiguous legacy delimiter sequences cannot be recovered automatically; convert them to structured entries with the intended values.
+
+The entity enum prompt also accepts a JSON array for custom values containing special characters. Only enum names are uppercased, not custom values.
+
+### Quoted JDL strings
+
+Quoted strings in enum values, annotations and configuration support JSON-style escapes: `\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t` and `\uXXXX`. For example:
+
+```jdl
+enum SpecialChars {
+  QUOTES ("\"")
+  BACKSLASH ("\\")
+  COMMA_SPACE (", ")
+}
+
+entity StreamRights {
+  @MapstructExpression("java(s.getId() + \" | \" + s.getName())")
+  details String
+}
+```
+
+Literal Unicode and multiline strings remain supported. Escape literal backslashes as `\\`; unknown escape sequences such as `\d` retain their legacy literal meaning. Comment and directive markers inside quoted strings are data, not JDL syntax. Export escapes string values, and generated Java, TypeScript and translation JSON escape them for their target languages.
+
+Existing JDL that relied on a literal recognized sequence such as `\n` must use `\\n` to keep the backslash rather than insert a newline. Legacy entity JSON values are not reinterpreted this way.
 
 ## <a name="setup"></a> Generator development setup
 

--- a/generators/base-application/internal/types/field-types.ts
+++ b/generators/base-application/internal/types/field-types.ts
@@ -49,10 +49,10 @@ export const isFieldBinaryType = (field: BaseApplicationField): field is SetFiel
   isBlobType(field.fieldType) || field.fieldType === 'byte[]';
 
 export const isFieldEnumType = (field: BaseApplicationField): field is SetRequired<BaseApplicationField, 'enumFileName' | 'enumValues'> =>
-  Boolean(field.fieldValues);
+  field.fieldValues !== undefined && field.fieldValues !== '';
 
 export const isFieldNotEnumType = (field: BaseApplicationField): field is SetFieldType<BaseApplicationField, 'fieldType', FieldType> =>
-  !field.fieldValues;
+  !isFieldEnumType(field);
 
 export function convertFieldBlobType<const F extends BaseApplicationField = BaseApplicationField>(field: F): F {
   // Convert fieldTypes to correct fieldTypes

--- a/generators/base-application/support/__snapshots__/enum-templates.spec.ts.snap
+++ b/generators/base-application/support/__snapshots__/enum-templates.spec.ts.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`enum template escaping should escape Java custom values from legacy storage 1`] = `
+"package com.example.domain.enumeration;
+
+/**
+ * The CustomEnum enumeration.
+ */
+public enum CustomEnum {
+    UNICODE("Ü"),
+    SPACES("two words"),
+    QUOTE("\\""),
+    BACKSLASH("a\\\\nb"),
+    APOSTROPHE("it's a value"),
+    OTHER;
+    private String value;
+
+    CustomEnum() {}
+
+    CustomEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}
+"
+`;
+
+exports[`enum template escaping should escape Java custom values from structured storage 1`] = `
+"package com.example.domain.enumeration;
+
+/**
+ * The CustomEnum enumeration.
+ */
+public enum CustomEnum {
+    UNICODE("Ü"),
+    QUOTE("\\""),
+    BACKSLASH("\\\\"),
+    COMMA(", "),
+    DELIMITERS("a), InjectedEnum(a"),
+    PARENTHESES("()"),
+    EMPTY(""),
+    NEWLINES("a\\r\\nb"),
+    SEPARATORS("a b c"),
+    CONTROLS("\\t\\b\\f\\u0000"),
+    APOSTROPHE("it's a value"),
+    UNICODE_ESCAPE("\\\\u000a"),
+    OTHER;
+    private String value;
+
+    CustomEnum() {}
+
+    CustomEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}
+"
+`;
+
+exports[`enum template escaping should generate executable TypeScript enums from legacy storage 1`] = `
+"export enum CustomEnum {
+
+  UNICODE = "Ü",
+
+  SPACES = "two words",
+
+  QUOTE = "\\"",
+
+  BACKSLASH = "a\\\\nb",
+
+  APOSTROPHE = "it's a value",
+
+  OTHER = "OTHER"
+
+}
+"
+`;
+
+exports[`enum template escaping should generate executable TypeScript enums from structured storage 1`] = `
+"export enum CustomEnum {
+
+  UNICODE = "Ü",
+
+  QUOTE = "\\"",
+
+  BACKSLASH = "\\\\",
+
+  COMMA = ", ",
+
+  DELIMITERS = "a), InjectedEnum(a",
+
+  PARENTHESES = "()",
+
+  EMPTY = "",
+
+  NEWLINES = "a\\r\\nb",
+
+  SEPARATORS = "a b c",
+
+  CONTROLS = "\\t\\b\\f\\u0000",
+
+  APOSTROPHE = "it's a value",
+
+  UNICODE_ESCAPE = "\\\\u000a",
+
+  OTHER = "OTHER"
+
+}
+"
+`;
+
+exports[`enum template escaping should generate valid i18n JSON from legacy storage 1`] = `
+"{
+    "sampleApp": {
+        "CustomEnum" : {
+            "null": "",
+            "UNICODE": "Ü",
+            "SPACES": "two words",
+            "QUOTE": "\\"",
+            "BACKSLASH": "a\\\\nb",
+            "APOSTROPHE": "it's a value",
+            "OTHER": "OTHER"
+        }
+    }
+}
+"
+`;
+
+exports[`enum template escaping should generate valid i18n JSON from structured storage 1`] = `
+"{
+    "sampleApp": {
+        "CustomEnum" : {
+            "null": "",
+            "UNICODE": "Ü",
+            "QUOTE": "\\"",
+            "BACKSLASH": "\\\\",
+            "COMMA": ", ",
+            "DELIMITERS": "a), InjectedEnum(a",
+            "PARENTHESES": "()",
+            "EMPTY": "",
+            "NEWLINES": "a\\r\\nb",
+            "SEPARATORS": "a b c",
+            "CONTROLS": "\\t\\b\\f\\u0000",
+            "APOSTROPHE": "it's a value",
+            "UNICODE_ESCAPE": "\\\\u000a",
+            "OTHER": "OTHER"
+        }
+    }
+}
+"
+`;

--- a/generators/base-application/support/enum-templates.spec.ts
+++ b/generators/base-application/support/enum-templates.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ejs from 'ejs';
+import { describe, expect, it } from 'esmocha';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+
+import type { EnumValues } from '../../../lib/utils/enum.ts';
+
+import { getEnumInfo } from './enum.ts';
+
+const render = (path: string, fieldValues: EnumValues) =>
+  ejs.render(readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8'), {
+    ...getEnumInfo({ fieldType: 'CustomEnum', fieldValues }),
+    entityAbsolutePackage: 'com.example',
+    frontendAppName: 'sampleApp',
+  });
+
+const javaTemplate = 'java/generators/domain/templates/src/main/java/_package_/_entityPackage_/domain/enumeration/_enumName_.java.ejs';
+const tsTemplate = 'client/templates/src/main/webapp/app/entities/enumerations/enum.model.ts.ejs';
+const i18nTemplate = 'client/generators/i18n/templates/entity/i18n/enum.json.ejs';
+
+describe('enum template escaping', () => {
+  for (const [format, fieldValues] of Object.entries({
+    legacy: String.raw`UNICODE (Ü),SPACES (two words),QUOTE ("),BACKSLASH (a\nb),APOSTROPHE (it's a value),OTHER`,
+    structured: [
+      { name: 'UNICODE', value: 'Ü' },
+      { name: 'QUOTE', value: '"' },
+      { name: 'BACKSLASH', value: '\\' },
+      { name: 'COMMA', value: ', ' },
+      { name: 'DELIMITERS', value: 'a), InjectedEnum(a' },
+      { name: 'PARENTHESES', value: '()' },
+      { name: 'EMPTY', value: '' },
+      { name: 'NEWLINES', value: 'a\r\nb' },
+      { name: 'SEPARATORS', value: 'a\u2028b\u2029c' },
+      { name: 'CONTROLS', value: '\t\b\f\0' },
+      { name: 'APOSTROPHE', value: "it's a value" },
+      { name: 'UNICODE_ESCAPE', value: String.raw`\u000a` },
+      { name: 'OTHER' },
+    ],
+  } satisfies Record<string, EnumValues>)) {
+    const expectedValues = getEnumInfo({ fieldType: 'CustomEnum', fieldValues }).enumValues;
+
+    it(`should escape Java custom values from ${format} storage`, () => {
+      const source = render(javaTemplate, fieldValues);
+
+      expect(source).toMatchSnapshot();
+      const renderedValues = [...source.matchAll(/^\s+(\w+)\(("(?:[^"\\]|\\.)*")\)/gm)].map(([, name, literal]) => ({
+        name,
+        value: JSON.parse(literal),
+      }));
+      expect(renderedValues).toEqual(
+        expectedValues.filter(({ name, value }) => name !== value).map(({ name, value }) => ({ name, value })),
+      );
+    });
+
+    it(`should generate executable TypeScript enums from ${format} storage`, () => {
+      const source = render(tsTemplate, fieldValues);
+
+      expect(source).toMatchSnapshot();
+      const compiled = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS }, reportDiagnostics: true });
+      expect(compiled.diagnostics).toEqual([]);
+      const exports: { CustomEnum?: Record<string, string> } = {};
+      runInNewContext(compiled.outputText, { exports });
+      expect(exports.CustomEnum).toEqual(Object.fromEntries(expectedValues.map(({ name, value }) => [name, value])));
+    });
+
+    it(`should generate valid i18n JSON from ${format} storage`, () => {
+      const source = render(i18nTemplate, fieldValues);
+
+      expect(source).toMatchSnapshot();
+      expect(JSON.parse(source).sampleApp.CustomEnum).toEqual({
+        null: '',
+        ...Object.fromEntries(expectedValues.map(({ name, value }) => [name, value])),
+      });
+    });
+  }
+});

--- a/generators/base-application/support/enum-templates.spec.ts
+++ b/generators/base-application/support/enum-templates.spec.ts
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-import ejs from 'ejs';
 import { describe, expect, it } from 'esmocha';
 import { readFileSync } from 'node:fs';
 import { runInNewContext } from 'node:vm';
+
+import ejs from 'ejs';
 import ts from 'typescript';
 
 import type { EnumValues } from '../../../lib/utils/enum.ts';

--- a/generators/base-application/support/enum.spec.ts
+++ b/generators/base-application/support/enum.spec.ts
@@ -17,13 +17,59 @@
  * limitations under the License.
  */
 
-import { before, describe, it } from 'esmocha';
+import { before, describe, expect, it } from 'esmocha';
 import assert from 'node:assert';
 
 import { getEnumInfo } from './enum.ts';
 
 describe('base-application - support - enum', () => {
   describe('::getEnumInfo', () => {
+    it('preserves custom values and their presence in structured entries', () => {
+      const values = ['Ü', '"', '\\', ', ', 'a), InjectedEnum(a', '()', '', 'a\nb', "it's a value"];
+      const fieldValues = [...values.map((value, index) => ({ name: `VALUE${index}`, value })), { name: 'OTHER' }];
+      const info = getEnumInfo({
+        fieldType: 'CustomEnum',
+        fieldValues,
+        fieldValuesJavadocs: { VALUE6: 'Empty custom value' },
+      });
+
+      expect(info.withoutCustomValues).toBe(false);
+      expect(info.withSomeCustomValues).toBe(true);
+      expect(info.withCustomValues).toBe(false);
+      expect(info.enumValues.map(({ name, value }) => ({ name, value }))).toEqual([
+        ...fieldValues.slice(0, -1),
+        { name: 'OTHER', value: 'OTHER' },
+      ]);
+      expect(info.enumValues[6].comment).toBe('    /**\n     * Empty custom value\n     */');
+    });
+
+    it('recognizes an explicitly empty custom value as a custom value', () => {
+      const info = getEnumInfo({ fieldType: 'CustomEnum', fieldValues: [{ name: 'EMPTY', value: '' }] });
+
+      expect(info.withCustomValues).toBe(true);
+      expect(info.withoutCustomValues).toBe(false);
+      expect(info.enumValues).toEqual([{ name: 'EMPTY', value: '', comment: undefined }]);
+    });
+
+    it('does not decode legacy custom values', () => {
+      expect(getEnumInfo({ fieldType: 'CustomEnum', fieldValues: String.raw`VALUE ("a\nb")` }).enumValues).toEqual([
+        { name: 'VALUE', value: String.raw`"a\nb"`, comment: undefined },
+      ]);
+    });
+
+    it('supports built-in client language constants', () => {
+      expect(getEnumInfo({ fieldType: 'Languages', fieldValues: 'en,pt-br', clientConstantsAsValues: true }).enumValues).toEqual([
+        { name: 'en', value: 'en', comment: undefined },
+        { name: 'pt-br', value: 'pt-br', comment: undefined },
+      ]);
+    });
+
+    it('rejects malformed entries before rendering templates', () => {
+      for (const fieldValues of [[{ name: 'VALUE,INJECTED' }], [{ name: 'VALUE\n' }], 'VALUE (a)b)']) {
+        expect(() => getEnumInfo({ fieldType: 'CustomEnum', fieldValues })).toThrow('Invalid enum entry');
+      }
+    });
+
     describe('when passing field data', () => {
       let enumInfo: ReturnType<typeof getEnumInfo>;
 

--- a/generators/base-application/support/enum.ts
+++ b/generators/base-application/support/enum.ts
@@ -18,8 +18,14 @@
  */
 import { lowerFirst } from 'lodash-es';
 
+import type { Field } from '../../../lib/jhipster/types/field.d.ts';
+import { type EnumValue, parseEnumValues } from '../../../lib/utils/enum.ts';
 import { formatDocAsJavaDoc } from '../../java/support/doc.ts';
-import type { Field as BaseApplicationField } from '../types.d.ts';
+
+type EnumField = Pick<Field, 'fieldType' | 'fieldValues' | 'fieldValuesJavadocs' | 'fieldTypeDocumentation'> & {
+  enumInstance?: string;
+  clientConstantsAsValues?: boolean;
+};
 
 type EnumValuesData = {
   withoutCustomValues: boolean;
@@ -33,15 +39,13 @@ type EnumNameValue = {
   comment?: string;
 };
 
-const doesTheEnumValueHaveACustomValue = (enumValue: string) => enumValue.includes('(');
-
-const getCustomValuesState = (enumValues: string[]): EnumValuesData => {
+const getCustomValuesState = (enumValues: EnumValue[]): EnumValuesData => {
   const state = {
     withoutCustomValue: 0,
     withCustomValue: 0,
   };
   enumValues.forEach(enumValue => {
-    if (doesTheEnumValueHaveACustomValue(enumValue)) {
+    if (enumValue.value !== undefined) {
       state.withCustomValue++;
     } else {
       state.withoutCustomValue++;
@@ -54,39 +58,17 @@ const getCustomValuesState = (enumValues: string[]): EnumValuesData => {
   };
 };
 
-const getEnums = (enums: string[], customValuesState: EnumValuesData, comments?: Record<string, string>): EnumNameValue[] => {
-  if (customValuesState.withoutCustomValues) {
-    return enums.map(enumValue => ({
-      name: enumValue,
-      value: enumValue,
-      comment: comments?.[enumValue] && formatDocAsJavaDoc(comments[enumValue], 4),
-    }));
-  }
-  return enums.map(enumValue => {
-    if (!doesTheEnumValueHaveACustomValue(enumValue)) {
-      return {
-        name: enumValue.trim(),
-        value: enumValue.trim(),
-        comment: comments?.[enumValue] && formatDocAsJavaDoc(comments[enumValue], 4),
-      };
-    }
+const getEnums = (enums: EnumValue[], comments?: Record<string, string>): EnumNameValue[] =>
+  enums.map(({ name, value }) => ({
+    name,
+    value: value ?? name,
+    comment: comments?.[name] && formatDocAsJavaDoc(comments[name], 4),
+  }));
 
-    const matched = /\s*(.+?)\s*\((.+?)\)/.exec(enumValue);
-    return {
-      name: matched![1],
-      value: matched![2],
-      comment: comments?.[matched![1]] && formatDocAsJavaDoc(comments[matched![1]], 4),
-    };
-  });
-};
-
-const extractEnumInstance = (field: Pick<BaseApplicationField, 'fieldType'>): string => {
+const extractEnumInstance = (field: Pick<EnumField, 'fieldType'>): string => {
   const { fieldType } = field;
   return lowerFirst(fieldType);
 };
-
-const extractEnumEntries = (field: Pick<BaseApplicationField, 'fieldValues'>): string[] =>
-  field.fieldValues!.split(',').map((fieldValue: string) => fieldValue.trim());
 
 /**
  * Build an enum object
@@ -96,7 +78,7 @@ const extractEnumEntries = (field: Pick<BaseApplicationField, 'fieldValues'>): s
  */
 
 export const getEnumInfo = (
-  field: Pick<BaseApplicationField, 'enumInstance' | 'fieldType' | 'fieldValues' | 'fieldValuesJavadocs' | 'fieldTypeDocumentation'>,
+  field: EnumField,
   clientRootFolder?: string,
 ): EnumValuesData & {
   enumName: string;
@@ -107,15 +89,18 @@ export const getEnumInfo = (
   enumJavadoc?: string;
 } => {
   field.enumInstance = extractEnumInstance(field); // TODO remove side effect
-  const enums = extractEnumEntries(field);
-  const customValuesState = getCustomValuesState(enums);
+  const entries = parseEnumValues(field.fieldValues, { clientConstants: field.clientConstantsAsValues });
+  const customValuesState = getCustomValuesState(entries);
   return {
     enumName: field.fieldType,
     enumJavadoc: field.fieldTypeDocumentation && formatDocAsJavaDoc(field.fieldTypeDocumentation),
     enumInstance: field.enumInstance,
-    enums,
+    enums:
+      typeof field.fieldValues === 'string' ?
+        field.fieldValues.split(',').map(value => value.trim())
+      : entries.map(({ name, value }) => `${name}${value === undefined ? '' : `(${value})`}`),
     ...customValuesState,
-    enumValues: getEnums(enums, customValuesState, field.fieldValuesJavadocs),
+    enumValues: getEnums(entries, field.fieldValuesJavadocs),
     clientRootFolder: clientRootFolder ? `${clientRootFolder}-` : '',
   };
 };

--- a/generators/base-application/support/prepare-field.spec.ts
+++ b/generators/base-application/support/prepare-field.spec.ts
@@ -50,6 +50,22 @@ describe('generator - base-application - support - prepareField', () => {
   });
 
   describe('getEnumValuesWithCustomValues', () => {
+    it('should consume structured values without losing empty values or delimiter characters', () => {
+      const entries = [{ name: 'SPECIAL', value: 'Ü, "a)\\\nb(' }, { name: 'EMPTY', value: '' }, { name: 'OTHER' }];
+      expect(getEnumValuesWithCustomValues(entries)).toEqual([entries[0], entries[1], { name: 'OTHER', value: 'OTHER' }]);
+    });
+    it('should preserve literal legacy quotes and backslashes', () => {
+      expect(getEnumValuesWithCustomValues(String.raw`VALUE ("a\nb")`)).toEqual([{ name: 'VALUE', value: String.raw`"a\nb"` }]);
+    });
+    it('should support built-in client language constants', () => {
+      expect(getEnumValuesWithCustomValues('en,pt-br', { clientConstants: true })).toEqual([
+        { name: 'en', value: 'en' },
+        { name: 'pt-br', value: 'pt-br' },
+      ]);
+    });
+    it('should reject invalid names', () => {
+      expect(() => getEnumValuesWithCustomValues([{ name: 'VALUE,INJECTED' }])).toThrow('Invalid enum entry');
+    });
     describe('when not passing anything', () => {
       it('should fail', () => {
         // @ts-expect-error testing invalid arguments

--- a/generators/base-application/support/prepare-field.ts
+++ b/generators/base-application/support/prepare-field.ts
@@ -20,6 +20,7 @@ import { defaults, kebabCase } from 'lodash-es';
 
 import { fieldTypesValues } from '../../../lib/jhipster/field-types.ts';
 import { fieldTypes, validations } from '../../../lib/jhipster/index.ts';
+import { type EnumValues, parseEnumValues } from '../../../lib/utils/enum.ts';
 import { mutateData } from '../../../lib/utils/index.ts';
 import type CoreGenerator from '../../base-core/generator.ts';
 import type { DatabaseProperty } from '../../liquibase/types.ts';
@@ -299,7 +300,7 @@ export function prepareCommonFieldForTemplates(
       throw new Error(`Field type '${fieldType}' is a reserved keyword and can't be used as an enum name.`);
     }
     field.enumFileName = kebabCase(field.fieldType);
-    field.enumValues = getEnumValuesWithCustomValues(field.fieldValues!);
+    field.enumValues = getEnumValuesWithCustomValues(field.fieldValues!, { clientConstants: field.clientConstantsAsValues });
   }
 
   field.fieldWithContentType = (fieldType === BYTES || fieldType === BYTE_BUFFER) && field.fieldTypeBlobContent !== TEXT;
@@ -368,22 +369,14 @@ export function prepareCommonFieldForTemplates(
 }
 
 /**
- * From an enum's values (with or without custom values), returns the enum's values without custom values.
- * @param {String} [enumValues] - an enum's values.
- * @return {Array<String>} the formatted enum's values.
+ * Resolve each enum value, falling back to its name only when no custom value is present.
  */
-export function getEnumValuesWithCustomValues(enumValues: string): { name: string; value: string }[] {
+export function getEnumValuesWithCustomValues(
+  enumValues: EnumValues,
+  options: Parameters<typeof parseEnumValues>[1] = {},
+): { name: string; value: string }[] {
   if (!enumValues || enumValues === '') {
     throw new Error('Enumeration values must be passed to get the formatted values.');
   }
-  return enumValues.split(',').map(enumValue => {
-    if (!enumValue.includes('(')) {
-      return { name: enumValue.trim(), value: enumValue.trim() };
-    }
-    const matched = /\s*(.+?)\s*\((.+?)\)/.exec(enumValue);
-    return {
-      name: matched![1],
-      value: matched![2],
-    };
-  });
+  return parseEnumValues(enumValues, options).map(({ name, value }) => ({ name, value: value ?? name }));
 }

--- a/generators/client/generators/i18n/templates/entity/i18n/enum.json.ejs
+++ b/generators/client/generators/i18n/templates/entity/i18n/enum.json.ejs
@@ -20,7 +20,7 @@
     "<%- frontendAppName %>": {
         "<%- enumName %>" : {
             "null": ""<% for (const enumValue of enumValues) { %>,
-            "<%- enumValue.name %>": "<%- enumValue.value %>"<% } %>
+            <%- JSON.stringify(enumValue.name) %>: <%- JSON.stringify(enumValue.value) %><% } %>
         }
     }
 }

--- a/generators/client/templates/src/main/webapp/app/entities/enumerations/enum.model.ts.ejs
+++ b/generators/client/templates/src/main/webapp/app/entities/enumerations/enum.model.ts.ejs
@@ -18,6 +18,6 @@
 -%>
 export enum <%- enumName %> {
 <% for (const [index, enumValue] of enumValues.entries()) { %>
-  <%- enumValue.name.includes('-') ? `'${enumValue.name}'` : enumValue.name %> = '<%- enumValue.value %>'<%- index < enumValues.length - 1 ? ',' : '' %>
+  <%- enumValue.name.includes('-') ? JSON.stringify(enumValue.name) : enumValue.name %> = <%- JSON.stringify(enumValue.value) %><%- index < enumValues.length - 1 ? ',' : '' %>
 <% } %>
 }

--- a/generators/entity/prompts.ts
+++ b/generators/entity/prompts.ts
@@ -19,7 +19,7 @@
 import fs from 'node:fs';
 
 import chalk from 'chalk';
-import { isArray, lowerFirst, snakeCase, uniq, upperFirst } from 'lodash-es';
+import { isArray, lowerFirst, snakeCase, upperFirst } from 'lodash-es';
 
 import { APPLICATION_TYPE_GATEWAY } from '../../lib/core/application-types.ts';
 import { clientFrameworkTypes, databaseTypes, entityOptions, fieldTypes, reservedKeywords, validations } from '../../lib/jhipster/index.ts';
@@ -27,7 +27,7 @@ import { asPromptingTask } from '../base-application/support/task-type-inference
 import type { Field as BaseApplicationField } from '../base-application/types.ts';
 
 import type EntityGenerator from './generator.ts';
-import { inputIsNumber, inputIsSignedDecimalNumber, inputIsSignedNumber } from './support/index.ts';
+import { inputIsNumber, inputIsSignedDecimalNumber, inputIsSignedNumber, parseEnumValuesInput } from './support/index.ts';
 
 const { isReservedPaginationWords, isReservedFieldName, isReservedTableName } = reservedKeywords;
 const { NO: NO_DATABASE, CASSANDRA, SQL } = databaseTypes;
@@ -517,30 +517,22 @@ async function askForField(this: EntityGenerator) {
         if (input === '') {
           return 'You must specify values for your enumeration';
         }
-        // Commas allowed so that user can input a list of values split by commas.
-        if (!/^[A-Za-z0-9_,]+$/.test(input)) {
-          return 'Enum values cannot contain special characters (allowed characters: A-Z, a-z, 0-9 and _)';
-        }
-        const enums = input.replace(/\s/g, '').split(',');
-        if (uniq(enums).length !== enums.length) {
-          return `Enum values cannot contain duplicates (typed values: ${input})`;
-        }
-        for (const enumValue of enums) {
-          if (/^\d.*/.test(enumValue)) {
-            return `Enum value "${enumValue}" cannot start with a number`;
+        try {
+          parseEnumValuesInput(input);
+        } catch (error) {
+          if (error instanceof Error) {
+            return error.message;
           }
-          if (enumValue === '') {
-            return 'Enum value cannot be empty (did you accidentally type "," twice in a row?)';
-          }
+          throw error;
         }
 
         return true;
       },
       message: () => {
         if (!context.existingEnum) {
-          return 'What are the values of your enumeration (separated by comma, no spaces)?';
+          return 'What are the values of your enumeration (comma-separated NAME or NAME(value), or a JSON array of { "name": "NAME", "value": "custom value" })?';
         }
-        return 'What are the new values of your enumeration (separated by comma, no spaces)?\nThe new values will replace the old ones.\nNothing will be done if there are no new values.';
+        return 'What are the new values of your enumeration (comma-separated NAME or NAME(value), or a JSON array of { "name": "NAME", "value": "custom value" })?\nThe new values will replace the old ones.\nNothing will be done if there are no new values.';
       },
     },
     {
@@ -694,7 +686,7 @@ async function askForField(this: EntityGenerator) {
 
   if ((answers as any).fieldIsEnum) {
     answers.fieldType = upperFirst(answers.fieldType);
-    answers.fieldValues = answers.fieldValues.toUpperCase();
+    answers.fieldValues = answers.fieldValues === '' ? '' : parseEnumValuesInput(answers.fieldValues);
   }
 
   const field = {

--- a/generators/entity/support/enum.spec.ts
+++ b/generators/entity/support/enum.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'esmocha';
+
+import { parseEnumValuesInput } from './enum.ts';
+
+describe('entity - enum prompt values', () => {
+  it('should uppercase ordinary names as before', () => {
+    expect(parseEnumValuesInput('one,two')).toBe('ONE,TWO');
+  });
+
+  it('should preserve custom values while uppercasing names', () => {
+    expect(parseEnumValuesInput('one(two words),two(Ü)')).toBe('ONE (two words),TWO (Ü)');
+  });
+
+  it('should accept JSON input for values containing delimiters, quotes, escapes and newlines', () => {
+    const entries = [{ name: 'one', value: 'a), Injected(a\n"\\' }, { name: 'two', value: '' }, { name: 'three' }];
+    const expected = [{ name: 'ONE', value: entries[0].value }, { name: 'TWO', value: '' }, { name: 'THREE' }];
+
+    expect(parseEnumValuesInput(JSON.stringify(entries))).toEqual(expected);
+    expect(parseEnumValuesInput(entries)).toEqual(expected);
+  });
+
+  it('should reject malformed input and names', () => {
+    for (const input of ['[]', '[', '[null]', '[{"name":"ONE","value":42}]', 'a-b', '1VALUE', 'VALUE,', 'one,ONE']) {
+      expect(() => parseEnumValuesInput(input)).toThrow();
+    }
+  });
+});

--- a/generators/entity/support/enum.ts
+++ b/generators/entity/support/enum.ts
@@ -16,12 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { ENUM_VALUE_NAME_PATTERN as ENUM_PROP_NAME_PATTERN } from '../../../utils/enum.ts';
 
-export const ALPHABETIC = /^[A-Za-z]+$/;
-export const ALPHABETIC_LOWER = /^[a-z]+$/;
-export const ALPHANUMERIC = /^[A-Za-z][A-Za-z0-9]*$/;
-export const ALPHANUMERIC_DASH = /^[A-Za-z][A-Za-z0-9-]*$/;
-export const ALPHABETIC_DASH_LOWER = /^[a-z][a-z-]*$/;
-export const ALPHANUMERIC_SPACE = /^"?[A-Za-z][A-Za-z0-9- ]*"?$/;
-export const ALPHANUMERIC_UNDERSCORE = /^[A-Za-z]\w*$/;
+import { type EnumValues, parseEnumValues, serializeEnumValues } from '../../../lib/utils/enum.ts';
+
+/** Accept legacy entries or a JSON array at the prompt; uppercase names, never custom values. */
+export function parseEnumValuesInput(input: EnumValues): EnumValues {
+  const values = typeof input === 'string' && input.trimStart().startsWith('[') ? JSON.parse(input) : input;
+  return serializeEnumValues(
+    parseEnumValues(values, { clientConstants: true }).map(entry => ({ ...entry, name: entry.name.toUpperCase() })),
+  );
+}

--- a/generators/entity/support/index.ts
+++ b/generators/entity/support/index.ts
@@ -22,3 +22,4 @@ export {
   isSignedDecimalNumber as inputIsSignedDecimalNumber,
   isSignedNumber as inputIsSignedNumber,
 } from './asserts.ts';
+export { parseEnumValuesInput } from './enum.ts';

--- a/generators/java/generators/domain/templates/src/main/java/_package_/_entityPackage_/domain/enumeration/_enumName_.java.ejs
+++ b/generators/java/generators/domain/templates/src/main/java/_package_/_entityPackage_/domain/enumeration/_enumName_.java.ejs
@@ -41,7 +41,7 @@ public enum <%- enumName %> {
     <%_ if (enumWithCustomValue.name === enumWithCustomValue.value) { _%>
     <%- enumWithCustomValue.name %><%- index < enumValues.length - 1 ? ',' : ';' %>
     <%_ } else { _%>
-    <%- enumWithCustomValue.name %>("<%- enumWithCustomValue.value %>")<%- index < enumValues.length - 1 ? ',' : ';' %>
+    <%- enumWithCustomValue.name %>(<%- JSON.stringify(enumWithCustomValue.value) %>)<%- index < enumValues.length - 1 ? ',' : ';' %>
     <%_ } _%>
   <%_ } _%>
   <%_ if (!withoutCustomValues) { _%>

--- a/generators/spring-boot/__snapshots__/mapstruct-expression.spec.ts.snap
+++ b/generators/spring-boot/__snapshots__/mapstruct-expression.spec.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`spring-boot - MapstructExpression escaping should render escaped expressions for direct fields 1`] = `
+"package com.example.service.mapper;
+
+
+
+import com.example.StreamRights;
+import com.example.service.dto.StreamRightsDTO;
+
+
+import org.mapstruct.*;
+
+/**
+ * Mapper for the entity {@link StreamRights} and its DTO {@link StreamRightsDTO}.
+ */
+@Mapper(componentModel = "spring")
+public interface StreamRightsMapper extends EntityMapper<StreamRightsDTO, StreamRights> {
+    @Mapping( target = "details", expression = "java(s.getId() + \\" | \\" + s.getName())")
+    StreamRightsDTO toDto(StreamRights s);
+
+}
+"
+`;
+
+exports[`spring-boot - MapstructExpression escaping should render escaped expressions for related fields 1`] = `
+"package com.example.service.mapper;
+
+
+
+import com.example.StreamRights;
+import com.example.service.dto.StreamRightsDTO;
+
+import com.example.Owner;
+import com.example.service.dto.OwnerDTO;
+
+import org.mapstruct.*;
+
+/**
+ * Mapper for the entity {@link StreamRights} and its DTO {@link StreamRightsDTO}.
+ */
+@Mapper(componentModel = "spring")
+public interface StreamRightsMapper extends EntityMapper<StreamRightsDTO, StreamRights> {
+    @Mapping(target = "owner", source = "owner", qualifiedByName="ownerDetails")
+    StreamRightsDTO toDto(StreamRights s);
+
+
+    @Named("ownerDetails")
+    @BeanMapping(ignoreByDefault = true)
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "details", expression = "java(s.getId() + \\" | \\" + s.getName())")
+    OwnerDTO toDtoOwnerDetails(Owner s);
+}
+"
+`;

--- a/generators/spring-boot/mapstruct-expression.spec.ts
+++ b/generators/spring-boot/mapstruct-expression.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ejs from 'ejs';
+import { describe, expect, it } from 'esmocha';
+import { uniq, uniqWith, upperFirst } from 'lodash-es';
+import { readFileSync } from 'node:fs';
+
+import { parseFromContent } from '../../lib/jdl/core/readers/jdl-reader.ts';
+import { createRuntime } from '../../lib/jdl/core/runtime.ts';
+
+const template = readFileSync(
+  new URL('./templates/src/main/java/_package_/_entityPackage_/service/mapper/_entityClass_Mapper.java.ejs', import.meta.url),
+  'utf8',
+);
+
+describe('spring-boot - MapstructExpression escaping', () => {
+  const runtime = createRuntime();
+
+  for (const related of [false, true]) {
+    it(`should render escaped expressions for ${related ? 'related' : 'direct'} fields`, () => {
+      const parsed = parseFromContent(
+        String.raw`entity StreamRights {
+  @MapstructExpression("java(s.getId() + \" | \" + s.getName())")
+  details String
+}`,
+        runtime,
+      );
+      const expression = parsed.entities[0].body?.[0].annotations?.[0].optionValue;
+      if (typeof expression !== 'string') {
+        throw new Error('Expected a parsed MapstructExpression string.');
+      }
+      const expressionField = { propertyName: 'details', mapstructExpression: expression };
+      const otherEntity = {
+        entityClass: 'Owner',
+        entityInstance: 'owner',
+        persistClass: 'Owner',
+        persistInstance: 'owner',
+        dtoClass: 'OwnerDTO',
+        entityAbsoluteClass: 'com.example.Owner',
+        entityAbsolutePackage: 'com.example',
+        primaryKey: { fields: [{ propertyName: 'id' }] },
+      };
+      const relationship = {
+        relationshipName: 'owner',
+        propertyName: 'owner',
+        otherEntityField: 'details',
+        ownerSide: true,
+        otherEntity,
+        relatedField: expressionField,
+      };
+      const source = ejs.render(
+        template,
+        {
+          entityAbsolutePackage: 'com.example',
+          entityAbsoluteClass: 'com.example.StreamRights',
+          entityClass: 'StreamRights',
+          persistClass: 'StreamRights',
+          dtoClass: 'StreamRightsDTO',
+          dtoInstance: 'streamRightsDTO',
+          embedded: false,
+          fluentMethods: false,
+          primaryKey: { ids: [{ name: 'id' }] },
+          fields: related ? [] : [expressionField],
+          restProperties: related ? [relationship] : [],
+          otherEntities: related ? [otherEntity] : [],
+          relationship,
+        },
+        { context: { _: { uniq, uniqWith, upperFirst } } },
+      );
+
+      expect(source).toMatchSnapshot();
+      const expressionLiteral = /expression = ("(?:[^"\\]|\\.)*")/.exec(source)?.[1];
+      if (!expressionLiteral) {
+        throw new Error('Expected a generated Java expression literal.');
+      }
+      expect(JSON.parse(expressionLiteral)).toBe(expression);
+    });
+  }
+});

--- a/generators/spring-boot/mapstruct-expression.spec.ts
+++ b/generators/spring-boot/mapstruct-expression.spec.ts
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-import ejs from 'ejs';
 import { describe, expect, it } from 'esmocha';
-import { uniq, uniqWith, upperFirst } from 'lodash-es';
 import { readFileSync } from 'node:fs';
+
+import ejs from 'ejs';
+import { uniq, uniqWith, upperFirst } from 'lodash-es';
 
 import { parseFromContent } from '../../lib/jdl/core/readers/jdl-reader.ts';
 import { createRuntime } from '../../lib/jdl/core/runtime.ts';

--- a/generators/spring-boot/templates/src/main/java/_package_/_entityPackage_/service/mapper/_entityClass_Mapper.java.ejs
+++ b/generators/spring-boot/templates/src/main/java/_package_/_entityPackage_/service/mapper/_entityClass_Mapper.java.ejs
@@ -71,7 +71,7 @@ public interface <%- entityClass %>Mapper extends EntityMapper<<%- dtoClass %>, 
   <%_ } _%>
   <%_ for (const field of fields.filter(field => field.mapstructExpression)) { _%>
     <%_ renMapAnotEnt = true; _%>
-    @Mapping( target = "<%- field.propertyName %>", expression = "<%- field.mapstructExpression %>")
+    @Mapping( target = "<%- field.propertyName %>", expression = <%- JSON.stringify(field.mapstructExpression) %>)
   <%_ } _%>
   <%_ if (renMapAnotEnt) { _%>
     <%- dtoClass %> toDto(<%- persistClass %> s);
@@ -106,7 +106,7 @@ public interface <%- entityClass %>Mapper extends EntityMapper<<%- dtoClass %>, 
     @Mapping(target = "<%- field.propertyName %>", source = "<%- field.propertyName %>")
     <%_ } _%>
     <%_ if (!relatedField.id && relatedField.mapstructExpression) { _%>
-    @Mapping(target = "<%- relatedField.propertyName %>", expression = "<%- relatedField.mapstructExpression %>")
+    @Mapping(target = "<%- relatedField.propertyName %>", expression = <%- JSON.stringify(relatedField.mapstructExpression) %>)
     <%_ } else if (!relatedField.id) { _%>
     @Mapping(target = "<%- relatedField.propertyName %>", source = "<%- relatedField.propertyName %>")
     <%_ } _%>

--- a/generators/spring-boot/types.d.ts
+++ b/generators/spring-boot/types.d.ts
@@ -69,7 +69,7 @@ export type Field = ServerField &
     filterableField?: boolean;
     autoGenerateByService?: boolean;
     autoGenerateByRepository?: boolean;
-    mapstructExpression?: boolean;
+    mapstructExpression?: string;
 
     requiresPersistableImplementation?: boolean;
     fieldNameAsDatabaseColumn?: string;

--- a/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.spec.ts
+++ b/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.spec.ts
@@ -25,6 +25,8 @@ import { JDLEntity, JDLEnum } from '../../core/models/index.ts';
 import JDLField from '../../core/models/jdl-field.ts';
 import JDLObject from '../../core/models/jdl-object.ts';
 import JDLValidation from '../../core/models/jdl-validation.ts';
+import { parseFromContent } from '../../core/readers/jdl-reader.ts';
+import { createRuntime } from '../../core/runtime.ts';
 
 import { convert } from './jdl-to-json-field-converter.ts';
 
@@ -203,6 +205,52 @@ describe('jdl - JDLToJSONFieldConverter', () => {
 `);
         });
       });
+      it('should not add JDL quotes to custom enum values in entity JSON', () => {
+        const jdlObject = new JDLObject();
+        const entity = new JDLEntity({ name: 'A' });
+        entity.addField(new JDLField({ name: 'enumField', type: 'CustomEnum' }));
+        jdlObject.addEntity(entity);
+        jdlObject.addEnum(
+          new JDLEnum({
+            name: 'CustomEnum',
+            values: [
+              { key: 'SPECIAL', value: '\u00dc' },
+              { key: 'SPACE', value: 'two words' },
+            ],
+          }),
+        );
+
+        expect(convert(jdlObject).get('A')).toMatchInlineSnapshot(`
+[
+  {
+    "fieldName": "enumField",
+    "fieldType": "CustomEnum",
+    "fieldValues": "SPECIAL (Ü),SPACE (two words)",
+  },
+]
+`);
+      });
+      for (const value of [
+        '"',
+        'a), InjectedEnum(a',
+        'a) }\nentity Unexpected\n enum Tail { Value(a',
+        ', ',
+        '()',
+        '',
+        'a\r\nb',
+        'a\u2028b',
+      ]) {
+        it(`should preserve arbitrary enum values using structured storage for ${JSON.stringify(value)}`, () => {
+          const parsed = parseFromContent(`enum CustomEnum { VALUE (${JSON.stringify(value)}), OTHER }`, createRuntime());
+          const jdlObject = new JDLObject();
+          const entity = new JDLEntity({ name: 'A' });
+          entity.addField(new JDLField({ name: 'enumField', type: 'CustomEnum' }));
+          jdlObject.addEntity(entity);
+          jdlObject.addEnum(new JDLEnum(parsed.enums[0]));
+
+          expect(convert(jdlObject).get('A')?.[0].fieldValues).toEqual([{ name: 'VALUE', value }, { name: 'OTHER' }]);
+        });
+      }
       describe('with comments', () => {
         let convertedField: any;
 

--- a/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
+++ b/lib/jdl/converters/jdl-to-json/jdl-to-json-field-converter.ts
@@ -61,7 +61,7 @@ function getConvertedFieldsForEntity(jdlEntity: JDLEntity, jdlObject: JDLObject)
       fieldData.documentation = comment;
     }
     if (jdlObject.hasEnum(jdlField.type)) {
-      fieldData.fieldValues = jdlObject.getEnum(fieldData.fieldType)?.getValuesAsString();
+      fieldData.fieldValues = jdlObject.getEnum(fieldData.fieldType)?.getValues();
       const fieldTypeComment = jdlObject.getEnum(fieldData.fieldType)?.comment;
       if (fieldTypeComment) {
         fieldData.fieldTypeDocumentation = fieldTypeComment;

--- a/lib/jdl/converters/json-to-jdl-entity-converter.ts
+++ b/lib/jdl/converters/json-to-jdl-entity-converter.ts
@@ -19,6 +19,7 @@
 
 import { lowerFirst, upperFirst } from 'lodash-es';
 
+import { parseEnumValues } from '../../utils/enum.ts';
 import { asJdlRelationshipType } from '../core/basic-types/relationship-types.ts';
 import type { JDLOptionName } from '../core/built-in-options/binary-options.ts';
 import { binaryOptions, relationshipOptions, unaryOptions } from '../core/built-in-options/index.ts';
@@ -127,27 +128,11 @@ function addEnumsToJDL(entity: JSONEntity): void {
       jdlObject.addEnum(
         new JDLEnum({
           name: field.fieldType,
-          values: getEnumValuesFromString(field.fieldValues),
+          values: parseEnumValues(field.fieldValues).map(({ name: key, value }) => (value === undefined ? { key } : { key, value })),
           comment: field.fieldTypeDocumentation,
         }),
       );
     }
-  });
-}
-
-function getEnumValuesFromString(valuesAsString: string): any[] {
-  return valuesAsString.split(',').map(fieldValue => {
-    // if fieldValue looks like ENUM_VALUE (something)
-    if (fieldValue.includes('(')) {
-      const [key, value] = fieldValue
-        .replace(/^(\w+)\s\((\w+)\)$/, (_match, matchedKey, matchedValue) => `${matchedKey},${matchedValue}`)
-        .split(',');
-      return {
-        key,
-        value,
-      };
-    }
-    return { key: fieldValue };
   });
 }
 

--- a/lib/jdl/converters/json-to-jdl-enum-converter.spec.ts
+++ b/lib/jdl/converters/json-to-jdl-enum-converter.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'esmocha';
+import { fileURLToPath } from 'node:url';
+
+import type { EnumValues } from '../../utils/enum.ts';
+import { parseFromContent } from '../core/readers/jdl-reader.ts';
+import { createRuntime } from '../core/runtime.ts';
+import type { JSONEntity } from '../core/types/json-config.ts';
+
+import { convert as convertFields } from './jdl-to-json/jdl-to-json-field-converter.ts';
+import { convertSingleContentToJDL, convertToJDL } from './json-to-jdl-converter.ts';
+import { convertEntitiesToJDL } from './json-to-jdl-entity-converter.ts';
+
+describe('jdl - JSONToJDLEntityConverter enum export', () => {
+  const runtime = createRuntime();
+  const convertEnum = (fieldValues: EnumValues) =>
+    convertEntitiesToJDL(
+      new Map<string, JSONEntity>([
+        ['Example', { name: 'Example', fields: [{ fieldName: 'value', fieldType: 'CustomEnum', fieldValues }], relationships: [] }],
+      ]),
+    );
+  const exportEnum = (fieldValues: EnumValues) => convertEnum(fieldValues).toString();
+
+  describe('PR 34901 declaration payload in entity JSON', () => {
+    const value = 'x)\n}\nentity Injected {\n  secret String\n}\nenum Dummy {\n  A(a';
+    const entity: JSONEntity = JSON.parse(
+      JSON.stringify({
+        name: 'Palette',
+        fields: [{ fieldName: 'color', fieldType: 'Colors', fieldValues: [{ name: 'RED', value }, { name: 'BLUE' }] }],
+        relationships: [],
+      }),
+    );
+    const entities = new Map([['Palette', entity]]);
+    const assertOriginalDeclarations = (exported: string) => {
+      const parsed = parseFromContent(exported, runtime);
+
+      expect(parsed.entities.map(({ name }) => name)).toEqual(['Palette']);
+      expect(parsed.enums.map(({ name }) => name)).toEqual(['Colors']);
+      expect(parsed.enums[0].values).toEqual([{ key: 'RED', value }, { key: 'BLUE' }]);
+    };
+
+    it('should keep the payload as one value when exporting structured entity JSON', () => {
+      assertOriginalDeclarations(convertEntitiesToJDL(entities).toString());
+    });
+
+    it('should preserve the payload when exporting application config with entity JSON', () => {
+      const exported = convertSingleContentToJDL({ 'generator-jhipster': { baseName: 'enumRoundtrip' } }, runtime, entities);
+
+      assertOriginalDeclarations(exported);
+      expect(parseFromContent(exported, runtime).applications).toHaveLength(1);
+    });
+
+    it('should preserve the payload through the actual .yo-rc.json and .jhipster file export path', () => {
+      const directory = fileURLToPath(new URL('../core/__test-support__/files/json_to_jdl_converter/enum_values/', import.meta.url));
+      const exported = convertToJDL(runtime, directory, false);
+
+      expect(exported).toBeDefined();
+      assertOriginalDeclarations(exported!.toString());
+    });
+
+    it('should reject the ambiguous legacy encoding instead of recovering guessed declarations or values', () => {
+      expect(() => exportEnum(`RED (${value}),BLUE`)).toThrow('Invalid enum entry in entity JSON');
+    });
+
+    it('should reject declaration payloads used as structured enum names', () => {
+      expect(() => exportEnum([{ name: value }])).toThrow('Invalid enum entry in entity JSON');
+    });
+  });
+
+  for (const value of [
+    '\u00dc',
+    'two words',
+    ' value ',
+    '_value',
+    'a-b',
+    'a.b',
+    'a\\b',
+    String.raw`\n`,
+    String.raw`\u0041`,
+    'a(b',
+    '"',
+    '',
+  ]) {
+    it(`should preserve the custom value ${JSON.stringify(value)} through JSON export`, () => {
+      const exported = exportEnum(`VALUE (${value}), OTHER`);
+
+      expect(parseFromContent(exported, runtime).enums[0].values).toEqual([{ key: 'VALUE', value }, { key: 'OTHER' }]);
+    });
+  }
+
+  it('should support custom values without whitespace before the parentheses', () => {
+    expect(parseFromContent(exportEnum('VALUE(custom)'), runtime).enums[0].values).toEqual([{ key: 'VALUE', value: 'custom' }]);
+  });
+
+  for (const value of ['\u00dc', '"', '\\', ', ', 'a), InjectedEnum(a', '()', '', 'a\nb', 'a\rb', 'a\u2028b', 'a\u2029b', '\t\b\f\0']) {
+    it(`should roundtrip structured custom values ${JSON.stringify(value)}`, () => {
+      const fieldValues = [{ name: 'VALUE', value }, { name: 'OTHER' }];
+      const jdlObject = convertEnum(fieldValues);
+      const parsed = parseFromContent(jdlObject.toString(), runtime);
+
+      expect(parsed.enums).toHaveLength(1);
+      expect(parsed.enums[0].values).toEqual([{ key: 'VALUE', value }, { key: 'OTHER' }]);
+      const storedValues = convertFields(jdlObject).get('Example')?.[0].fieldValues;
+      expect(parseFromContent(exportEnum(storedValues!), runtime).enums[0].values).toEqual(parsed.enums[0].values);
+    });
+  }
+
+  for (const fieldValues of [
+    'VALUE (a) }\nentity Unexpected\n enum Tail { Value(a)',
+    'VALUE (a,b)',
+    'VALUE (a)b)',
+    'VALUE (a\nb)',
+    'VALUE (a\rb)',
+    'VALUE (a\u2028b)',
+    'VALUE (a\u2029b)',
+    'VALUE (unclosed',
+    'VALUE } entity Unexpected {',
+  ]) {
+    it(`should reject malformed entity JSON enum entries: ${JSON.stringify(fieldValues)}`, () => {
+      expect(() => exportEnum(fieldValues)).toThrow('Invalid enum entry in entity JSON');
+    });
+  }
+
+  const malformedValues: unknown[] = [
+    null,
+    42,
+    {},
+    [],
+    ['VALUE'],
+    [null],
+    [{}],
+    [{ name: '' }],
+    [{ name: 'lowercase' }],
+    [{ name: '1VALUE' }],
+    [{ name: 'VALUE,INJECTED' }],
+    [{ name: 'VALUE\n' }],
+    [{ name: 42 }],
+    [{ name: 'VALUE', value: null }],
+    [{ name: 'VALUE', value: undefined }],
+    [{ name: 'VALUE', value: 42 }],
+    [{ name: 'VALUE', value: [] }],
+    [{ name: 'VALUE', values: 'typo' }],
+  ];
+  for (const fieldValues of malformedValues) {
+    it(`should reject malformed structured enum entries: ${JSON.stringify(fieldValues)}`, () => {
+      expect(() => exportEnum(fieldValues as EnumValues)).toThrow('Invalid enum entry in entity JSON');
+    });
+  }
+
+  it('should reject duplicate enum names in either representation', () => {
+    expect(() => exportEnum('VALUE,VALUE(custom)')).toThrow('Duplicate enum value name');
+    expect(() => exportEnum([{ name: 'VALUE' }, { name: 'VALUE', value: 'custom' }])).toThrow('Duplicate enum value name');
+  });
+});

--- a/lib/jdl/core/__test-support__/files/json_to_jdl_converter/enum_values/.jhipster/Palette.json
+++ b/lib/jdl/core/__test-support__/files/json_to_jdl_converter/enum_values/.jhipster/Palette.json
@@ -1,0 +1,19 @@
+{
+  "name": "Palette",
+  "fields": [
+    {
+      "fieldName": "color",
+      "fieldType": "Colors",
+      "fieldValues": [
+        {
+          "name": "RED",
+          "value": "x)\n}\nentity Injected {\n  secret String\n}\nenum Dummy {\n  A(a"
+        },
+        {
+          "name": "BLUE"
+        }
+      ]
+    }
+  ],
+  "relationships": []
+}

--- a/lib/jdl/core/__test-support__/files/json_to_jdl_converter/enum_values/.yo-rc.json
+++ b/lib/jdl/core/__test-support__/files/json_to_jdl_converter/enum_values/.yo-rc.json
@@ -1,0 +1,6 @@
+{
+  "generator-jhipster": {
+    "baseName": "enumRoundtrip",
+    "entities": ["Palette"]
+  }
+}

--- a/lib/jdl/core/models/jdl-entity.ts
+++ b/lib/jdl/core/models/jdl-entity.ts
@@ -77,7 +77,7 @@ export default class JDLEntity {
       if (value === true) {
         stringifiedEntity += `@${key}\n`;
       } else if (typeof value === 'string') {
-        stringifiedEntity += `@${key}("${value}")\n`;
+        stringifiedEntity += `@${key}(${JSON.stringify(value)})\n`;
       } else {
         stringifiedEntity += `@${key}(${value})\n`;
       }

--- a/lib/jdl/core/models/jdl-enum-value.spec.ts
+++ b/lib/jdl/core/models/jdl-enum-value.spec.ts
@@ -19,7 +19,12 @@
 
 import { before, describe, expect, it } from 'esmocha';
 
+import { parseFromContent } from '../readers/jdl-reader.ts';
+import { createRuntime } from '../runtime.ts';
+
 import JDLEnumValue from './jdl-enum-value.ts';
+
+const runtime = createRuntime();
 
 describe('jdl - JDLEnumValue', () => {
   describe('new', () => {
@@ -53,5 +58,44 @@ describe('jdl - JDLEnumValue', () => {
         expect(enumValue.toString()).toBe('FRENCH (frenchy)');
       });
     });
+    for (const [value, literal] of [
+      ['frenchy', 'frenchy'],
+      ['value_123', 'value_123'],
+      ['entity', 'entity'],
+      ['\u00dc', '"\u00dc"'],
+      ['two words', '"two words"'],
+      ['a), InjectedEnum(a', '"a), InjectedEnum(a"'],
+      ['a) }\nentity Unexpected\n enum Tail { Value(a', '"a) }\\nentity Unexpected\\n enum Tail { Value(a"'],
+      ['123', '"123"'],
+      ['_value', '"_value"'],
+      ['a-b', '"a-b"'],
+      ['a.b', '"a.b"'],
+      ['value\n', '"value\\n"'],
+      [' value ', '" value "'],
+      ['a\\b', '"a\\\\b"'],
+      ['"', '"\\""'],
+      ['a"b', '"a\\"b"'],
+      ['a\\"b', '"a\\\\\\"b"'],
+      ['a"), InjectedEnum("a', '"a\\"), InjectedEnum(\\"a"'],
+      ['', '""'],
+    ]) {
+      describe(`with value ${JSON.stringify(value)}`, () => {
+        it('should emit a valid enum value literal', () => {
+          expect(new JDLEnumValue('VALUE', value).toString()).toBe(`VALUE (${literal})`);
+        });
+
+        it('should round-trip without introducing JDL declarations', () => {
+          const original = parseFromContent(`enum Example { VALUE (${JSON.stringify(value)}) }`, runtime);
+          const exported = `enum Example { ${new JDLEnumValue('VALUE', value)} }`;
+
+          expect(parseFromContent(exported, runtime)).toEqual(original);
+        });
+      });
+    }
+    for (const name of ['VALUE (a), INJECTED (b)', 'VALUE\n', 'VALUE } entity Unexpected {']) {
+      it(`should reject an invalid enum value name ${JSON.stringify(name)}`, () => {
+        expect(() => new JDLEnumValue(name).toString()).toThrow('Invalid enum value name');
+      });
+    }
   });
 });

--- a/lib/jdl/core/models/jdl-enum-value.ts
+++ b/lib/jdl/core/models/jdl-enum-value.ts
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import { ALPHANUMERIC_UNDERSCORE, ENUM_PROP_NAME_PATTERN } from '../built-in-options/validation-patterns.ts';
+
 export default class JDLEnumValue {
   name: string;
   value?: string;
@@ -32,7 +34,15 @@ export default class JDLEnumValue {
   }
 
   toString() {
-    const value = this.value ? ` (${this.value})` : '';
-    return `${this.name}${value}`;
+    if (this.name.match(ENUM_PROP_NAME_PATTERN)?.[0] !== this.name) {
+      throw new Error(`Invalid enum value name ${JSON.stringify(this.name)}.`);
+    }
+    if (this.value === undefined) {
+      return this.name;
+    }
+    // Bare values must also satisfy the enum validator, which is stricter than the NAME token.
+    const unquotedValue = this.value.match(ALPHANUMERIC_UNDERSCORE)?.[0];
+    const value = unquotedValue === this.value ? this.value : JSON.stringify(this.value);
+    return `${this.name} (${value})`;
   }
 }

--- a/lib/jdl/core/models/jdl-enum.spec.ts
+++ b/lib/jdl/core/models/jdl-enum.spec.ts
@@ -19,6 +19,9 @@
 
 import { before, describe, expect, it } from 'esmocha';
 
+import { parseFromContent } from '../readers/jdl-reader.ts';
+import { createRuntime } from '../runtime.ts';
+
 import { JDLEnum } from './index.ts';
 
 describe('jdl - JDLEnum', () => {
@@ -55,6 +58,43 @@ describe('jdl - JDLEnum', () => {
     it('should return the values separated by a comma', () => {
       expect(result).toBe('A (aaaa),B');
     });
+
+    it('should preserve raw custom values in entity JSON', () => {
+      const jdlEnum = new JDLEnum({
+        name: 'Language',
+        values: [
+          { key: 'SPECIAL', value: '\u00dc' },
+          { key: 'SPACE', value: 'two words' },
+        ],
+      });
+
+      expect(jdlEnum.getValuesAsString()).toBe('SPECIAL (\u00dc),SPACE (two words)');
+    });
+
+    for (const value of ['', ',', ', ', 'a), InjectedEnum(a', 'a)b', 'a\nb', 'a\rb', 'a\u2028b', 'a\u2029b']) {
+      it(`should direct legacy-only callers to structured storage for ${JSON.stringify(value)}`, () => {
+        const jdlEnum = new JDLEnum({ name: 'Example', values: [{ key: 'VALUE', value }] });
+
+        expect(() => jdlEnum.getValuesAsString()).toThrow(
+          'The enum Example requires structured entity JSON values. Use getValues() instead.',
+        );
+      });
+    }
+
+    it('should reject malformed enum names in entity JSON', () => {
+      const jdlEnum = new JDLEnum({ name: 'Example', values: [{ key: 'VALUE, INJECTED' }] });
+
+      expect(() => jdlEnum.getValuesAsString()).toThrow('Invalid enum entry in entity JSON');
+    });
+  });
+  describe('getValues', () => {
+    for (const value of ['', '"', ', ', 'a), InjectedEnum(a', '(', ')', 'a\nb', 'a\rb', 'a\u2028b', 'a\u2029b']) {
+      it(`should preserve complex custom values in structured entity JSON: ${JSON.stringify(value)}`, () => {
+        const jdlEnum = new JDLEnum({ name: 'Example', values: [{ key: 'VALUE', value }, { key: 'OTHER' }] });
+
+        expect(jdlEnum.getValues()).toEqual([{ name: 'VALUE', value }, { name: 'OTHER' }]);
+      });
+    }
   });
   describe('getValueJavadocs', () => {
     let result: Record<string, string>;
@@ -80,6 +120,28 @@ describe('jdl - JDLEnum', () => {
     });
   });
   describe('toString', () => {
+    it('should preserve the top-level declaration payload from PR 34901 as one value', () => {
+      const value = 'x)\n}\nentity Injected {\n  secret String\n}\nenum Dummy {\n  A(a';
+      const exported = new JDLEnum({ name: 'Colors', values: [{ key: 'RED', value }] }).toString();
+      const parsed = parseFromContent(exported, createRuntime());
+
+      expect(parsed.entities).toEqual([]);
+      expect(parsed.enums.map(enumDefinition => enumDefinition.name)).toEqual(['Colors']);
+      expect(parsed.enums[0].values).toEqual([{ key: 'RED', value }]);
+    });
+
+    it('should round-trip special characters and injection payloads', () => {
+      const runtime = createRuntime();
+      const original = parseFromContent('enum SpecialChars { Ue ("\u00dc"), Injected ("a), InjectedEnum(a") }', runtime);
+      const exported = new JDLEnum(original.enums[0]).toString();
+
+      expect(parseFromContent(exported, runtime)).toEqual(original);
+      expect(parseFromContent(exported, runtime).enums[0].values).toEqual([
+        { key: 'Ue', value: '\u00dc' },
+        { key: 'Injected', value: 'a), InjectedEnum(a' },
+      ]);
+    });
+
     describe('with simple enum values', () => {
       let values: any[] = [];
       let jdlEnum: JDLEnum;

--- a/lib/jdl/core/models/jdl-enum.ts
+++ b/lib/jdl/core/models/jdl-enum.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { type EnumValues, serializeEnumValues } from '../../../utils/enum.ts';
 import type { ParsedJDLEnumValue } from '../types/parsed.ts';
 import { merge } from '../utils/object-utils.ts';
 
@@ -39,8 +40,17 @@ export default class JDLEnum {
     );
   }
 
+  /** Legacy-only storage. Use getValues() when writing entity JSON with arbitrary custom values. */
   getValuesAsString(): string {
-    return stringifyValues(this.values).join(',');
+    const values = this.getValues();
+    if (typeof values !== 'string') {
+      throw new Error(`The enum ${this.name} requires structured entity JSON values. Use getValues() instead.`);
+    }
+    return values;
+  }
+
+  getValues(): EnumValues {
+    return serializeEnumValues(Array.from(this.values.values(), ({ name, value }) => (value === undefined ? { name } : { name, value })));
   }
 
   getValueJavadocs(): Record<string, string> {

--- a/lib/jdl/core/models/jdl-field.ts
+++ b/lib/jdl/core/models/jdl-field.ts
@@ -87,7 +87,7 @@ export default class JDLField {
       if (value === true) {
         string += `@${key}\n`;
       } else if (typeof value === 'string') {
-        string += `@${key}("${value}")\n`;
+        string += `@${key}(${JSON.stringify(value)})\n`;
       } else {
         string += `@${key}(${value})\n`;
       }

--- a/lib/jdl/core/models/jdl-relationship.spec.ts
+++ b/lib/jdl/core/models/jdl-relationship.spec.ts
@@ -402,7 +402,7 @@ describe('jdl - JDLRelationship', () => {
         it('should add them', () => {
           expect(relationship.toString()).toBe(
             `relationship ${relationship.type} {
-  @Id ${relationship.from}{${relationship.injectedFieldInFrom}} to @Id @IdGenerator(sequence) ${relationship.to}{${relationship.injectedFieldInTo}} with ${BUILT_IN_ENTITY}
+  @Id ${relationship.from}{${relationship.injectedFieldInFrom}} to @Id @IdGenerator("sequence") ${relationship.to}{${relationship.injectedFieldInTo}} with ${BUILT_IN_ENTITY}
 }`,
           );
         });

--- a/lib/jdl/core/models/jdl-relationship.ts
+++ b/lib/jdl/core/models/jdl-relationship.ts
@@ -162,7 +162,8 @@ export default class JDLRelationship implements JDLRelationshipModel {
       .map(name => {
         const value = options[name];
         const capitalizedName = upperFirst(name);
-        return `@${capitalizedName}${value != null && value !== true ? `(${value}) ` : ' '}`;
+        const literal = typeof value === 'string' ? JSON.stringify(value) : value;
+        return `@${capitalizedName}${value != null && value !== true ? `(${literal}) ` : ' '}`;
       })
       .join('');
   }

--- a/lib/jdl/core/models/string-jdl-application-configuration-option.ts
+++ b/lib/jdl/core/models/string-jdl-application-configuration-option.ts
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import { parseJDLString } from '../utils/jdl-string.ts';
+
 import JDLApplicationConfigurationOption from './jdl-application-configuration-option.ts';
 
 export default class StringJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption<string> {
@@ -28,7 +30,8 @@ export default class StringJDLApplicationConfigurationOption extends JDLApplicat
   }
 
   toString(): string {
-    const value = this.quoted && !this.value.includes('"') ? `"${this.value}"` : this.value;
+    const unquotedValue = this.value.startsWith('"') && this.value.endsWith('"') ? parseJDLString(this.value) : this.value;
+    const value = this.quoted ? JSON.stringify(unquotedValue) : this.value;
     return `${this.name} ${value}`;
   }
 }

--- a/lib/jdl/core/parsing/jdl-ast-builder-visitor.ts
+++ b/lib/jdl/core/parsing/jdl-ast-builder-visitor.ts
@@ -30,6 +30,7 @@ import type {
 } from '../types/parsed.ts';
 import type { JDLRuntime } from '../types/runtime.ts';
 import deduplicate from '../utils/array-utils.ts';
+import { parseJDLString } from '../utils/jdl-string.ts';
 import logger from '../utils/objects/logger.ts';
 
 const { BUILT_IN_ENTITY } = relationshipOptions;
@@ -213,8 +214,11 @@ export const buildJDLAstBuilderVisitor = (runtime: JDLRuntime) => {
         case 'FALSE':
           optionValue = false;
           break;
+        case 'STRING':
+          optionValue = parseJDLString(valueImage);
+          break;
         default:
-          optionValue = valueImage.replace(/"/g, '');
+          optionValue = valueImage;
       }
       return { optionName, optionValue, type: 'BINARY' };
     }
@@ -416,7 +420,7 @@ export const buildJDLAstBuilderVisitor = (runtime: JDLRuntime) => {
         prop.value = context.enumPropValue[0].image;
       }
       if (context.enumPropValueWithQuotes) {
-        prop.value = context.enumPropValueWithQuotes[0].image.replace(/"/g, '');
+        prop.value = parseJDLString(context.enumPropValueWithQuotes[0].image);
       }
       return prop;
     }
@@ -634,8 +638,7 @@ export const buildJDLAstBuilderVisitor = (runtime: JDLRuntime) => {
         return context.INTEGER[0].image;
       }
       if (context.STRING) {
-        const stringImage = context.STRING[0].image;
-        return stringImage.substring(1, stringImage.length - 1);
+        return parseJDLString(context.STRING[0].image);
       }
       if (context.BOOLEAN) {
         return context.BOOLEAN[0].image === 'true';
@@ -683,8 +686,7 @@ export const buildJDLAstBuilderVisitor = (runtime: JDLRuntime) => {
         return context.INTEGER[0].image;
       }
       if (context.STRING) {
-        const stringImage = context.STRING[0].image;
-        return stringImage.substring(1, stringImage.length - 1);
+        return parseJDLString(context.STRING[0].image);
       }
       if (context.BOOLEAN) {
         return context.BOOLEAN[0].image === 'true';
@@ -709,7 +711,7 @@ export const buildJDLAstBuilderVisitor = (runtime: JDLRuntime) => {
       if (!context.STRING) {
         return [];
       }
-      return context.STRING.map(namePart => namePart.image.slice(1, -1));
+      return context.STRING.map(namePart => parseJDLString(namePart.image));
     }
   }
 

--- a/lib/jdl/core/parsing/lexer/lexer.ts
+++ b/lib/jdl/core/parsing/lexer/lexer.ts
@@ -20,6 +20,7 @@
 import { type ITokenConfig, Lexer, type TokenType } from 'chevrotain';
 
 import { relationshipOptions } from '../../built-in-options/index.ts';
+import { JDL_STRING_PATTERN } from '../../utils/jdl-string.ts';
 
 import OptionTokens from './option-tokens.ts';
 import RelationshipTypeTokens from './relationship-type-tokens.ts';
@@ -70,6 +71,25 @@ export const buildTokens = (tokens: { applicationTokens: TokenParam; deploymentT
   createTokenFromConfig({
     name: 'BLOCK_COMMENT',
     pattern: /\/\*([\s\S]*?)\*\//,
+    group: Lexer.SKIPPED,
+  });
+
+  createTokenFromConfig({
+    name: 'LINE_COMMENT',
+    pattern: /\/\/[^\n\r]*/,
+    group: Lexer.SKIPPED,
+  });
+
+  createTokenFromConfig({
+    name: 'DIRECTIVE',
+    pattern: (text, offset) => {
+      if (offset > 0 && !/[\n\r\u2028\u2029]/.test(text[offset - 1])) {
+        return null;
+      }
+      return /^#[^\n\r\u2028\u2029]*/.exec(text.slice(offset));
+    },
+    start_chars_hint: ['#'],
+    line_breaks: false,
     group: Lexer.SKIPPED,
   });
 
@@ -128,8 +148,7 @@ export const buildTokens = (tokens: { applicationTokens: TokenParam; deploymentT
   createTokenFromConfig({ name: 'REGEX', pattern: /\/[^\n\r]*\// });
   createTokenFromConfig({ name: 'DECIMAL', pattern: /-?\d+\.\d+/ });
   createTokenFromConfig({ name: 'INTEGER', pattern: /-?\d+/ });
-  // No escaping, no unicode, just a plain string literal
-  createTokenFromConfig({ name: 'STRING', pattern: /"(?:[^"])*"/ });
+  createTokenFromConfig({ name: 'STRING', pattern: JDL_STRING_PATTERN, line_breaks: true });
 
   // punctuation
   createTokenFromConfig({ name: 'LPAREN', pattern: '(' });

--- a/lib/jdl/core/parsing/string-literals.spec.ts
+++ b/lib/jdl/core/parsing/string-literals.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'esmocha';
+
+import JDLEntity from '../models/jdl-entity.ts';
+import JDLField from '../models/jdl-field.ts';
+import JDLRelationship from '../models/jdl-relationship.ts';
+import ListJDLApplicationConfigurationOption from '../models/list-jdl-application-configuration-option.ts';
+import StringJDLApplicationConfigurationOption from '../models/string-jdl-application-configuration-option.ts';
+import { parseFromContent } from '../readers/jdl-reader.ts';
+import { createRuntime } from '../runtime.ts';
+import { parseJDLString } from '../utils/jdl-string.ts';
+
+import { parse } from './api.ts';
+
+describe('jdl - escaped string literals', () => {
+  const runtime = createRuntime();
+
+  it('should import the quoted enum values from issue 31082', () => {
+    const parsed = parseFromContent(
+      String.raw`enum SpecialChars {
+  Ue ("Ü")
+  ESCAPING_WORKS("\\")
+  ESCAPED_QUOTES_FAIL("\"")
+  COMMA_SPACE (", ")
+}`,
+      runtime,
+    );
+
+    expect(parsed.enums[0].values).toEqual([
+      { key: 'Ue', value: '\u00dc' },
+      { key: 'ESCAPING_WORKS', value: '\\' },
+      { key: 'ESCAPED_QUOTES_FAIL', value: '"' },
+      { key: 'COMMA_SPACE', value: ', ' },
+    ]);
+  });
+
+  it('should parse the MapstructExpression from issue 24910', () => {
+    const parsed = parseFromContent(
+      String.raw`entity StreamRights {
+  name String
+  description TextBlob
+  @MapstructExpression("java(s.getId() + \" | \" + s.getName())")
+  details String
+}`,
+      runtime,
+    );
+
+    expect(parsed.entities[0].body?.[2].annotations).toEqual([
+      { optionName: 'MapstructExpression', optionValue: 'java(s.getId() + " | " + s.getName())', type: 'BINARY' },
+    ]);
+  });
+
+  it('should preserve every ASCII character through a quoted enum literal', () => {
+    for (let code = 0; code < 128; code++) {
+      const value = String.fromCharCode(code);
+      const parsed = parseFromContent(`enum Example { VALUE (${JSON.stringify(value)}) }`, runtime);
+      expect(parsed.enums[0].values).toEqual([{ key: 'VALUE', value }]);
+    }
+  });
+
+  it('should decode Unicode escapes and preserve unknown legacy escape sequences', () => {
+    expect(parseJDLString(String.raw`"\u00dc\uD83D\uDE00"`)).toBe('\u00dc\uD83D\uDE00');
+    expect(parseJDLString(String.raw`"\d+\w+\q"`)).toBe(String.raw`\d+\w+\q`);
+    expect(parseJDLString(String.raw`"\\n"`)).toBe(String.raw`\n`);
+  });
+
+  for (const content of [String.raw`enum Example { VALUE ("unterminated\") }`, 'enum Example { VALUE ("one"two") }']) {
+    it(`should reject malformed string literals: ${content}`, () => {
+      expect(() => parseFromContent(content, runtime)).toThrow();
+    });
+  }
+
+  for (const value of ['https://example.org/a#b', 'one\n#not a directive\n//not a comment', 'a"b\\c\n', '/* not a comment */']) {
+    it(`should preserve annotation values ${JSON.stringify(value)} on export and import`, () => {
+      const entity = new JDLEntity({ name: 'Example', annotations: { label: value } });
+      entity.addField(new JDLField({ name: 'details', type: 'String', options: { mapstructExpression: value } }));
+      const parsed = parseFromContent(entity.toString(), runtime).entities[0];
+
+      expect(parsed.annotations).toEqual([{ optionName: 'Label', optionValue: value, type: 'BINARY' }]);
+      expect(parsed.body?.[0].annotations).toEqual([{ optionName: 'MapstructExpression', optionValue: value, type: 'BINARY' }]);
+    });
+  }
+
+  it('should preserve relationship annotation values', () => {
+    const value = 'a"b\\c';
+    const relationship = new JDLRelationship({
+      from: 'A',
+      to: 'B',
+      type: 'OneToOne',
+      injectedFieldInFrom: 'b',
+      options: { source: { custom: value }, destination: {}, global: {} },
+    });
+    const original = parseFromContent(`relationship OneToOne { @Custom(${JSON.stringify(value)}) A{b} to B }`, runtime);
+
+    expect(parseFromContent(relationship.toString(), runtime)).toEqual(original);
+  });
+
+  it('should ignore comments and directives only outside string literals', () => {
+    const parsed = parseFromContent(
+      `# a directive
+// a comment
+enum Example {
+  VALUE ("one
+# inside the literal
+// still inside") // trailing comment
+}`,
+      runtime,
+    );
+
+    expect(parsed.enums[0].values).toEqual([{ key: 'VALUE', value: 'one\n# inside the literal\n// still inside' }]);
+  });
+
+  it('should escape and decode quoted application configuration consistently', () => {
+    const value = 'a"b\\c\n';
+    const stringOption = new StringJDLApplicationConfigurationOption('greeting', value, true);
+    const listOption = new ListJDLApplicationConfigurationOption('messages', [value], true);
+    const parsed = parseFromContent(`application { config(custom) { ${stringOption} } }`, runtime);
+
+    expect(parsed.applications[0].namespaceConfigs?.custom).toEqual({ greeting: value });
+    expect(parse(listOption.toString().slice('messages '.length), runtime, { startRule: 'quotedList' })).toEqual([value]);
+  });
+});

--- a/lib/jdl/core/parsing/validator.ts
+++ b/lib/jdl/core/parsing/validator.ts
@@ -27,6 +27,7 @@ import {
   ALPHANUMERIC_DASH,
   ALPHANUMERIC_SPACE,
   ALPHANUMERIC_UNDERSCORE,
+  ENUM_PROP_NAME_PATTERN,
 } from '../built-in-options/validation-patterns.ts';
 import type { JDLValidatorOptionType } from '../types/parsing.ts';
 import type { JDLRuntime } from '../types/runtime.ts';
@@ -35,7 +36,6 @@ const CONSTANT_PATTERN = /^[A-Z_]+$/;
 const ENTITY_NAME_PATTERN = /^[A-Z][A-Za-z0-9]*$/;
 const TYPE_NAME_PATTERN = /^[A-Z][A-Za-z0-9]*$/;
 const ENUM_NAME_PATTERN = /^[A-Z][A-Za-z0-9]*$/;
-const ENUM_PROP_NAME_PATTERN = /^[A-Z]\w*$/;
 const ENUM_PROP_VALUE_PATTERN = /^[A-Za-z]\w*$/;
 const METHOD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-_]*$/;
 

--- a/lib/jdl/core/readers/jdl-reader.ts
+++ b/lib/jdl/core/readers/jdl-reader.ts
@@ -83,8 +83,7 @@ function parse(content: string, runtime: JDLRuntime) {
     throw new Error('File content must be passed, it is currently empty.');
   }
   try {
-    const processedInput = filterJDLDirectives(removeInternalJDLComments(content));
-    const parsedContent = apiParser(processedInput, runtime);
+    const parsedContent = apiParser(content, runtime);
     return performJDLPostParsingTasks(parsedContent);
   } catch (error) {
     if (error instanceof SyntaxError) {
@@ -99,26 +98,13 @@ function getCst(content: string, runtime: JDLRuntime) {
     throw new Error('File content must be passed, it is currently empty.');
   }
   try {
-    const processedInput = filterJDLDirectives(removeInternalJDLComments(content));
-    return apiGetCst(processedInput, runtime);
+    return apiGetCst(content, runtime);
   } catch (error) {
     if (error instanceof SyntaxError) {
       logger.error(`Syntax error message:\n\t${error.message}`);
     }
     throw error;
   }
-}
-
-function removeInternalJDLComments(content: string) {
-  // Removing an internal Comment will not affect line/column location info
-  // as no lines are removed and the comments consumes the rest of the line.
-  return content.replace(/\/\/[^\n\r]*/gm, '');
-}
-
-function filterJDLDirectives(content: string) {
-  // We are only removing the directive not the whole line to avoid modifying line/column
-  // location information in parsers errors.
-  return content.replace(/^\u0023.*/gm, '');
 }
 
 /**

--- a/lib/jdl/core/utils/array-utils.ts
+++ b/lib/jdl/core/utils/array-utils.ts
@@ -25,5 +25,5 @@ export function join(set: unknown[], separator = ',', quoted = false) {
   if (!set) {
     throw new Error('An Array must be passed so as to join elements.');
   }
-  return set.map(val => (quoted ? `"${val}"` : val)).join(separator);
+  return set.map(val => (quoted ? JSON.stringify(String(val)) : val)).join(separator);
 }

--- a/lib/jdl/core/utils/jdl-string.ts
+++ b/lib/jdl/core/utils/jdl-string.ts
@@ -16,12 +16,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { ENUM_VALUE_NAME_PATTERN as ENUM_PROP_NAME_PATTERN } from '../../../utils/enum.ts';
 
-export const ALPHABETIC = /^[A-Za-z]+$/;
-export const ALPHABETIC_LOWER = /^[a-z]+$/;
-export const ALPHANUMERIC = /^[A-Za-z][A-Za-z0-9]*$/;
-export const ALPHANUMERIC_DASH = /^[A-Za-z][A-Za-z0-9-]*$/;
-export const ALPHABETIC_DASH_LOWER = /^[a-z][a-z-]*$/;
-export const ALPHANUMERIC_SPACE = /^"?[A-Za-z][A-Za-z0-9- ]*"?$/;
-export const ALPHANUMERIC_UNDERSCORE = /^[A-Za-z]\w*$/;
+export const JDL_STRING_PATTERN = /"(?:[^"\\]|\\[\s\S])*"/;
+
+const escapedCharacters: Record<string, string> = {
+  '"': '"',
+  '\\': '\\',
+  '/': '/',
+  b: '\b',
+  f: '\f',
+  n: '\n',
+  r: '\r',
+  t: '\t',
+};
+
+export function parseJDLString(literal: string): string {
+  // Preserve unknown escape sequences used by existing JDL, such as \d in regular expressions.
+  return literal
+    .slice(1, -1)
+    .replace(/\\(["\\/bfnrt]|u[\dA-Fa-f]{4})/g, (_match, escaped: string) =>
+      escaped.startsWith('u') ? String.fromCharCode(Number.parseInt(escaped.slice(1), 16)) : escapedCharacters[escaped],
+    );
+}

--- a/lib/jhipster/types/field.d.ts
+++ b/lib/jhipster/types/field.d.ts
@@ -17,11 +17,12 @@
  * limitations under the License.
  */
 import type { ValidationType } from '../../jdl/core/built-in-options/validations.ts';
+import type { EnumValues } from '../../utils/enum.ts';
 
 import type { Property } from './property.ts';
 
 type FieldEnum = {
-  fieldValues: string;
+  fieldValues: EnumValues;
   fieldTypeDocumentation?: string;
   fieldValuesJavadocs?: Record<string, string>;
 };

--- a/lib/utils/enum.spec.ts
+++ b/lib/utils/enum.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'esmocha';
+
+import { parseEnumValues, serializeEnumValues } from './enum.ts';
+
+describe('enum values storage', () => {
+  for (const value of ['Ü', 'two words', ' value ', 'a\\b', String.raw`\n`, String.raw`\u0041`, 'a-b', "it's a value"]) {
+    it(`should retain legacy storage for ${JSON.stringify(value)}`, () => {
+      const entries = [{ name: 'VALUE', value }, { name: 'OTHER' }];
+      const stored = serializeEnumValues(entries);
+
+      expect(stored).toBe(`VALUE (${value}),OTHER`);
+      expect(parseEnumValues(stored)).toEqual(entries);
+    });
+  }
+
+  for (const value of ['"', ', ', 'a), InjectedEnum(a', '(', ')', '()', '', 'a\nb', 'a\rb', 'a\u2028b', 'a\u2029b']) {
+    it(`should use structured storage for ${JSON.stringify(value)}`, () => {
+      const entries = [{ name: 'VALUE', value }, { name: 'OTHER' }];
+      const stored = serializeEnumValues(entries);
+
+      expect(stored).toEqual(entries);
+      expect(parseEnumValues(JSON.parse(JSON.stringify(stored)))).toEqual(entries);
+    });
+  }
+
+  it('should not decode quotes and escapes in old raw values', () => {
+    expect(parseEnumValues(String.raw`VALUE ("a\nb"),OTHER (a\"b)`)).toEqual([
+      { name: 'VALUE', value: String.raw`"a\nb"` },
+      { name: 'OTHER', value: String.raw`a\"b` },
+    ]);
+  });
+
+  it('should preserve absence versus explicit empty custom values', () => {
+    const entries = [{ name: 'ABSENT' }, { name: 'EMPTY', value: '' }];
+    expect(parseEnumValues(entries)).toEqual(entries);
+    expect(parseEnumValues('ABSENT,EMPTY ()')).toEqual(entries);
+  });
+
+  it('should reject ambiguous or malformed legacy strings rather than inventing custom values', () => {
+    for (const value of ['VALUE (a,b)', 'VALUE (a)b)', 'VALUE (unclosed', 'VALUE,', 'VALUE } entity Injected {']) {
+      expect(() => parseEnumValues(value)).toThrow('Invalid enum entry');
+    }
+  });
+
+  it('should support language tags only for client constants', () => {
+    expect(parseEnumValues('en,pt-br', { clientConstants: true })).toEqual([{ name: 'en' }, { name: 'pt-br' }]);
+    expect(() => parseEnumValues('en,pt-br')).toThrow('Invalid enum entry');
+    expect(() => parseEnumValues('en);injected', { clientConstants: true })).toThrow('Invalid enum entry');
+  });
+});

--- a/lib/utils/enum.ts
+++ b/lib/utils/enum.ts
@@ -38,18 +38,21 @@ export function parseEnumValues(fieldValues: unknown, { clientConstants = false 
   const invalidEntry = (entry: unknown): never => {
     throw new Error(`Invalid enum entry in entity JSON: ${JSON.stringify(entry)}.`);
   };
-  const values: unknown[] =
-    typeof fieldValues === 'string' ?
-      fieldValues.split(',').map(entry => {
-        const trimmed = entry.trim();
-        const match = /^([\w-]+)(?:[ \t]*\(([^,)\r\n\u2028\u2029]*)\))?$/.exec(trimmed);
-        if (!match || match[0] !== trimmed) {
-          return invalidEntry(entry);
-        }
-        return match[2] === undefined ? { name: match[1] } : { name: match[1], value: match[2] };
-      })
-    : Array.isArray(fieldValues) ? fieldValues
-    : invalidEntry(fieldValues);
+  let values: unknown[];
+  if (typeof fieldValues === 'string') {
+    values = fieldValues.split(',').map(entry => {
+      const trimmed = entry.trim();
+      const match = /^([\w-]+)(?:[ \t]*\(([^,)\r\n\u2028\u2029]*)\))?$/.exec(trimmed);
+      if (match?.[0] !== trimmed) {
+        return invalidEntry(entry);
+      }
+      return match[2] === undefined ? { name: match[1] } : { name: match[1], value: match[2] };
+    });
+  } else if (Array.isArray(fieldValues)) {
+    values = fieldValues;
+  } else {
+    return invalidEntry(fieldValues);
+  }
 
   if (values.length === 0) {
     return invalidEntry(fieldValues);

--- a/lib/utils/enum.ts
+++ b/lib/utils/enum.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2013-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type EnumValue = { name: string; value?: string };
+
+/** Legacy raw comma-separated entries, or structured entries for arbitrary custom values. */
+export type EnumValues = string | EnumValue[];
+
+type ParseEnumValuesOptions = {
+  /** Built-in client constants also use language tags such as pt-br. */
+  clientConstants?: boolean;
+};
+
+export const ENUM_VALUE_NAME_PATTERN = /^[A-Z]\w*$/;
+const clientConstantNamePattern = /^[A-Za-z][\w-]*$/;
+
+/**
+ * Read entity JSON enum values without treating legacy quotes or backslashes as escapes.
+ * An absent custom value is different from an explicitly empty custom value.
+ */
+export function parseEnumValues(fieldValues: unknown, { clientConstants = false }: ParseEnumValuesOptions = {}): EnumValue[] {
+  const invalidEntry = (entry: unknown): never => {
+    throw new Error(`Invalid enum entry in entity JSON: ${JSON.stringify(entry)}.`);
+  };
+  const values: unknown[] =
+    typeof fieldValues === 'string' ?
+      fieldValues.split(',').map(entry => {
+        const trimmed = entry.trim();
+        const match = /^([\w-]+)(?:[ \t]*\(([^,)\r\n\u2028\u2029]*)\))?$/.exec(trimmed);
+        if (!match || match[0] !== trimmed) {
+          return invalidEntry(entry);
+        }
+        return match[2] === undefined ? { name: match[1] } : { name: match[1], value: match[2] };
+      })
+    : Array.isArray(fieldValues) ? fieldValues
+    : invalidEntry(fieldValues);
+
+  if (values.length === 0) {
+    return invalidEntry(fieldValues);
+  }
+  const names = new Set<string>();
+  return values.map(entry => {
+    if (
+      !entry ||
+      typeof entry !== 'object' ||
+      Array.isArray(entry) ||
+      !('name' in entry) ||
+      typeof entry.name !== 'string' ||
+      entry.name.match(clientConstants ? clientConstantNamePattern : ENUM_VALUE_NAME_PATTERN)?.[0] !== entry.name ||
+      ('value' in entry && typeof entry.value !== 'string') ||
+      Object.keys(entry).some(key => key !== 'name' && key !== 'value')
+    ) {
+      return invalidEntry(entry);
+    }
+    if (names.has(entry.name)) {
+      throw new Error(`Duplicate enum value name ${JSON.stringify(entry.name)}.`);
+    }
+    names.add(entry.name);
+    return 'value' in entry && typeof entry.value === 'string' ? { name: entry.name, value: entry.value } : { name: entry.name };
+  });
+}
+
+/** Keep existing entity JSON strings where they can represent the values without ambiguity. */
+export function serializeEnumValues(values: EnumValue[]): EnumValues {
+  if (values.length === 0) {
+    return '';
+  }
+  const entries = parseEnumValues(values);
+  if (entries.some(({ value }) => value !== undefined && (value === '' || /[",()\r\n\u2028\u2029]/.test(value)))) {
+    return entries;
+  }
+  return entries.map(({ name, value }) => `${name}${value === undefined ? '' : ` (${value})`}`).join(',');
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -19,6 +19,7 @@
 export * from './basename.ts';
 export * from './contents.ts';
 export * from './derived-property.ts';
+export * from './enum.ts';
 export { default as getGenerator } from './get-generator.ts';
 export * from './logger.ts';
 export * from './lookup.ts';


### PR DESCRIPTION
<!--
PR description.
-->

Custom enum values could lose quotes or become new top-level JDL declarations during export and reimport. Escaped quotes also prevented valid `@MapstructExpression` annotations from parsing. This change preserves those values throughout JDL parsing, entity JSON storage, export, and generated output.

Fixes: #31082
Fixes: #24910

### Approach

- Keep existing `fieldValues` strings for safely representable values; use structured `{ name, value }` entries for quotes, delimiters, parentheses, line breaks, and empty custom values. Shared readers support both formats, including entity prompts and generator preparation.
- Add consistent JDL string escape handling and serialization. Handle comments and directives in the lexer so markers inside quoted strings remain data.
- Escape generated Java enums, TypeScript enums, translation JSON, and both direct and related MapStruct expressions.
- Cover the exact top-level declaration payload from [the #34901 comment](https://github.com/jhipster/generator-jhipster/pull/34901#issuecomment-5634559376), including structured entity JSON and actual `.yo-rc.json`/`.jhipster` export paths. It stays one custom value without adding unintended entities or enums.

### Compatibility

Existing entity JSON quotes and backslashes remain literal. Recognized escapes in JDL strings are now decoded: existing JDL that intended a literal `\n` must use `\\n`. Already-corrupted, ambiguous legacy enum strings cannot be repaired by guessing their original boundaries. The storage format, shared helper APIs, and migration considerations are documented in `DEVELOPMENT.md`.

This fixes model-integrity defects; it does not claim that the original report demonstrated JHipster Online RCE.

### Validation

- CI is green on `eccf862def`: 73 passing checks, 3 skipped, none pending or failing.
- The Generator workflow passed formatting, packaging, ESLint, repository-wide test type-checking, and the full `npm test` suite.
- Both linked-issue reproductions passed generation, backend tests, frontend tests, packaging, and end-to-end checks. The Angular, React, Vue, Dev Server, and other generator checks also passed.
- 544 focused tests passed locally across parsing, converters, disk export, prompts, and generated-output snapshots, alongside combined strict TypeScript checks.
- Generated Java enums compiled targeting Java 17 and preserved all 13 tested runtime values. Rendered mapper syntax compiled with annotation/domain stubs; the reported Java expression separately compiled and evaluated correctly.
- `npm run prettier:format` and diff whitespace checks passed. Some exact dependencies were unavailable locally, so CI supplied the full-project validation; no dependency versions were changed.

The linked-issue jobs initially read malformed diagnostic examples from the issue descriptions. With maintainer approval, the deliberately broken exported output in #31082 was relabeled as diagnostic-only, the runnable #24910 expression was aligned with its correctly escaped overview, and the #31082 sample entity was renamed from `Test` to `EnumSample` to avoid an unrelated JUnit name collision. Original diagnostics were preserved. No checks were disabled and the parser was not loosened to accept malformed examples.

Significant portions of this change were produced with GitHub Copilot. The commits include the corresponding `Co-authored-by:` trailers.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary - N/A: generator-only change
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [x] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->