### PR TITLE
feat(bootstrap): add --export-application to export a zip instead of …

### DIFF
--- a/generators/app/__snapshots__/generator.spec.ts.snap
+++ b/generators/app/__snapshots__/generator.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`generator - app help should print expected information 1`] = `
 
 Options:
   --auto-crlf                              Detect line endings (default: false)
+  --export-application                     Serialize the generated application instead of writing it to disk
   --jhi-prefix <value>                     Add prefix before services, controllers and states name
   --entity-suffix <value>                  Add suffix after entities name
   --dto-suffix <value>                     Add suffix after dtos name

--- a/generators/base/generator.ts
+++ b/generators/base/generator.ts
@@ -121,10 +121,17 @@ export default class BaseGenerator<
 
     if (jhipsterBootstrap) {
       // jhipster:bootstrap is always required. Run it once the environment starts.
-      this.env.queueTask('environment:run', async () => this.composeWithJHipster('bootstrap').then(), {
-        once: 'queueJhipsterBootstrap',
-        startQueue: false,
-      });
+      this.env.queueTask(
+        'environment:run',
+        async () => {
+          const bootstrapGenerator = await this.composeWithJHipster('bootstrap');
+          // The bootstrap generator can be replaced by a blueprint or mocked at tests.
+          bootstrapGenerator.registerExportPath?.(this.destinationPath());
+        },
+        {
+          startQueue: false,
+        },
+      );
     }
 
     this.on('before:queueOwnTasks', () => {

--- a/generators/bootstrap/command.ts
+++ b/generators/bootstrap/command.ts
@@ -53,6 +53,13 @@ const command = {
       },
       scope: 'generator',
     },
+    exportApplication: {
+      description: 'Serialize the generated application instead of writing it to disk',
+      cli: {
+        type: Boolean,
+      },
+      scope: 'generator',
+    },
   },
 } as const satisfies JHipsterCommandDefinition;
 

--- a/generators/bootstrap/command.ts
+++ b/generators/bootstrap/command.ts
@@ -60,6 +60,14 @@ const command = {
       },
       scope: 'generator',
     },
+    deferCommit: {
+      description: 'Apply the commit transforms but leave the files in the shared mem-fs for the parent generator to commit',
+      cli: {
+        type: Boolean,
+        hide: true,
+      },
+      scope: 'generator',
+    },
   },
 } as const satisfies JHipsterCommandDefinition;
 

--- a/generators/bootstrap/generator.spec.ts
+++ b/generators/bootstrap/generator.spec.ts
@@ -117,6 +117,66 @@ describe(`generator - ${generator}`, () => {
     });
   });
 
+  describe('deferCommit', () => {
+    class WriteGenerator extends BaseGenerator {
+      get [BaseGenerator.WRITING]() {
+        return this.asWritingTaskGroup({
+          write() {
+            this.writeDestination('deferred.txt', 'deferred content\n');
+          },
+        });
+      }
+    }
+
+    before(async () => {
+      await basicHelpers.run(WriteGenerator).withOptions({ deferCommit: true }).withJHipsterGenerators();
+    });
+
+    it('does not write the generated file to disk', () => {
+      expect(existsSync(join(result.cwd, 'deferred.txt'))).toBe(false);
+    });
+
+    it('does not write an archive, the parent generator owns the export', () => {
+      expect(existsSync(join(result.cwd, 'export-application.zip'))).toBe(false);
+    });
+
+    it('leaves the file in the shared mem-fs', () => {
+      expect(result.getStateSnapshot()).toMatchObject({ 'deferred.txt': { state: 'modified' } });
+    });
+  });
+
+  describe('exportApplication with a registered path outside of the destination root', () => {
+    class SiblingGenerator extends BaseGenerator {
+      get [BaseGenerator.WRITING]() {
+        return this.asWritingTaskGroup({
+          async write() {
+            // A deployment or a blueprint generating a sibling application registers its own destination root.
+            const siblingRoot = this.destinationPath('..', 'exported-sibling');
+            const bootstrapGenerator = await this.composeWithJHipster('bootstrap');
+            bootstrapGenerator.registerExportPath(siblingRoot);
+
+            this.writeDestination('inside.txt', 'inside\n');
+            this.writeDestination(join(siblingRoot, 'sibling.txt'), 'sibling\n');
+          },
+        });
+      }
+    }
+
+    before(async () => {
+      await basicHelpers.run(SiblingGenerator).withOptions({ exportApplication: true }).withJHipsterGenerators();
+    });
+
+    it('does not write the generated file to disk', () => {
+      expect(existsSync(join(result.cwd, '..', 'exported-sibling', 'sibling.txt'))).toBe(false);
+    });
+
+    it('exports the registered path under its folder name', () => {
+      const archive = unzipSync(readFileSync(join(result.cwd, 'export-application.zip')));
+      expect(Object.keys(archive)).toContain('inside.txt');
+      expect(Object.keys(archive)).toContain('exported-sibling/sibling.txt');
+    });
+  });
+
   describe('exportApplication with a file outside the destination root', () => {
     class EscapeGenerator extends BaseGenerator {
       get [BaseGenerator.WRITING]() {

--- a/generators/bootstrap/generator.spec.ts
+++ b/generators/bootstrap/generator.spec.ts
@@ -17,14 +17,17 @@
  * limitations under the License.
  */
 import { before, describe, expect, it } from 'esmocha';
-import { basename } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { unzipSync } from 'fflate';
 
 import { shouldSupportFeatures } from '../../test/support/tests.ts';
 import BaseGenerator from '../base/index.ts';
 
 import Generator from './index.ts';
 
-import { defaultHelpers as helpers, result } from '#testing';
+import { basicHelpers, defaultHelpers as helpers, result } from '#testing';
 
 const generator = basename(import.meta.dirname);
 
@@ -80,6 +83,64 @@ describe(`generator - ${generator}`, () => {
       it('should keep needles', () => {
         result.assertEqualsFileContent('file.txt', content);
       });
+    });
+  });
+
+  describe('exportApplication', () => {
+    class WriteGenerator extends BaseGenerator {
+      get [BaseGenerator.WRITING]() {
+        return this.asWritingTaskGroup({
+          write() {
+            this.writeDestination('file.txt', 'exported content\n');
+          },
+        });
+      }
+    }
+
+    before(async () => {
+      // basicHelpers keeps dryRun disabled, so files would be written to disk without export mode.
+      await basicHelpers.run(WriteGenerator).withOptions({ exportApplication: true }).withJHipsterGenerators();
+    });
+
+    it('does not write the generated file to disk', () => {
+      expect(existsSync(join(result.cwd, 'file.txt'))).toBe(false);
+    });
+
+    it('writes an export-application.zip archive instead', () => {
+      expect(existsSync(join(result.cwd, 'export-application.zip'))).toBe(true);
+    });
+
+    it('includes the generated file in the archive', () => {
+      const archive = unzipSync(readFileSync(join(result.cwd, 'export-application.zip')));
+      expect(Object.keys(archive)).toContain('file.txt');
+      expect(Buffer.from(archive['file.txt']).toString('utf8')).toBe('exported content\n');
+    });
+  });
+
+  describe('exportApplication with a file outside the destination root', () => {
+    class EscapeGenerator extends BaseGenerator {
+      get [BaseGenerator.WRITING]() {
+        return this.asWritingTaskGroup({
+          write() {
+            this.writeDestination('inside.txt', 'inside\n');
+            this.writeDestination(this.destinationPath('..', 'escaped.txt'), 'escaped\n');
+          },
+        });
+      }
+    }
+
+    before(async () => {
+      await basicHelpers.run(EscapeGenerator).withOptions({ exportApplication: true }).withJHipsterGenerators();
+    });
+
+    it('does not write the escaped file to disk', () => {
+      expect(existsSync(join(result.cwd, '..', 'escaped.txt'))).toBe(false);
+    });
+
+    it('ignores the escaped file and keeps the ones inside the root', () => {
+      const archive = unzipSync(readFileSync(join(result.cwd, 'export-application.zip')));
+      expect(Object.keys(archive)).toContain('inside.txt');
+      expect(Object.keys(archive).some(entry => entry.includes('escaped.txt'))).toBe(false);
     });
   });
 });

--- a/generators/bootstrap/generator.ts
+++ b/generators/bootstrap/generator.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { rm, writeFile } from 'node:fs/promises';
-import { isAbsolute, relative, sep } from 'node:path';
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 import { createConflicterTransform, createYoResolveTransform, forceYoFiles } from '@yeoman/conflicter';
 import { transform } from '@yeoman/transform';
@@ -54,6 +54,9 @@ const { MULTISTEP_TRANSFORM_QUEUE, PRE_CONFLICTS_QUEUE } = QUEUES;
 const MULTISTEP_TRANSFORM_PRIORITY = BaseGenerator.asPriority(MULTISTEP_TRANSFORM);
 const PRE_CONFLICTS_PRIORITY = BaseGenerator.asPriority(PRE_CONFLICTS);
 
+// Zip entries always use forward slashes, regardless of the host platform.
+const toArchiveEntry = (filePath: string) => filePath.split(sep).join('/');
+
 export default class BootstrapGenerator extends CommandBaseGenerator<typeof command> {
   static readonly MULTISTEP_TRANSFORM = MULTISTEP_TRANSFORM_PRIORITY;
 
@@ -63,6 +66,9 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   skipPrettier?: boolean;
   skipEslint?: boolean;
   exportApplication?: boolean;
+  deferCommit?: boolean;
+  /** Paths, outside of the destination root, whose files must be part of the exported archive. */
+  private exportPaths: string[] = [];
   prettierExtensions: string[] = PRETTIER_EXTENSIONS.split(',');
   prettierJava = false;
   prettierOptions: PrettierOptions = { plugins: [] };
@@ -162,8 +168,8 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   }
 
   async commitPrettierConfig() {
-    if (this.exportApplication) {
-      // In export mode nothing is written to disk; the prettier config files are captured with the rest of the application.
+    if (this.exportApplication || this.deferCommit) {
+      // Nothing is written to disk; the prettier config files are captured with the rest of the application.
       return;
     }
     await this.commitSharedFs({
@@ -173,6 +179,10 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   }
 
   async commitTask() {
+    if (this.deferCommit) {
+      await this.deferSharedFs();
+      return;
+    }
     if (this.exportApplication) {
       await this.exportSharedFs();
       return;
@@ -203,6 +213,51 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   }
 
   /**
+   * Applies the commit transforms without writing anything, leaving the files pending in this environment's mem-fs.
+   *
+   * A parent generator running the application in a child environment (`jhipster jdl` with multiple applications) then
+   * copies the pending files to its own mem-fs and exports them along with the rest of the workspace.
+   */
+  async deferSharedFs() {
+    await this.commitSharedFs({ defer: true });
+  }
+
+  /**
+   * Registers a path whose files must be part of the exported archive.
+   *
+   * Deployments are generated in a destination root of their own (`jhipster jdl` composes them with a
+   * `destinationRoot` option), which is not necessarily below the root being exported.
+   */
+  registerExportPath(exportPath: string) {
+    const resolved = resolve(exportPath);
+    if (!this.isOutsidePath(this.destinationPath(), resolved) || this.exportPaths.some(path => !this.isOutsidePath(path, resolved))) {
+      // Already exported, through the destination root or through a registered parent path.
+      return;
+    }
+
+    // Keep a single entry per tree: the registered paths below the new one are exported through it.
+    this.exportPaths = this.exportPaths.filter(path => this.isOutsidePath(resolved, path));
+    this.exportPaths.push(resolved);
+  }
+
+  /**
+   * Returns the archive entry a file must be written at, or `undefined` when the file is not exportable.
+   */
+  private exportEntryName(root: string, filePath: string): string | undefined {
+    if (!this.isOutsidePath(root, filePath)) {
+      return toArchiveEntry(relative(root, filePath));
+    }
+    const exportPath = this.exportPaths.find(exportPath => !this.isOutsidePath(exportPath, filePath));
+    // A registered path is not below the archive root, keep its folder name so the entries don't escape the archive.
+    return exportPath === undefined ? undefined : toArchiveEntry(join(basename(exportPath), relative(exportPath, filePath)));
+  }
+
+  private isOutsidePath(root: string, filePath: string): boolean {
+    const relativePath = relative(root, filePath);
+    return isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`);
+  }
+
+  /**
    * Collects committed files into `entries` (a zip-entries map) instead of writing them to disk.
    * Files resolving outside the destination root are warned about and ignored.
    */
