### PR TITLE
[Vue] Reuse the happy-dom instance with the vmThreads pool

### DIFF
--- a/generators/vue/templates/vitest.config.ts.ejs
+++ b/generators/vue/templates/vitest.config.ts.ejs
@@ -31,6 +31,7 @@ export default mergeConfig(
     test: {
       globals: true,
       environment: 'happy-dom', // happy-dom provides a better performance but doesn't have a default url.
+      pool: 'vmThreads',
       setupFiles: [fileURLToPath(new URL('./<%- this.relativeDir(clientRootDir, clientSrcDir) %>app/test-setup.ts', import.meta.url))],
       reporters: ['default', 'vitest-sonar-reporter'],
       outputFile: {


### PR DESCRIPTION
Fix these logs in `npm t`
<img width="1207" height="294" alt="image" src="https://github.com/user-attachments/assets/e80afba6-b9ab-4f4d-bfe8-7f7025cbd392" />
