### PR TITLE
[Vue] Use reset.finish.title on the reset password finish page

### DIFF
--- a/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.vue.ejs
+++ b/generators/vue/templates/src/main/webapp/app/account/reset-password/finish/reset-password-finish.vue.ejs
@@ -2,7 +2,7 @@
   <div>
     <div class="d-flex justify-content-center">
       <div class="col-md-8">
-        <h1>{{ t$('reset.request.title') }}</h1>
+        <h1>{{ t$('reset.finish.title') }}</h1>
 
         <div class="alert alert-danger" v-html="t$('reset.finish.messages.keymissing')" v-if="keyMissing">
           <strong>The password reset key is missing.</strong>


### PR DESCRIPTION
`reset.request.title` is used here https://github.com/jhipster/generator-jhipster/blob/7c1f95b399b04a65cb4d120897b5b2fa23cf1882/generators/vue/templates/src/main/webapp/app/account/reset-password/init/reset-password-init.vue.ejs#L5