@@ -213,13 +268,12 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
         // Deleted or empty files have nothing to add to a fresh archive.
         return file;
       }
-      const relativePath = relative(root, file.path);
-      if (isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+      const entry = this.exportEntryName(root, file.path);
+      if (entry === undefined) {
         this.log.warn(`Ignoring file outside of the destination root: ${file.path}`);
         return file;
       }
-      // Zip entries always use forward slashes, regardless of the host platform.
-      entries[relativePath.split(sep).join('/')] = new Uint8Array(file.contents);
+      entries[entry] = new Uint8Array(file.contents);
       return file;
     });
   }
@@ -228,10 +282,17 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
    * Commits the MemFs to the disc.
    */
   async commitSharedFs(
-    { log, exportFiles, ...options }: PipelineOptions<MemFsEditorFile> & { log?: string; exportFiles?: Record<string, Uint8Array> } = {},
+    {
+      log,
+      exportFiles,
+      defer,
+      ...options
+    }: PipelineOptions<MemFsEditorFile> & { log?: string; exportFiles?: Record<string, Uint8Array>; defer?: boolean } = {},
     ...transforms: FileTransform<MemFsEditorFile>[]
   ) {
     const exportMode = Boolean(exportFiles);
+    // Neither export nor defer write to disk, the disk only transforms must be skipped in both.
+    const diskMode = !exportMode && !defer;
     const { autoCrlf = isWin32, devBlueprintEnabled, skipYoResolve } = this.options;
     const pipelineOptions: GeneratorPipelineOptions = {
       refresh: false,
@@ -243,7 +304,7 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
     };
 
     let customizeActions: NonNullable<Parameters<typeof createConflicterTransform>[1]>['customizeActions'];
-    if (devBlueprintEnabled && !exportMode) {
+    if (devBlueprintEnabled && diskMode) {
       customizeActions = (actions, { separator }) => {
         return [
           ...(actions as any),
@@ -280,8 +341,8 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
       }
 
       transformStreams.push(
-        // forceYoFiles only matters when committing to disk through the conflicter, skip it when exporting.
-        ...(exportMode ? [] : [forceYoFiles()]),
+        // forceYoFiles only matters when committing to disk through the conflicter, skip it otherwise.
+        ...(diskMode ? [forceYoFiles()] : []),
         createSortConfigFilesTransform(),
         createForceWriteConfigFilesTransform(),
         // Needles are removed from the files whose project enabled `removeNeedles`, see `editorMetadata` at base-core.
@@ -308,7 +369,9 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
         transformStreams.push(await autoCrlfTransform());
       }
 
-      if (exportMode) {
+      if (defer) {
+        // Nothing to do, the files are left pending for the parent generator.
+      } else if (exportMode) {
         // Collect the transformed files in memory instead of committing them to disk.
         transformStreams.push(this.createExportTransform(exportFiles!));
       } else {
@@ -321,7 +384,7 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
       return transformStreams;
     };
 
-    if (autoCrlf && !exportMode) {
+    if (autoCrlf && diskMode) {
       this.log.info('autoCrlf is enabled, line endings will be detected and normalized');
       await this.pipeline(
         {
@@ -342,7 +405,7 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
       transform((file: MemFsEditorFile) => (isFilePending(file) ? file : undefined)),
       ...(await createTransformStreams()),
     );
-    if (!exportMode) {
+    if (diskMode) {
       this.log.ok(log ?? 'files committed to disk');
     }
   }

--- a/generators/bootstrap/generator.ts
+++ b/generators/bootstrap/generator.ts
@@ -16,10 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { rm } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
+import { isAbsolute, relative, sep } from 'node:path';
 
 import { createConflicterTransform, createYoResolveTransform, forceYoFiles } from '@yeoman/conflicter';
 import { transform } from '@yeoman/transform';
+import { zipSync } from 'fflate';
 import type { FileTransform, PipelineOptions } from 'mem-fs';
 import type { MemFsEditorFile, VinylMemFsEditorFile } from 'mem-fs-editor';
 import { isFilePending, isFileStateModified } from 'mem-fs-editor/state';
@@ -60,6 +62,7 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   upgradeCommand?: boolean;
   skipPrettier?: boolean;
   skipEslint?: boolean;
+  exportApplication?: boolean;
   prettierExtensions: string[] = PRETTIER_EXTENSIONS.split(',');
   prettierJava = false;
   prettierOptions: PrettierOptions = { plugins: [] };
@@ -159,6 +162,10 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   }
 
   async commitPrettierConfig() {
+    if (this.exportApplication) {
+      // In export mode nothing is written to disk; the prettier config files are captured with the rest of the application.
+      return;
+    }
     await this.commitSharedFs({
       log: 'prettier configuration files committed to disk',
       filter: file => isPrettierConfigFilePath(file.path),
@@ -166,6 +173,10 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   }
 
   async commitTask() {
+    if (this.exportApplication) {
+      await this.exportSharedFs();
+      return;
+    }
     await this.commitSharedFs(
       { refresh: this.refreshOnCommit },
       ...this.env.findFeature('commitTransformFactory').flatMap(({ feature }) => feature()),
@@ -173,12 +184,54 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
   }
 
   /**
+   * Serializes the in-memory application to a single zip archive instead of committing it to disk.
+   *
+   * Reuses the {@link commitSharedFs} pipeline so the archived files go through the same transforms as a
+   * regular generation (prettier, eslint, needles, ...); only the disk-commit transforms (`forceYoFiles`,
+   * conflicter, commit) are skipped and replaced by an in-memory collector.
+   *
+   * This lets server-side consumers generate from an untrusted `.yo-rc.json` without the generator writing
+   * attacker-controlled paths onto the host filesystem: every generated path becomes a zip entry (data),
+   * not a real file write.
+   */
+  async exportSharedFs() {
+    const entries: Record<string, Uint8Array> = {};
+    await this.commitSharedFs({ exportFiles: entries });
+    const archivePath = this.destinationPath('export-application.zip');
+    await writeFile(archivePath, zipSync(entries));
+    this.log.ok(`application exported to ${archivePath} (${Object.keys(entries).length} files)`);
+  }
+
+  /**
+   * Collects committed files into `entries` (a zip-entries map) instead of writing them to disk.
+   * Files resolving outside the destination root are warned about and ignored.
+   */
+  private createExportTransform(entries: Record<string, Uint8Array>): FileTransform<MemFsEditorFile> {
+    const root = this.destinationPath();
+    return transform((file: MemFsEditorFile) => {
+      if (!file.contents) {
+        // Deleted or empty files have nothing to add to a fresh archive.
+        return file;
+      }
+      const relativePath = relative(root, file.path);
+      if (isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+        this.log.warn(`Ignoring file outside of the destination root: ${file.path}`);
+        return file;
+      }
+      // Zip entries always use forward slashes, regardless of the host platform.
+      entries[relativePath.split(sep).join('/')] = new Uint8Array(file.contents);
+      return file;
+    });
+  }
+
+  /**
    * Commits the MemFs to the disc.
    */
   async commitSharedFs(
-    { log, ...options }: PipelineOptions<MemFsEditorFile> & { log?: string } = {},
+    { log, exportFiles, ...options }: PipelineOptions<MemFsEditorFile> & { log?: string; exportFiles?: Record<string, Uint8Array> } = {},
     ...transforms: FileTransform<MemFsEditorFile>[]
   ) {
+    const exportMode = Boolean(exportFiles);
     const { autoCrlf = isWin32, devBlueprintEnabled, skipYoResolve } = this.options;
     const pipelineOptions: GeneratorPipelineOptions = {
       refresh: false,
@@ -190,7 +243,7 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
     };
 
     let customizeActions: NonNullable<Parameters<typeof createConflicterTransform>[1]>['customizeActions'];
-    if (devBlueprintEnabled) {
+    if (devBlueprintEnabled && !exportMode) {
       customizeActions = (actions, { separator }) => {
         return [
           ...(actions as any),
@@ -227,7 +280,8 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
       }
 
       transformStreams.push(
-        forceYoFiles(),
+        // forceYoFiles only matters when committing to disk through the conflicter, skip it when exporting.
+        ...(exportMode ? [] : [forceYoFiles()]),
         createSortConfigFilesTransform(),
         createForceWriteConfigFilesTransform(),
         // Needles are removed from the files whose project enabled `removeNeedles`, see `editorMetadata` at base-core.
@@ -254,15 +308,20 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
         transformStreams.push(await autoCrlfTransform());
       }
 
-      transformStreams.push(
-        createConflicterTransform(this.env.adapter, { ...this.env.conflicterOptions, customizeActions }),
-        createCommitTransform(),
-      );
+      if (exportMode) {
+        // Collect the transformed files in memory instead of committing them to disk.
+        transformStreams.push(this.createExportTransform(exportFiles!));
+      } else {
+        transformStreams.push(
+          createConflicterTransform(this.env.adapter, { ...this.env.conflicterOptions, customizeActions }),
+          createCommitTransform(),
+        );
+      }
 
       return transformStreams;
     };
 
-    if (autoCrlf) {
+    if (autoCrlf && !exportMode) {
       this.log.info('autoCrlf is enabled, line endings will be detected and normalized');
       await this.pipeline(
         {
@@ -283,6 +342,8 @@ export default class BootstrapGenerator extends CommandBaseGenerator<typeof comm
       transform((file: MemFsEditorFile) => (isFilePending(file) ? file : undefined)),
       ...(await createTransformStreams()),
     );
-    this.log.ok(log ?? 'files committed to disk');
+    if (!exportMode) {
+      this.log.ok(log ?? 'files committed to disk');
+    }
   }
 }

--- a/generators/generate-blueprint/__snapshots__/generator.spec.ts.snap
+++ b/generators/generate-blueprint/__snapshots__/generator.spec.ts.snap
@@ -7,6 +7,7 @@ Generate a blueprint
 
 Options:
   --auto-crlf                          Detect line endings (default: false)
+  --export-application                 Serialize the generated application instead of writing it to disk
   --javascript-blueprint               Generate a javascript blueprint
   --caret                              Use caret in package.json engines
   --defaults                           Use default values for the generator

--- a/generators/git/generator.spec.ts
+++ b/generators/git/generator.spec.ts
@@ -63,6 +63,24 @@ describe(`generator - ${generator}`, () => {
         });
       });
     });
+    describe('with exportApplication', () => {
+      before(async () => {
+        await helpers.runJHipster(generator).withOptions({ skipGit: false, exportApplication: true });
+      });
+      it('should not create .git, the application is exported as an archive', async () => {
+        await expect(access(resolve(runResult.cwd, '.git'))).rejects.toThrow();
+      });
+    });
+
+    describe('with deferCommit, the child of an exported workspace', () => {
+      before(async () => {
+        await helpers.runJHipster(generator).withOptions({ skipGit: false, deferCommit: true });
+      });
+      it('should not create .git, the parent generator writes the archive', async () => {
+        await expect(access(resolve(runResult.cwd, '.git'))).rejects.toThrow();
+      });
+    });
+
     describe('inside an existing repository at a parent folder', () => {
       let parentDir: string;
 

--- a/generators/git/generator.ts
+++ b/generators/git/generator.ts
@@ -23,6 +23,7 @@ import { CheckRepoActions } from 'simple-git';
 
 import BaseGenerator from '../base/index.ts';
 import { CONTEXT_DATA_GIT_ROOT_KEY } from '../base-core/support/index.ts';
+import type { Options as BootstrapOptions } from '../bootstrap/types.d.ts';
 
 import { files } from './files.ts';
 import type { Config as GitConfig, GeneratorProperties as GitGeneratorProperties, Options as GitOptions } from './types.ts';
@@ -43,6 +44,13 @@ export default class GitGenerator extends BaseGenerator<GitConfig, GitOptions> {
   get initializing() {
     return this.asInitializingTaskGroup({
       async checkGit() {
+        const { exportApplication, deferCommit } = this.options as BootstrapOptions;
+        if (!this.skipGit && (exportApplication || deferCommit)) {
+          // The exported application is an archive, a git repository would be the only thing written to disk.
+          // `deferCommit` is the child of an export: the parent generator writes the archive.
+          this.log.info('Git repository will not be created, as the application is being exported');
+          this.skipGit = true;
+        }
         if (!this.skipGit) {
           const gitInstalled = (await this.createGit().version()).installed;
           if (!gitInstalled) {

--- a/generators/init/__snapshots__/generator.spec.ts.snap
+++ b/generators/init/__snapshots__/generator.spec.ts.snap
@@ -7,6 +7,7 @@ Init project (alpha)
 
 Options:
   --auto-crlf                   Detect line endings (default: false)
+  --export-application          Serialize the generated application instead of writing it to disk
   --skip-git                    Skip git repository initialization
   --force-git                   Force commit to git repository
   --commit-msg <value>          Commit changes (implies forceGit)

--- a/generators/java/support/key-store.ts
+++ b/generators/java/support/key-store.ts
@@ -17,8 +17,9 @@
  * limitations under the License.
  */
 
-import { lstat, mkdir } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { lstat, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 import { execa } from 'execa';
 
@@ -69,5 +70,33 @@ export async function generateKeyStore(keyStoreFile: string, { packageName }: { 
     return { info: [...result.stderr.split('\n').filter(Boolean), `KeyStore '${keyStoreFile}' generated successfully.`] };
   } catch (error) {
     return { debug: error, warning: `Failed to create a KeyStore with 'keytool': ${(error as Error).message}` };
+  }
+}
+
+/**
+ * Generates a KeyStore without touching the destination: `keytool` can only write to a file (`-keystore /dev/stdout`
+ * is rejected with `keystore file exists, but is empty`), so it is generated in a temporary folder and read back.
+ *
+ * Lets the caller write the contents through the in-memory file system, which is what `--export-application` needs.
+ */
+export async function generateKeyStoreContents(
+  keyStoreFile: string,
+  { packageName }: { packageName: string },
+): Promise<{ contents?: Buffer; result: ValidationResult }> {
+  const temporaryFolder = await mkdtemp(join(tmpdir(), 'jhipster-keystore-'));
+  const temporaryFile = join(temporaryFolder, 'keystore.p12');
+  try {
+    const result = await generateKeyStore(temporaryFile, { packageName });
+    if (!Array.isArray(result.info)) {
+      // `keytool` failed, the result holds the warning.
+      return { result };
+    }
+    return {
+      contents: await readFile(temporaryFile),
+      // Report the destination, not the temporary file the KeyStore was generated into.
+      result: { ...result, info: [...result.info.slice(0, -1), `KeyStore '${keyStoreFile}' generated successfully.`] },
+    };
+  } finally {
+    await rm(temporaryFolder, { recursive: true, force: true });
   }
 }

--- a/generators/jdl/__snapshots__/generator.spec.ts.snap
+++ b/generators/jdl/__snapshots__/generator.spec.ts.snap
@@ -159,6 +159,7 @@ Create entities from the JDL file/URL/content passed in argument.
 
 Options:
   --auto-crlf                              Detect line endings (default: false)
+  --export-application                     Serialize the generated application instead of writing it to disk
   --interactive                            Generate multiple applications in series so that questions can be interacted with. This is the default when there is an existing application configuration in any of the folders
   --json-only                              Generate only the JSON files and skip entity regeneration
   --ignore-application                     Ignores application generation

--- a/generators/jdl/generator.ts
+++ b/generators/jdl/generator.ts
@@ -192,6 +192,13 @@ export default class JdlGenerator extends BaseGenerator<JdlConfig, JdlOptions> {
         } else {
           this.writeConfig(...this.applications.map(app => (this.ignoreApplication ? { ...app, config: undefined } : app)));
         }
+
+        if (!this.ignoreDeployments) {
+          // Deployment configuration must be in place before the workspaces generator looks deployments up.
+          for (const deployment of this.exportedDeployments ?? []) {
+            this.writeDeploymentConfig(deployment[GENERATOR_JHIPSTER].deploymentType, deployment);
+          }
+        }
       },
       async generate() {
         if (this.jsonOnly) {
@@ -261,7 +268,6 @@ export default class JdlGenerator extends BaseGenerator<JdlConfig, JdlOptions> {
           const { deploymentType } = deploymentConfig;
           this.log.debug(`Generating deployment: ${JSON.stringify(deploymentConfig, null, 2)}`);
 
-          this.writeDeploymentConfig(deploymentType, deployment);
           await this.composeWithJHipster(deploymentType, {
             generatorOptions: {
               destinationRoot: this.destinationPath(deploymentType),

--- a/generators/jdl/generator.ts
+++ b/generators/jdl/generator.ts
@@ -22,6 +22,7 @@ import { extname } from 'node:path';
 import { upperFirst } from 'lodash-es';
 import { type Store as MemFs, create as createMemFs } from 'mem-fs';
 import { type MemFsEditor, type MemFsEditorFile, create as createMemFsEditor } from 'mem-fs-editor';
+import { isFilePending } from 'mem-fs-editor/state';
 
 import { downloadJdlFile } from '../../cli/download.ts';
 import EnvironmentBuilder from '../../cli/environment-builder.ts';
@@ -32,6 +33,7 @@ import { mergeYoRcContent } from '../../lib/utils/yo-rc.ts';
 import BaseGenerator from '../base/index.ts';
 import { normalizeBlueprintName } from '../base/internal/blueprint.ts';
 import { updateApplicationEntitiesTransform } from '../base-application/support/update-application-entities-transform.ts';
+import type { Options as BootstrapOptions } from '../bootstrap/types.d.ts';
 import { GENERATOR_JHIPSTER, JHIPSTER_CONFIG_DIR } from '../generator-constants.ts';
 import type { Options as GitOptions } from '../git/types.d.ts';
 
@@ -135,6 +137,8 @@ export default class JdlGenerator extends BaseGenerator<JdlConfig, JdlOptions> {
           {
             applicationName: this.options.baseName ?? (this.existingProject ? this.jhipsterConfig.baseName : undefined),
             applicationType: this.options.applicationType ?? (this.existingProject ? this.jhipsterConfig.applicationType : undefined),
+            // Deployment configuration is written through the in-memory file system, like the application one.
+            skipDeploymentFileGeneration: true,
           },
           this.options.jdlDefinition,
         );
@@ -257,6 +261,7 @@ export default class JdlGenerator extends BaseGenerator<JdlConfig, JdlOptions> {
           const { deploymentType } = deploymentConfig;
           this.log.debug(`Generating deployment: ${JSON.stringify(deploymentConfig, null, 2)}`);
 
+          this.writeDeploymentConfig(deploymentType, deployment);
           await this.composeWithJHipster(deploymentType, {
             generatorOptions: {
               destinationRoot: this.destinationPath(deploymentType),
@@ -273,6 +278,8 @@ export default class JdlGenerator extends BaseGenerator<JdlConfig, JdlOptions> {
   }
 
   async runNonInteractive(applications: ApplicationWithEntitiesAndPath[], options: any) {
+    // The archive is written once, by the workspace root, children defer their commit and hand the files over.
+    const deferCommit = Boolean((this.options as BootstrapOptions).exportApplication) && applications.length > 1;
     await Promise.all(
       applications.map(async application => {
         const rootCwd = this.destinationPath();
@@ -281,6 +288,11 @@ export default class JdlGenerator extends BaseGenerator<JdlConfig, JdlOptions> {
         const envOptions: any = { cwd, logCwd: rootCwd, sharedFs: application.sharedFs, adapter };
         const generatorOptions = { ...this.options, ...options, skipPriorities: ['prompting'] };
 
+        if (deferCommit) {
+          generatorOptions.exportApplication = undefined;
+          generatorOptions.deferCommit = true;
+        }
+
         // Install should happen at the root of the monorepository. Force skip install at children.
         if ((this.options as GitOptions).monorepository) {
           generatorOptions.skipInstall = true;
@@ -288,8 +300,36 @@ export default class JdlGenerator extends BaseGenerator<JdlConfig, JdlOptions> {
         const envBuilder = await this.createEnvBuilder(envOptions);
         const env = envBuilder.getEnvironment();
         await env.run([this.entrypointGenerator], generatorOptions);
+
+        if (deferCommit && application.sharedFs) {
+          // Every environment commits its own mem-fs: the files must be moved to this environment's mem-fs before it
+          // commits, otherwise they are never exported.
+          this.adoptPendingFiles(application.sharedFs);
+        }
       }),
     );
+  }
+
+  /**
+   * Moves the files a child environment left pending to this environment's mem-fs, so that they are committed
+   * (exported) with the rest of the workspace.
+   */
+  private adoptPendingFiles(childFs: MemFs<MemFsEditorFile>) {
+    childFs.each(file => {
+      if (isFilePending(file)) {
+        this.env.sharedFs.add(file);
+      }
+    });
+  }
+
+  /**
+   * Writes the deployment `.yo-rc.json` through the in-memory file system, so that it goes through the commit
+   * pipeline like every other generated file.
+   */
+  writeDeploymentConfig(deploymentType: string, deployment: Record<string, any>) {
+    const configFile = this.destinationPath(deploymentType, '.yo-rc.json');
+    const oldConfig: YoRcFileContent = this.fs.readJSON(configFile, {}) as YoRcFileContent;
+    this.fs.writeJSON(configFile, mergeYoRcContent(oldConfig, deployment as YoRcFileContent));
   }
 
   writeConfig(...applications: Partial<ApplicationWithEntitiesAndPath>[]) {

--- a/generators/spring-boot/generator.ts
+++ b/generators/spring-boot/generator.ts
@@ -29,7 +29,7 @@ import { editPropertiesFileCallback } from '../base-core/support/properties-file
 import type { Config as ClientConfig, Entity as ClientEntity } from '../client/types.ts';
 import type { Source as CommonSource } from '../common/types.ts';
 import { ADD_SPRING_MILESTONE_REPOSITORY } from '../generator-constants.ts';
-import { addJavaImport, generateKeyStore, javaBeanCase } from '../java/support/index.ts';
+import { addJavaImport, generateKeyStoreContents, javaBeanCase } from '../java/support/index.ts';
 import type { JavaArtifactType } from '../java-simple-application/types.ts';
 import {
   getJavaValueGeneratorForType,
@@ -643,8 +643,16 @@ ${classProperties
         const keyStoreFile = this.destinationPath(`${application.srcMainResources}config/tls/keystore.p12`);
         if (this.fakeKeytool) {
           this.writeDestination(keyStoreFile, 'fake key-tool');
+        } else if (this.fs.exists(keyStoreFile)) {
+          this.log.info(`KeyStore '${keyStoreFile}' already exists. Leaving unchanged.`);
         } else {
-          this.validateResult(await generateKeyStore(keyStoreFile, { packageName: application.packageName! }));
+          // `keytool` writes to the filesystem, route the KeyStore through the in-memory file system so that it goes
+          // through the commit pipeline like any other generated file, `--export-application` included.
+          const { contents, result } = await generateKeyStoreContents(keyStoreFile, { packageName: application.packageName! });
+          if (contents) {
+            this.writeDestination(keyStoreFile, contents);
+          }
+          this.validateResult(result);
         }
       },
     });

--- a/generators/workspaces/generator.spec.ts
+++ b/generators/workspaces/generator.spec.ts
@@ -31,6 +31,31 @@ describe(`generator - ${generator}`, () => {
   shouldSupportFeatures(Generator);
   describe('blueprint support', () => testBlueprintSupport(generator));
 
+  describe('with a deployment configuration', () => {
+    it('adds the docker compose scripts when the deployment is only in the in-memory file system', async () => {
+      await helpers
+        .runJHipster(generator)
+        .withOptions({ workspaces: true, monorepository: true })
+        .withJHipsterConfig({ baseName: 'workspaces' })
+        .withWorkspaceApplicationAtFolder('gateway', { baseName: 'gateway', applicationType: 'gateway' })
+        .withWorkspaceApplicationAtFolder('micro1', { baseName: 'micro1', applicationType: 'microservice' })
+        .onGenerator(generator => {
+          // The jdl generator writes the deployment configuration through the in-memory file system, it only reaches
+          // the disk at the commit, after this generator has run.
+          generator.fs.writeJSON(generator.destinationPath('docker-compose', '.yo-rc.json'), {
+            'generator-jhipster': { deploymentType: 'docker-compose', appsFolders: ['gateway', 'micro1'] },
+          });
+        });
+
+      result.assertJsonFileContent('package.json', {
+        scripts: {
+          'ci:e2e:prepare': 'npm run docker-compose',
+          'ci:e2e:teardown': 'docker compose -f docker-compose/docker-compose.yml down -v',
+        },
+      });
+    });
+  });
+
   it('bootstrap migration', async () => {
     await helpers
       .runJHipster('jhipster:bootstrap-application-base')

--- a/generators/workspaces/generator.ts
+++ b/generators/workspaces/generator.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 import assert from 'node:assert';
-import { existsSync } from 'node:fs';
 
 import { packageJson } from '../../lib/index.ts';
 import BaseWorkspacesGenerator from '../base-workspaces/index.ts';
@@ -77,7 +76,8 @@ export default class WorkspacesGenerator extends BaseWorkspacesGenerator<any, Wo
       async configureUsingFiles() {
         if (!this.generateWorkspaces) return;
 
-        if (existsSync(this.destinationPath('docker-compose'))) {
+        // The deployment configuration may have been written by the jdl generator and not committed to disk yet.
+        if (this.fs.exists(this.destinationPath('docker-compose', '.yo-rc.json'))) {
           this.workspacesConfig.dockerCompose = true;
         }
         this.workspacesConfig.appsFolders = [...new Set([...(this.workspacesConfig.packages ?? []), ...this.appsFolders])];

--- a/lib/jdl/converters/exporters/jhipster-deployment-exporter.ts
+++ b/lib/jdl/converters/exporters/jhipster-deployment-exporter.ts
@@ -31,14 +31,19 @@ import { GENERATOR_NAME, writeConfigFile } from './export-utils.ts';
  * @param deployments the deployments to exporters (key: deployment type, value: JDLDeployment- deployment config).
  * @return object[] exported deployments in their final form.
  */
-export default function exportDeployments(deployments: Record<string, JDLDeployment>): Partial<YoRcJHipsterDeploymentContent>[] {
+export default function exportDeployments(
+  deployments: Record<string, JDLDeployment>,
+  { skipFileGeneration = false }: { skipFileGeneration?: boolean } = {},
+): Partial<YoRcJHipsterDeploymentContent>[] {
   if (!deployments) {
     throw new Error('Deployments have to be passed to be exported.');
   }
   return Object.values(deployments).map(deployment => {
     checkForErrors(deployment);
     const yoRcDeployment: Partial<YoRcJHipsterDeploymentContent> = setUpDeploymentStructure(deployment);
-    writeDeploymentConfigs(yoRcDeployment);
+    if (!skipFileGeneration) {
+      writeDeploymentConfigs(yoRcDeployment);
+    }
     return yoRcDeployment;
   });
 }

--- a/lib/jdl/jdl-importer.ts
+++ b/lib/jdl/jdl-importer.ts
@@ -58,6 +58,11 @@ type JDLApplicationConfiguration = {
     };
   };
   forSeveralApplications?: boolean;
+  /**
+   * Returns the deployments without writing their `.yo-rc.json` files, letting the caller write them through its
+   * own file system. Deployment files are written to the disk otherwise.
+   */
+  skipDeploymentFileGeneration?: boolean;
 };
 
 /**
@@ -137,7 +142,7 @@ function makeJDLImporter(content: ParsedJDLApplications, configuration: JDLAppli
         importState = importApplicationsAndEntities(jdlObject);
       }
       if (jdlObject.getDeploymentQuantity()) {
-        importState.exportedDeployments = importDeployments(jdlObject.deployments);
+        importState.exportedDeployments = importDeployments(jdlObject.deployments, configuration);
       }
       return importState;
     },
@@ -248,8 +253,8 @@ function importApplicationsAndEntities(jdlObject: JDLObject) {
   return importState;
 }
 
-function importDeployments(deployments: Record<string, JDLDeployment>) {
-  return exportDeployments(deployments);
+function importDeployments(deployments: Record<string, JDLDeployment>, configuration: JDLApplicationConfiguration) {
+  return exportDeployments(deployments, { skipFileGeneration: configuration.skipDeploymentFileGeneration });
 }
 
 function exportJSONEntities(entities: JDLJSONEntity[], configuration: JDLApplicationConfiguration): JSONEntity[] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "execa": "10.0.1",
         "fast-xml-builder": "1.3.1",
         "fast-xml-parser": "5.11.1",
+        "fflate": "0.8.2",
         "globals": "17.12.0",
         "isbinaryfile": "5.0.0",
         "latest-version": "9.0.0",
@@ -5882,6 +5883,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "execa": "10.0.1",
         "fast-xml-builder": "1.3.1",
         "fast-xml-parser": "5.11.1",
-        "fflate": "0.8.2",
+        "fflate": "0.8.3",
         "globals": "17.12.0",
         "isbinaryfile": "5.0.0",
         "latest-version": "9.0.0",
@@ -5885,9 +5885,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/figures": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "execa": "10.0.1",
     "fast-xml-builder": "1.3.1",
     "fast-xml-parser": "5.11.1",
-    "fflate": "0.8.2",
+    "fflate": "0.8.3",
     "globals": "17.12.0",
     "isbinaryfile": "5.0.0",
     "latest-version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "execa": "10.0.1",
     "fast-xml-builder": "1.3.1",
     "fast-xml-parser": "5.11.1",
+    "fflate": "0.8.2",
     "globals": "17.12.0",
     "isbinaryfile": "5.0.0",
     "latest-version": "9.0.0",


### PR DESCRIPTION
…writing to disk

`--export-application` diverts the bootstrap commit task: instead of writing the in-memory application to disk, it packs the generated files into a single `export-application.zip` archive at the destination root and skips the disk commit, including the early prettier-config commit.

Export reuses the `commitSharedFs` pipeline so the archived files go through the same transforms as a regular generation (prettier, eslint, needles, ...); only the disk-commit transforms (`forceYoFiles`, conflicter, commit) are skipped and replaced by an in-memory collector. Files resolving outside the destination root are warned about and ignored.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
- [ ] If AI coding assistants (GitHub Copilot, Claude Code, Cursor, etc.) were used to produce significant parts of this PR, it is disclosed in the description above and credited via a `Co-authored-by:` trailer in the commit(s)
- [ ] I have personally reviewed, understood, and tested the changes — including any AI-generated code

When you are still working on the PR, consider converting it to Draft (below reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
